### PR TITLE
Cache extension dependencies

### DIFF
--- a/common/ext/class.Extension.php
+++ b/common/ext/class.Extension.php
@@ -39,6 +39,20 @@ class common_ext_Extension
      */
     const MANIFEST_NAME = 'manifest.php';
 
+    /**
+     * Cache storage
+     *
+     * @var string
+     */
+    const STORAGE = 'cache';
+
+    /**
+     * Cache storage key
+     *
+     * @var string
+     */
+    const STORAGE_KEY = 'common_ext_extension_';
+
     static $dependencies = [];
 
     /**
@@ -65,8 +79,6 @@ class common_ext_Extension
      */
     protected $loaded = false;
     
-    private $configPersistence;
-
     /**
      * Should not be called directly, please use ExtensionsManager
      *
@@ -354,6 +366,9 @@ class common_ext_Extension
      */
     public function getDependencies()
     {
+        if (empty(self::$dependencies)) {
+            self::$dependencies = $this->getStorage()->get(self::STORAGE_KEY . 'dependencies');
+        }
         if (!isset(self::$dependencies[$this->getId()])) {
             $returnValue = array();
             foreach ($this->getManifest()->getDependencies() as $id => $version) {
@@ -362,6 +377,7 @@ class common_ext_Extension
                 $returnValue = array_merge($returnValue, $dependence->getDependencies());
             }
             self::$dependencies[$this->getId()] = $returnValue;
+            $this->getStorage()->set(self::STORAGE_KEY . 'dependencies', self::$dependencies);
         }
 
         return self::$dependencies[$this->getId()];
@@ -446,4 +462,13 @@ class common_ext_Extension
 		}
 		
 	}
+
+    /**
+     * Get cache storage
+     * @return \common_persistence_KeyValuePersistence
+     */
+    protected function getStorage()
+    {
+        return \common_persistence_KeyValuePersistence::getPersistence(self::STORAGE);
+    }
 }

--- a/common/ext/class.Extension.php
+++ b/common/ext/class.Extension.php
@@ -38,7 +38,9 @@ class common_ext_Extension
      * @var string
      */
     const MANIFEST_NAME = 'manifest.php';
-    
+
+    static $dependencies = [];
+
     /**
      * Short description of attribute id
      *
@@ -352,14 +354,17 @@ class common_ext_Extension
      */
     public function getDependencies()
     {
-        $returnValue = array();
-        foreach ($this->getManifest()->getDependencies() as $id => $version) {
-        	$returnValue[$id] = $version;
-        	$dependence = common_ext_ExtensionsManager::singleton()->getExtensionById($id);
-        	$returnValue = array_merge($returnValue, $dependence->getDependencies());
+        if (!isset(self::$dependencies[$this->getId()])) {
+            $returnValue = array();
+            foreach ($this->getManifest()->getDependencies() as $id => $version) {
+                $returnValue[$id] = $version;
+                $dependence = common_ext_ExtensionsManager::singleton()->getExtensionById($id);
+                $returnValue = array_merge($returnValue, $dependence->getDependencies());
+            }
+            self::$dependencies[$this->getId()] = $returnValue;
         }
 
-        return (array) $returnValue;
+        return self::$dependencies[$this->getId()];
     }
 
     /**

--- a/common/ext/class.Extension.php
+++ b/common/ext/class.Extension.php
@@ -40,20 +40,11 @@ class common_ext_Extension
     const MANIFEST_NAME = 'manifest.php';
 
     /**
-     * Cache storage
+     * List of extension dependencies
      *
-     * @var string
+     * @var array
      */
-    const STORAGE = 'cache';
-
-    /**
-     * Cache storage key
-     *
-     * @var string
-     */
-    const STORAGE_KEY = 'common_ext_extension_';
-
-    static $dependencies = [];
+    private $dependencies = [];
 
     /**
      * Short description of attribute id
@@ -357,30 +348,21 @@ class common_ext_Extension
     }
 
     /**
-     * returns the extension the current extension
-     * depends on recursively
+     * Returns the extension the current extension depends on recursively
      *
      * @access public
-     * @author firstname and lastname of author, <author@example.org>
-     * @return array
+     * @return array Where key is name of extension and value is required version.
      */
     public function getDependencies()
     {
-        if (empty(self::$dependencies)) {
-            self::$dependencies = $this->getStorage()->get(self::STORAGE_KEY . 'dependencies');
-        }
-        if (!isset(self::$dependencies[$this->getId()])) {
-            $returnValue = array();
+        if (empty($this->dependencies)) {
             foreach ($this->getManifest()->getDependencies() as $id => $version) {
-                $returnValue[$id] = $version;
+                $this->dependencies[$id] = $version;
                 $dependence = common_ext_ExtensionsManager::singleton()->getExtensionById($id);
-                $returnValue = array_merge($returnValue, $dependence->getDependencies());
+                $this->dependencies = array_merge($this->dependencies, $dependence->getDependencies());
             }
-            self::$dependencies[$this->getId()] = $returnValue;
-            $this->getStorage()->set(self::STORAGE_KEY . 'dependencies', self::$dependencies);
         }
-
-        return self::$dependencies[$this->getId()];
+        return $this->dependencies;
     }
 
     /**
@@ -462,13 +444,4 @@ class common_ext_Extension
 		}
 		
 	}
-
-    /**
-     * Get cache storage
-     * @return \common_persistence_KeyValuePersistence
-     */
-    protected function getStorage()
-    {
-        return \common_persistence_KeyValuePersistence::getPersistence(self::STORAGE);
-    }
 }

--- a/common/ext/class.ExtensionLoader.php
+++ b/common/ext/class.ExtensionLoader.php
@@ -46,8 +46,6 @@ class common_ext_ExtensionLoader
 
     // --- OPERATIONS ---
 
-    static $loadedConstants = [];
-
     /**
      * Load the extension.
      *
@@ -64,46 +62,47 @@ class common_ext_ExtensionLoader
 
 
     /**
-     * Load the constant files and constants declared in manifest file.
+     * Load the constantfiles.
      *
      * @access protected
      * @author Jerome Bogaerts, <jerome@taotesting.com>
-     * @param array $extraConstants list of extension ids
+     * @param array $extraConstants
      * @return void
      */
-    protected function loadConstants(array $extraConstants = [])
+    protected function loadConstants($extraConstants)
     {
-        $extensions = [];
 
-        if (!isset(self::$loadedConstants[$this->extension->getId()])) {
-            common_Logger::t('Loading extension ' . $this->extension->getId() . ' constants');
+        common_Logger::t('Loading extension ' . $this->extension->getId() . ' constants');
 
-            // we will load the constant file of the current extension and all it's dependencies
-            // get the dependencies
-            $extensions = array_keys($this->extension->getDependencies());
+    	// load the constants from the manifest
+        if ($this->extension->getId() != "generis"){
+   			foreach ($this->extension->getConstants() as $key => $value) {
+   				if(!defined($key) && !is_array($value)){
+   					define($key, $value);
+   				}
+   			}
+    	}
+    	// we will load the constant file of the current extension and all it's dependancies
 
-            // load the constants from the manifest
-            if ($this->extension->getId() != "generis"){
-                foreach ($this->extension->getConstants() as $key => $value) {
-                    if(!defined($key) && !is_array($value)){
-                        define($key, $value);
-                    }
-                }
-                $extensions[] = $this->extension->getId();
-            }
-        }
+    	// get the dependancies
+    	$extensions = array_keys($this->extension->getDependencies());
 
-        // merge them with the additional constants (defined in the options)
-        $extensions = array_merge($extensions, $extraConstants);
+    	// merge them with the additional constants (defined in the options)
+   		$extensions = array_merge($extensions, $extraConstants);
 
-        foreach ($extensions as $extension) {
-            //load the config of the extension
-            if (!isset(self::$loadedConstants[$extension])) {
-                $this->loadConstantsFile($extension);
-            }
-        }
-        
-        self::$loadedConstants[$this->extension->getId()] = true;
+   		// add the current extension (as well !)
+    	$extensions = array_merge(array($this->extension->getId()), $extensions);
+
+    	foreach($extensions as $extension){
+
+    		if($extension == 'generis') {
+    			continue; //generis constants are already loaded
+    		}
+
+    		//load the config of the extension
+    		$this->loadConstantsFile($extension);
+    	}
+
     }
 
     /**

--- a/common/persistence/class.Manager.php
+++ b/common/persistence/class.Manager.php
@@ -121,6 +121,7 @@ class common_persistence_Manager extends ConfigurableService
      * @return common_persistence_Persistence
      */
     private function createPersistence($persistenceId) {
+        $generis = common_ext_ExtensionsManager::singleton()->getExtensionById('generis');
         $configs = $this->getOption(self::OPTION_PERSISTENCES);
         if (isset($configs[$persistenceId])) {
             $config = $configs[$persistenceId];

--- a/common/persistence/class.Manager.php
+++ b/common/persistence/class.Manager.php
@@ -121,7 +121,7 @@ class common_persistence_Manager extends ConfigurableService
      * @return common_persistence_Persistence
      */
     private function createPersistence($persistenceId) {
-        $generis = common_ext_ExtensionsManager::singleton()->getExtensionById('generis');
+        //$generis = common_ext_ExtensionsManager::singleton()->getExtensionById('generis');
         $configs = $this->getOption(self::OPTION_PERSISTENCES);
         if (isset($configs[$persistenceId])) {
             $config = $configs[$persistenceId];

--- a/common/persistence/class.Manager.php
+++ b/common/persistence/class.Manager.php
@@ -121,7 +121,6 @@ class common_persistence_Manager extends ConfigurableService
      * @return common_persistence_Persistence
      */
     private function createPersistence($persistenceId) {
-        //$generis = common_ext_ExtensionsManager::singleton()->getExtensionById('generis');
         $configs = $this->getOption(self::OPTION_PERSISTENCES);
         if (isset($configs[$persistenceId])) {
             $config = $configs[$persistenceId];

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '2.31.1',
+    'version' => '2.31.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -217,7 +217,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('2.30.0');
         }
 
-        $this->skip('2.30.0', '2.31.1');
+        $this->skip('2.30.0', '2.31.2');
     }
     
     private function getReadableModelIds() {


### PR DESCRIPTION
During profiling of call to `/taoItems/Items/editItemClass` action I found that the most of the time takes initialization of tao. I found out that `common_ext_Extension::getDependencies()` and `common_ext_Manifest::getDependencies()` was called 1574 times

Ideally all those function should be called no more times than amount of extensions in tao. I made small improvements to cache results of those functions. I got the following results:
getDependencies(): 119 vs 1574 calls

Time of execution of  `/taoItems/Items/editItemClass` request was reduced on 20% (119ms vs 143ms)

Not really big acceleration but i guess it worth to merge.
