### PR TITLE
fix dbal version to prevent having 2.6.x that requires PHP 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
 	"require" : {
 		"clearFw/clearFw" : "~1.0",
 		"easyrdf/easyrdf" : "0.9.*",
-		"doctrine/dbal" : "^2.5",
+		"doctrine/dbal" : "~2.5.0",
 		"zendframework/zend-servicemanager" : "~2.5.0",
 		"league/flysystem": "~1.0",
 		"oat-sa/oatbox-extension-installer": "dev-master",

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '3.21.0',
+    'version' => '3.21.1',
 
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -311,7 +311,7 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('3.10.0');
         }
 
-        $this->skip('3.10.0', '3.21.0');
+        $this->skip('3.10.0', '3.21.1');
 
 
     }


### PR DESCRIPTION
Prevents : 

```
14:40:21   Problem 1
14:40:21     - Installation request for doctrine/dbal 2.6.x-dev -> satisfiable by doctrine/dbal[2.6.x-dev].
14:40:21     - doctrine/dbal 2.6.x-dev requires php ^7.0 -> your PHP version (5.6.24) does not satisfy that requirement.
14:40:21   Problem 2
14:40:21     - Installation request for doctrine/dbal dev-master -> satisfiable by doctrine/dbal[dev-master].
14:40:21     - doctrine/dbal dev-master requires php ^7.0 -> your PHP version (5.6.24) does not satisfy that requirement.
14:40:21   Problem 3
14:40:21     - doctrine/dbal 2.6.x-dev requires php ^7.0 -> your PHP version (5.6.24) does not satisfy that requirement.
14:40:21     - oat-sa/generis v3.21.0 requires doctrine/dbal ^2.5 -> satisfiable by doctrine/dbal[2.6.x-dev].
14:40:21     - Installation request for oat-sa/generis v3.21.0 -> satisfiable by oat-sa/generis[v3.21.0].
```