### PR TITLE
Count of result must always have integer type

### DIFF
--- a/core/kernel/persistence/smoothsql/class.Class.php
+++ b/core/kernel/persistence/smoothsql/class.Class.php
@@ -346,7 +346,7 @@ class core_kernel_persistence_smoothsql_Class extends core_kernel_persistence_sm
         }
         
 		$query = 'SELECT count(subject) FROM (' . $this->getFilteredQuery($resource, $propertyFilters, $options) . ') as countq';
-		return $this->getPersistence()->query($query)->fetchColumn();
+		return (int)$this->getPersistence()->query($query)->fetchColumn();
     }
 
     /**

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '3.14.1',
+    'version' => '3.14.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -311,7 +311,7 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('3.10.0');
         }
         
-        $this->skip('3.10.0', '3.14.1');
+        $this->skip('3.10.0', '3.14.2');
     }
     
     private function getReadableModelIds() {


### PR DESCRIPTION
In order to have consistency across various platforms and RDBMS implementations - result should be cast to the integer. 