### PR TITLE
Extend task interface; Create AbstractTask class

### DIFF
--- a/common/oatbox/task/AbstractTask.php
+++ b/common/oatbox/task/AbstractTask.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+namespace oat\oatbox\task;
+
+/**
+ * Class SyncTask
+ *
+ * Basic implementation of `Task` interface
+ *
+ * @package oat\oatbox\task\implementation
+ * @author Aleh Hutnikau, <huntikau@1pt.com>
+ */
+abstract class AbstractTask implements Task
+{
+
+    /**
+     * @var string
+     */
+    protected $id;
+
+    /**
+     * @var
+     */
+    protected $invocable;
+
+    /**
+     * @var
+     */
+    protected $status;
+
+    /**
+     * @var array
+     */
+    protected $params;
+
+    /**
+     * Task execution report
+     * @var null|array
+     */
+    protected $report;
+
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param string $id
+     * @return string
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return Action|string
+     */
+    public function getInvocable()
+    {
+        return $this->invocable;
+    }
+
+    /**
+     * Set action to invoke
+     */
+    public function setInvocable($invocable)
+    {
+        $this->invocable = $invocable;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    /**
+     * @param string $status
+     */
+    public function setStatus($status)
+    {
+        $this->status = $status;
+    }
+
+    /**
+     * @return array
+     */
+    public function getParameters()
+    {
+        return $this->params;
+    }
+
+    /**
+     * @param array $params
+     */
+    public function setParameters(array $params)
+    {
+        $this->params = $params;
+    }
+
+    /**
+     * @return array|null
+     */
+    public function getReport()
+    {
+        return $this->report;
+    }
+
+    /**
+     * @param $report
+     */
+    public function setReport($report)
+    {
+        $this->report = $report;
+    }
+}

--- a/common/oatbox/task/Queue.php
+++ b/common/oatbox/task/Queue.php
@@ -35,4 +35,11 @@ interface Queue extends \IteratorAggregate
     public function getIterator();
 
     public function updateTaskStatus($taskId, $status);
+
+    /**
+     * Get task instance by id
+     * @param $taskId
+     * @return Task
+     */
+    public function getTask($taskId);
 }

--- a/common/oatbox/task/Task.php
+++ b/common/oatbox/task/Task.php
@@ -30,17 +30,25 @@ interface Task
     public function getLabel();
 
     public function getOwner();
-
+    */
     public function getStatus();
 
-    public function setStatus();
-    */
+    public function setStatus($status);
+
     public function getId();
-    
+
+    public function setId($id);
+
     public function getInvocable();
-    
+
+    public function setInvocable($invocable);
+
     public function getParameters();
-    
+
     public function setParameters(array $params);
-    
+
+    public function getReport();
+
+    public function setReport($report);
+
 }

--- a/common/oatbox/task/TaskService.php
+++ b/common/oatbox/task/TaskService.php
@@ -25,6 +25,8 @@ use common_report_Report as Report;
 
 class TaskService extends ConfigurableService
 {
+    const TASK_QUEUE_MANAGER_ROLE = 'http://www.tao.lu/Ontologies/TAO.rdf#TaskQueueManager';
+
     const OPTION_LIMIT = 'limit';
 
     /**

--- a/common/oatbox/task/implementation/SyncQueue.php
+++ b/common/oatbox/task/implementation/SyncQueue.php
@@ -95,6 +95,15 @@ class SyncQueue extends ConfigurableService implements Queue
     }
 
     /**
+     * @param $taskId
+     * @return SyncTask
+     */
+    public function getTask($taskId)
+    {
+        return isset($this->tasks[$taskId]) ? $this->tasks[$taskId] : null;
+    }
+
+    /**
      * @param Task $task
      * @return mixed
      */

--- a/common/oatbox/task/implementation/SyncTask.php
+++ b/common/oatbox/task/implementation/SyncTask.php
@@ -42,7 +42,7 @@ class SyncTask extends AbstractTask
     public function __construct($invocable, $params)
     {
         $this->id = \common_Utils::getNewUri();
-        $this->set = $invocable;
+        $this->setInvocable($invocable);
         $this->setParameters($params);
         $this->setStatus(self::STATUS_CREATED);
     }

--- a/common/oatbox/task/implementation/SyncTask.php
+++ b/common/oatbox/task/implementation/SyncTask.php
@@ -20,39 +20,19 @@
 
 namespace oat\oatbox\task\implementation;
 
-use oat\oatbox\task\Task;
+use oat\oatbox\task\AbstractTask;
 use oat\oatbox\action\Action;
 
 /**
  * Class SyncTask
  *
- * Basic implementation of `Task` interface
+ * Basic implementation of `AbstractTask` class
  *
  * @package oat\oatbox\task\implementation
  * @author Aleh Hutnikau, <huntikau@1pt.com>
  */
-class SyncTask implements Task
+class SyncTask extends AbstractTask
 {
-
-    /**
-     * @var string
-     */
-    private $id;
-
-    /**
-     * @var
-     */
-    private $invocable;
-
-    /**
-     * @var
-     */
-    private $status;
-
-    /**
-     * @var array
-     */
-    private $params;
 
     /**
      * SyncTask constructor.
@@ -62,56 +42,8 @@ class SyncTask implements Task
     public function __construct($invocable, $params)
     {
         $this->id = \common_Utils::getNewUri();
-        $this->invocable = $invocable;
+        $this->set = $invocable;
         $this->setParameters($params);
         $this->setStatus(self::STATUS_CREATED);
-    }
-
-    /**
-     * @return string
-     */
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    /**
-     * @return Action|string
-     */
-    public function getInvocable()
-    {
-        return $this->invocable;
-    }
-
-    /**
-     * @return string
-     */
-    public function getStatus()
-    {
-        return $this->status;
-    }
-
-    /**
-     * @param string $status
-     */
-    public function setStatus($status)
-    {
-        $this->status = $status;
-    }
-
-    /**
-     * @return array
-     */
-    public function getParameters()
-    {
-        return $this->params;
-    }
-
-    /**
-     * @param array $params
-     */
-    public function setParameters(array $params)
-    {
-        $this->params = $params;
     }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '3.8.5',
+    'version' => '3.9.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -302,7 +302,7 @@ class Updater extends common_ext_ExtensionUpdater {
             }
             $this->setVersion('3.8.4');
         }
-        $this->skip('3.8.4', '3.8.5');
+        $this->skip('3.8.4', '3.9.0');
     }
     
     private function getReadableModelIds() {


### PR DESCRIPTION
Added `Queue::getTask()` to be able get task from storage and check it's status, report etc.
Needed for https://oat-sa.atlassian.net/browse/TAO-3395

related to https://github.com/oat-sa/lib-oatbox-taskqueue/pull/11