### PR TITLE
Fix/incorrect event detaching

### DIFF
--- a/common/oatbox/event/EventManager.php
+++ b/common/oatbox/event/EventManager.php
@@ -78,7 +78,7 @@ class EventManager extends ConfigurableService
         foreach ($events as $event) {
             $eventObject = is_object($event) ? $event : new GenericEvent($event);
             if (isset($listeners[$eventObject->getName()])) {
-                if (($index = array_search($callback, array_values($listeners[$eventObject->getName()]))) !== false) {
+                if (($index = array_search($callback, $listeners[$eventObject->getName()])) !== false) {
                     unset($listeners[$eventObject->getName()][$index]);
                 }
             }

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '2.31.4',
+    'version' => '2.31.5',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -42,8 +42,8 @@ use oat\oatbox\task\implementation\SyncQueue;
 class Updater extends \common_ext_ExtensionUpdater {
     
     /**
-     * 
-     * @param string $currentVersion
+     *
+     * @param string $initialVersion
      * @return string $versionUpdatedTo
      */
     public function update($initialVersion) {
@@ -217,7 +217,7 @@ class Updater extends \common_ext_ExtensionUpdater {
             $this->setVersion('2.30.0');
         }
 
-        $this->skip('2.30.0', '2.31.4');
+        $this->skip('2.30.0', '2.31.5');
     }
     
     private function getReadableModelIds() {

--- a/test/oatbox/EventManagerTest.php
+++ b/test/oatbox/EventManagerTest.php
@@ -31,6 +31,12 @@ class EmptyClass
     public function testfunction($event) {
         
     }
+    public function testfunction2($event) {
+
+    }
+    public function testfunction3($event) {
+
+    }
 }
 
 class EventManagerTest extends GenerisPhpUnitTestRunner
@@ -91,12 +97,22 @@ class EventManagerTest extends GenerisPhpUnitTestRunner
     public function testDetatch($eventManager)
     {
         $callable = $this->prophesize('oat\\generis\\test\\oatbox\\EmptyClass');
+
         $callable->testfunction(Argument::any())->should(new CallTimesPrediction(1));
+        $callable->testfunction2(Argument::any())->should(new CallTimesPrediction(1));
+        $callable->testfunction3(Argument::any())->should(new CallTimesPrediction(1));
         $revelation = $callable->reveal();
 
-        $eventManager->attach(array('testEvent1'), array($revelation, 'testfunction'));
-        $eventManager->trigger('testEvent1');
-        $eventManager->detach(array('testEvent1'), array($revelation, 'testfunction'));
-        $eventManager->trigger('testEvent1');
+        $eventManager->attach(array('testEvent'), array($revelation, 'testfunction'));
+        $eventManager->attach(array('testEvent'), array($revelation, 'testfunction2'));
+        $eventManager->attach(array('testEvent'), array($revelation, 'testfunction3'));
+
+        $eventManager->trigger('testEvent');
+
+        $eventManager->detach(array('testEvent'), array($revelation, 'testfunction'));
+        $eventManager->detach(array('testEvent'), array($revelation, 'testfunction2'));
+        $eventManager->detach(array('testEvent'), array($revelation, 'testfunction3'));
+
+        $eventManager->trigger('testEvent');
     }
 }


### PR DESCRIPTION
In case of event have several listeners attached and one of them ( not last one ) is going to be detached, array turns in associative with numeric keys and gap in sequence see bellow

`'event' => array(
            0 => $callback1,
            2 => $callback2,
            3 => $callback3
)
`

Afterwards attempt to detach any of listeners with index more than previously removed will fail