### PR TITLE
Remove redundant union query

### DIFF
--- a/core/kernel/persistence/smoothsql/search/ComplexSearchService.php
+++ b/core/kernel/persistence/smoothsql/search/ComplexSearchService.php
@@ -211,12 +211,6 @@ class ComplexSearchService extends ConfigurableService
             foreach ($nextValue as $val) {
                 $criteria->addOr($this->parseValue($val));
             }
-            if($and === false) {
-                $criteria = $query->newQuery()
-                ->add('http://www.w3.org/1999/02/22-rdf-syntax-ns#type')
-                ->in($classUri);
-                $query->setOr($criteria);
-            }
         }
         $queryString = $this->gateway->serialyse($query)->getQuery();
         return $queryString;

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '3.1.0',
+    'version' => '3.1.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '3.1.1',
+    'version' => '3.1.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -270,7 +270,7 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('3.0.0');
         }
         
-        $this->skip('3.0.0', '3.1.0');
+        $this->skip('3.0.0', '3.1.1');
     }
     
     private function getReadableModelIds() {

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -270,7 +270,7 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('3.0.0');
         }
         
-        $this->skip('3.0.0', '3.1.1');
+        $this->skip('3.0.0', '3.1.2');
     }
     
     private function getReadableModelIds() {


### PR DESCRIPTION
`searchInstances` returns absolutely wrong result (it does not take in account any options such as filters and so on).
To reproduce this bug you have to create sample resources:
https://gist.github.com/hutnikau/04d051fb446d7fadeee543e86101a078
and run search test:
https://gist.github.com/hutnikau/048466408179f21916a92a12f5077766

You will see that result will has much more instances than expected (8 insead 3 for me).

Sql Query will be:
```sql
SELECT "subject" FROM ( 
  (SELECT DISTINCT "subject" FROM "statements" WHERE 
	 "predicate" = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' AND  
	 ("object" IN ('http://www.tao.lu/Ontologies/TAOSubject.rdf#Subject' , 'http://www.tao.lu/Ontologies/TAO.rdf#User')  )
  )  
  UNION ALL   
  (SELECT DISTINCT "subject" FROM "statements" 
    WHERE  "predicate" = 'http://www.tao.lu/Ontologies/TAOTestCenter.rdf#authorizedProctor' AND 
    ("object" = 'http://myTest.case#TestCenter1' 
    OR  "object" = 'http://myTest.case#TestCenter2'  
    OR  "object" = 'http://myTest.case#TestCenter3')) 
) AS unionq GROUP BY "subject" HAVING COUNT(*) >=2 
UNION SELECT "subject" FROM (  
  (SELECT DISTINCT "subject" FROM "statements" WHERE  
  "predicate" = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' AND 
  ("object" IN ('http://www.tao.lu/Ontologies/TAOSubject.rdf#Subject' , 'http://www.tao.lu/Ontologies/TAO.rdf#User')  ))
) AS unionq GROUP BY "subject" HAVING COUNT(*) >=1 
```
the last SELECT is redundant there.
I tried to find the reason of this additional query but did not succeed.