### PR TITLE
Fix/tao 4011 real unit test

### DIFF
--- a/core/kernel/classes/class.Literal.php
+++ b/core/kernel/classes/class.Literal.php
@@ -58,10 +58,6 @@ class core_kernel_classes_Literal
     {
         
         $this->literal = strval($literal);
-        if(DEBUG_MODE){
-    		$this->debug = $debug;
-        }
-        
     }
 
     /**

--- a/core/kernel/classes/class.Resource.php
+++ b/core/kernel/classes/class.Resource.php
@@ -116,11 +116,6 @@ class core_kernel_classes_Resource
 		}
 		
 		$this->uriResource = $uri;
-        
-        if(DEBUG_MODE){
-        	$this->debug = $debug;
-        }
-        
     }
 
 

--- a/core/kernel/rules/class.Expression.php
+++ b/core/kernel/rules/class.Expression.php
@@ -105,9 +105,7 @@ class core_kernel_rules_Expression
     {
         
         parent::__construct($uri);
-        $this->debug = $debug;
 
-        
     }
 
     /**

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '3.20.1',
+    'version' => '3.21.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -311,7 +311,7 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('3.10.0');
         }
 
-        $this->skip('3.10.0', '3.20.1');
+        $this->skip('3.10.0', '3.21.0');
 
     }
     

--- a/test/FileHelperTest.php
+++ b/test/FileHelperTest.php
@@ -1,5 +1,5 @@
 <?php
-/*  
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
@@ -16,6 +16,7 @@
  * 
  * Copyright (c) 2008-2010 (original work) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
+ *               2017      (update and modification) Open Assessment Technologies SA;
  * 
  */
 

--- a/test/FileHelperTest.php
+++ b/test/FileHelperTest.php
@@ -19,15 +19,12 @@
  * 
  */
 
-use oat\generis\test\GenerisPhpUnitTestRunner;
 
-
-class FileHelperTest extends GenerisPhpUnitTestRunner 
+class FileHelperTest extends \PHPUnit_Framework_TestCase
 {
     
     protected function setUp()
     {
-        GenerisPhpUnitTestRunner::initTest();
     }
     
 	public function testRemoveFile()

--- a/test/GenerisPhpUnitTestRunner.php
+++ b/test/GenerisPhpUnitTestRunner.php
@@ -30,7 +30,7 @@ use \common_persistence_Manager;
 /**
  * @author CRP Henri Tudor - TAO Team
  * @license GPLv2
- *
+ * @deprecated it uses constants
  */
 
 abstract class GenerisPhpUnitTestRunner extends \PHPUnit_Framework_TestCase

--- a/test/ManifestTest.php
+++ b/test/ManifestTest.php
@@ -1,5 +1,5 @@
 <?php
-/*  
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
@@ -16,6 +16,7 @@
  * 
  * Copyright (c) 2008-2010 (original work) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
+ *               2017      (update and modification) Open Assessment Technologies SA;
  * 
  */
 

--- a/test/ManifestTest.php
+++ b/test/ManifestTest.php
@@ -19,9 +19,8 @@
  * 
  */
 
-use oat\generis\test\GenerisPhpUnitTestRunner;
 
-class ManifestTest extends GenerisPhpUnitTestRunner {
+class ManifestTest extends \PHPUnit_Framework_TestCase {
 	
 	const SAMPLES_PATH = '/../test/samples/manifests/';
 	const MANIFEST_PATH_DOES_NOT_EXIST = 'idonotexist.php';
@@ -29,7 +28,6 @@ class ManifestTest extends GenerisPhpUnitTestRunner {
 	const MANIFEST_PATH_COMPLEX = 'complexManifest.php';
 	
 	public function setUp(){
-        GenerisPhpUnitTestRunner::initTest();
 	}
 	
 	public function testManifestLoading(){
@@ -42,18 +40,18 @@ class ManifestTest extends GenerisPhpUnitTestRunner {
 			$this->assertTrue(false, "Trying to load a manifest that does not exist should raise an exception");
 		}
 		catch (Exception $e){
-			$this->assertIsA($e, 'common_ext_ManifestNotFoundException');
+			$this->assertInstanceOf('common_ext_ManifestNotFoundException', $e);
 		}
 		
 		// Load a simple lightweight manifest that exists and is well formed.
 		$manifestPath = $currentPath . self::SAMPLES_PATH . self::MANIFEST_PATH_LIGHTWEIGHT;
 		try{
 			$manifest = new common_ext_Manifest($manifestPath);
-			$this->assertIsA($manifest, 'common_ext_Manifest');
-			$this->assertEquals($manifest->getName(), 'lightweight');
-			$this->assertEquals($manifest->getDescription(), 'lightweight testing manifest');
-			$this->assertEquals($manifest->getVersion(), '1.0');
-			$this->assertEquals($manifest->getAuthor(), 'TAO Team');
+			$this->assertInstanceOf('common_ext_Manifest', $manifest);
+			$this->assertEquals('lightweight', $manifest->getName());
+			$this->assertEquals('lightweight testing manifest', $manifest->getDescription());
+			$this->assertEquals('1.0', $manifest->getVersion());
+			$this->assertEquals('TAO Team', $manifest->getAuthor());
 		}
 		catch (common_ext_ManifestException $e){
 			$this->assertTrue(false, "Trying to load a manifest that exists and well formed should not raise an exception.");
@@ -63,17 +61,20 @@ class ManifestTest extends GenerisPhpUnitTestRunner {
 		$manifestPath = $currentPath . self::SAMPLES_PATH . self::MANIFEST_PATH_COMPLEX;
 		try{
 			$manifest = new common_ext_Manifest($manifestPath);
-			$this->assertIsA($manifest, 'common_ext_Manifest');
-			$this->assertEquals($manifest->getName(), 'complex');
-			$this->assertEquals($manifest->getDescription(), 'complex testing manifest');
-			$this->assertEquals($manifest->getVersion(), '1.0');
-			$this->assertEquals($manifest->getAuthor(), 'TAO Team');
-			$this->assertEquals(array_keys($manifest->getDependencies()), array('taoItemBank', 'taoDocuments'));
-			$this->assertEquals($manifest->getInstallModelFiles(), array('/extension/path/models/ontology/taofuncacl.rdf',
-																  		'/extension/path/models/ontology/taoitembank.rdf'));
-			$this->assertEquals($manifest->getConstants(), array('WS_ENDPOINT_TWITTER' => 'http://twitter.com/statuses/', 'WS_ENDPOINT_FACEBOOK' => 'http://api.facebook.com/restserver.php'));
-			$this->assertEquals($manifest->getOptimizableClasses(), array('http://www.linkeddata.org/ontologies/data.rdf#myClass1','http://www.linkeddata.org/ontologies/data.rdf#myClass2'));
-			$this->assertEquals($manifest->getOptimizableProperties(), array('http://www.linkeddata.org/ontologies/props.rdf#myProp1','http://www.linkeddata.org/ontologies/props.rdf#myProp2'));
+			$this->assertInstanceOf('common_ext_Manifest', $manifest);
+			$this->assertEquals('complex', $manifest->getName());
+			$this->assertEquals('complex testing manifest', $manifest->getDescription());
+			$this->assertEquals('1.0', $manifest->getVersion());
+			$this->assertEquals('TAO Team', $manifest->getAuthor());
+			$this->assertEquals(array('taoItemBank', 'taoDocuments'), array_keys($manifest->getDependencies()));
+			$this->assertEquals(array(
+			    '/extension/path/models/ontology/taofuncacl.rdf',
+                '/extension/path/models/ontology/taoitembank.rdf'
+            ),
+                $manifest->getInstallModelFiles());
+			$this->assertEquals(array('WS_ENDPOINT_TWITTER' => 'http://twitter.com/statuses/', 'WS_ENDPOINT_FACEBOOK' => 'http://api.facebook.com/restserver.php'), $manifest->getConstants());
+			$this->assertEquals(array('http://www.linkeddata.org/ontologies/data.rdf#myClass1','http://www.linkeddata.org/ontologies/data.rdf#myClass2'), $manifest->getOptimizableClasses());
+			$this->assertEquals(array('http://www.linkeddata.org/ontologies/props.rdf#myProp1','http://www.linkeddata.org/ontologies/props.rdf#myProp2'), $manifest->getOptimizableProperties());
 			
 		}
 		catch (common_ext_ManifestException $e){

--- a/test/NamespaceTest.php
+++ b/test/NamespaceTest.php
@@ -1,5 +1,5 @@
 <?php
-/*  
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
@@ -19,7 +19,6 @@
  * 
  */
 
-use oat\generis\test\GenerisPhpUnitTestRunner;
 
 /**
  * Test of the common_ext_Namespace and common_ext_NamesapceManager
@@ -28,10 +27,10 @@ use oat\generis\test\GenerisPhpUnitTestRunner;
  * @package generis
  
  */
-class NamespaceTest extends GenerisPhpUnitTestRunner {
+class NamespaceTest extends \PHPUnit_Framework_TestCase
+{
 	
 	public function setUp(){
-        GenerisPhpUnitTestRunner::initTest();
 	}
 
 	/**
@@ -39,12 +38,12 @@ class NamespaceTest extends GenerisPhpUnitTestRunner {
 	 */
 	public function testModel(){
 		$namespaceManager = common_ext_NamespaceManager::singleton();
-		$this->assertIsA($namespaceManager, 'common_ext_NamespaceManager');
+		$this->assertInstanceOf('common_ext_NamespaceManager', $namespaceManager);
 		
 		//$this->assertReference($namespaceManager, common_ext_NamespaceManager::singleton());
 		
 		$tempNamesapce = new common_ext_Namespace();
-		$this->assertIsA($tempNamesapce, 'common_ext_Namespace');
+		$this->assertInstanceOf('common_ext_Namespace', $tempNamesapce);
 	}
 	
 	/**
@@ -56,14 +55,14 @@ class NamespaceTest extends GenerisPhpUnitTestRunner {
 		$this->assertTrue(count($namespaces) > 0);
 		
 		foreach($namespaces as $namespace){
-			$this->assertIsA($namespace, 'common_ext_Namespace');
+			$this->assertInstanceOf('common_ext_Namespace', $namespace);
 		}
 		
 		$localNs = $namespaceManager->getLocalNamespace();
-		$this->assertIsA($localNs, 'common_ext_Namespace');
+		$this->assertInstanceOf('common_ext_Namespace', $localNs);
 
 		$otherLocalNs = $namespaceManager->getNamespace($localNs->getModelId());
-		$this->assertIsA($otherLocalNs, 'common_ext_Namespace');
+		$this->assertInstanceOf('common_ext_Namespace', $otherLocalNs);
 		
 		$this->assertEquals((string)$otherLocalNs, (string)$localNs);
 	}

--- a/test/NamespaceTest.php
+++ b/test/NamespaceTest.php
@@ -16,6 +16,7 @@
  * 
  * Copyright (c) 2008-2010 (original work) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
+ *               2017      (update and modification) Open Assessment Technologies SA;
  * 
  */
 

--- a/test/RegistryTest.php
+++ b/test/RegistryTest.php
@@ -23,7 +23,7 @@ namespace oat\generis\test;
 
 use oat\oatbox\BasicRegistry;
 
-class RegistryTest extends GenerisPhpUnitTestRunner 
+class RegistryTest extends \PHPUnit_Framework_TestCase
 {
     /**
      *
@@ -31,7 +31,6 @@ class RegistryTest extends GenerisPhpUnitTestRunner
      */
     public function setUp()
     {
-        GenerisPhpUnitTestRunner::initTest();
     }
     
     /**

--- a/test/ReportTest.php
+++ b/test/ReportTest.php
@@ -18,9 +18,7 @@
  * 
  */
 
-use oat\generis\test\GenerisPhpUnitTestRunner;
-
-class ReportTest extends GenerisPhpUnitTestRunner {
+class ReportTest extends \PHPUnit_Framework_TestCase {
 	
 	public function testBasicReport()
 	{

--- a/test/model/data/permission/FreeAccessTest.php
+++ b/test/model/data/permission/FreeAccessTest.php
@@ -19,19 +19,18 @@
  */
 namespace oat\generis\test\model\data\permission;
 
-use oat\generis\test\GenerisPhpUnitTestRunner;
 use oat\generis\model\data\permission\implementation\FreeAccess;
+use oat\oatbox\user\User;
 
-class FreeAccessTest extends GenerisPhpUnitTestRunner
+class FreeAccessTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var oat\oatbox\user\User
+     * @var User
      */
     private $user;
 
     public function setUp()
     {
-        GenerisPhpUnitTestRunner::initTest();
         $user = $this->prophesize('oat\oatbox\user\User');
         $user->getIdentifier()->willReturn('tastIdentifier\\_of_//User');
         

--- a/test/model/data/permission/IntersectionTest.php
+++ b/test/model/data/permission/IntersectionTest.php
@@ -19,19 +19,18 @@
  */
 namespace oat\generis\test\model\data\permission;
 
-use oat\generis\test\GenerisPhpUnitTestRunner;
 use oat\generis\model\data\permission\implementation\Intersection;
+use oat\oatbox\user\User;
 
-class IntersectionTest extends GenerisPhpUnitTestRunner
+class IntersectionTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var oat\oatbox\user\User
+     * @var User
      */
     private $user;
 
     public function setUp()
     {
-        GenerisPhpUnitTestRunner::initTest();
         $user = $this->prophesize('oat\oatbox\user\User');
         $user->getIdentifier()->willReturn('tastIdentifier\\_of_//User');
         

--- a/test/model/data/permission/NoAccessTest.php
+++ b/test/model/data/permission/NoAccessTest.php
@@ -19,19 +19,18 @@
  */
 namespace oat\generis\test\model\data\permission;
 
-use oat\generis\test\GenerisPhpUnitTestRunner;
 use oat\generis\model\data\permission\implementation\NoAccess;
+use oat\oatbox\user\User;
 
-class NoAccessTest extends GenerisPhpUnitTestRunner
+class NoAccessTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var oat\oatbox\user\User
+     * @var User
      */
     private $user;
 
     public function setUp()
     {
-        GenerisPhpUnitTestRunner::initTest();
         $user = $this->prophesize('oat\oatbox\user\User');
         $user->getIdentifier()->willReturn('tastIdentifier\\_of_//User');
         

--- a/test/model/persistence/file/FileModelTest.php
+++ b/test/model/persistence/file/FileModelTest.php
@@ -19,11 +19,10 @@
  */
 namespace oat\generis\test\model\kernel\persistence\file;
 
-use oat\generis\test\GenerisPhpUnitTestRunner;
 use oat\generis\model\kernel\persistence\file\FileModel;
 use \common_exception_MissingParameter;
 
-class FileModelTest extends GenerisPhpUnitTestRunner
+class FileModelTest extends \PHPUnit_Framework_TestCase
 {
 
     /**
@@ -32,7 +31,6 @@ class FileModelTest extends GenerisPhpUnitTestRunner
      */
     public function setUp()
     {
-        GenerisPhpUnitTestRunner::initTest();
     }
 
     /**

--- a/test/model/persistence/smoothsql/SmoothModelIteratorTest.php
+++ b/test/model/persistence/smoothsql/SmoothModelIteratorTest.php
@@ -19,16 +19,14 @@
  */
 namespace oat\generis\test\model\persistence\smoothsql;
 
-use oat\generis\test\GenerisPhpUnitTestRunner;
 use Prophecy\Promise\ReturnPromise;
 use Prophecy\Argument;
 
-class SmoothModelIteratorTest extends GenerisPhpUnitTestRunner
+class SmoothModelIteratorTest extends \PHPUnit_Framework_TestCase
 {
 
     public function setUp()
     {
-        GenerisPhpUnitTestRunner::initTest();
     }
 
    

--- a/test/model/persistence/smoothsql/SmoothRdfTest.php
+++ b/test/model/persistence/smoothsql/SmoothRdfTest.php
@@ -23,7 +23,7 @@ use \core_kernel_persistence_smoothsql_SmoothRdf;
 use oat\generis\test\GenerisPhpUnitTestRunner;
 use Prophecy\Prophet;
 
-class SmoothRdfTest extends GenerisPhpUnitTestRunner
+class SmoothRdfTest extends \PHPUnit_Framework_TestCase
 {
 
     /**
@@ -32,7 +32,6 @@ class SmoothRdfTest extends GenerisPhpUnitTestRunner
      */
     public function setUp()
     {
-        GenerisPhpUnitTestRunner::initTest();
     }
 
     /**

--- a/test/oatbox/config/ConfigSetsTest.php
+++ b/test/oatbox/config/ConfigSetsTest.php
@@ -20,7 +20,6 @@
 
 namespace oat\generis\test\config;
 
-use oat\generis\test\GenerisPhpUnitTestRunner;
 use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\config\ConfigSets;
 
@@ -29,7 +28,7 @@ use oat\oatbox\config\ConfigSets;
  * @package oat\generis\test\config
  * @author Aleh Hutnikau, <hutnikau@1pt.com>
  */
-class ConfigSetsTest extends GenerisPhpUnitTestRunner
+class ConfigSetsTest extends \PHPUnit_Framework_TestCase
 {
 
     /**

--- a/test/oatbox/extension/InstallActionTest.php
+++ b/test/oatbox/extension/InstallActionTest.php
@@ -19,7 +19,6 @@
  */
 namespace oat\generis\test\oatbox\extension;
 
-use oat\generis\test\GenerisPhpUnitTestRunner;
 use oat\oatbox\event\EventManager;
 use oat\oatbox\extension\InstallAction;
 use oat\oatbox\service\ServiceManager;
@@ -27,7 +26,8 @@ use oat\oatbox\service\ServiceManager;
  *
  * @author Christophe GARCIA <christopheg@taotesting.com>
  */
-class InstallActionTest extends GenerisPhpUnitTestRunner {
+class InstallActionTest extends \PHPUnit_Framework_TestCase
+{
     
     public function testRegisterEvent() {
         

--- a/test/oatbox/extension/UninstallActionTest.php
+++ b/test/oatbox/extension/UninstallActionTest.php
@@ -19,7 +19,6 @@
  */
 namespace oat\generis\test\oatbox\extension;
 
-use oat\generis\test\GenerisPhpUnitTestRunner;
 use oat\oatbox\event\EventManager;
 use oat\oatbox\extension\UninstallAction;
 use oat\oatbox\service\ServiceManager;
@@ -27,7 +26,8 @@ use oat\oatbox\service\ServiceManager;
  *
  * @author Christophe GARCIA <christopheg@taotesting.com>
  */
-class UninstallActionTest extends GenerisPhpUnitTestRunner {
+class UninstallActionTest extends \PHPUnit_Framework_TestCase
+{
     
      public function testUnregisterEvent() {
         

--- a/test/oatbox/log/TestLoggerTest.php
+++ b/test/oatbox/log/TestLoggerTest.php
@@ -26,7 +26,7 @@ use Psr\Log\LogLevel;
 /**
  * Test of test logger implementation
  */
-class TestRunnerFeatureTest extends TaoPhpUnitTestRunner
+class TestLoggerTest extends \PHPUnit_Framework_TestCase
 {
     public function testArbitraryLogger() {
         $logger = new TestLogger();

--- a/test/oatbox/task/SyncQueueTest.php
+++ b/test/oatbox/task/SyncQueueTest.php
@@ -31,7 +31,7 @@ use Prophecy\Argument;
  *
  * @author Aleh Hutnikau, <huntikau@1pt.com>
  */
-class SyncQueueTest extends GenerisPhpUnitTestRunner
+class SyncQueueTest extends \PHPUnit_Framework_TestCase
 {
 
     protected $prophet;

--- a/test/oatbox/task/SyncTaskTest.php
+++ b/test/oatbox/task/SyncTaskTest.php
@@ -26,7 +26,7 @@ use oat\oatbox\task\implementation\SyncTask;
 /**
  * @author Aleh Hutnikau, <huntikau@1pt.com>
  */
-class SyncTaskTest extends GenerisPhpUnitTestRunner
+class SyncTaskTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstruct()
     {

--- a/test/oatbox/task/TaskRunnerTest.php
+++ b/test/oatbox/task/TaskRunnerTest.php
@@ -25,7 +25,7 @@ use oat\oatbox\task\TaskRunner;
 use Prophecy\Argument;
 use Prophecy\Prophet;
 
-class TaskRunnerTest extends GenerisPhpUnitTestRunner
+class TaskRunnerTest extends \PHPUnit_Framework_TestCase
 {
     private $prophet;
 

--- a/test/rules/ExpressionTest.php
+++ b/test/rules/ExpressionTest.php
@@ -1,5 +1,5 @@
 <?php
-/*  
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
@@ -16,6 +16,7 @@
  * 
  * Copyright (c) 2008-2010 (original work) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
+ *               2017      (update and modification) Open Assessment Technologies SA;
  * 
  */
 

--- a/test/rules/ExpressionTest.php
+++ b/test/rules/ExpressionTest.php
@@ -19,9 +19,9 @@
  * 
  */
 
-use oat\generis\test\GenerisPhpUnitTestRunner;
 
-class ExpressionTest extends GenerisPhpUnitTestRunner {
+class ExpressionTest extends \PHPUnit_Framework_TestCase
+{
 
     public function testEvaluate(){
         $constantResource1 = core_kernel_rules_TermFactory::createConst('test1');


### PR DESCRIPTION
This is a good base of unit test that can be launched without the platform installed.

you can use this phpunit.xml to launch only relevant unit test :
```xml
<phpunit 
	bootstrap="vendor/autoload.php">
	
	<testsuites>
		<testsuite name="generis">
			<directory>generis/test/oatbox/extension</directory>
			<directory>generis/test/oatbox/config</directory>
			<directory>generis/test/oatbox/log</directory>
			<directory>generis/test/model/data</directory>
			<file>generis/test/model/persistence/smoothsql/SmoothModelIteratorTest.php</file>
			<file>generis/test/model/persistence/smoothsql/SmoothRdfTest.php</file>
			<file>generis/test/FileHelperTest.php</file>
			<file>generis/test/ManifestTest.php</file>
			<file>generis/test/ReportTest.php</file>
			<file>generis/test/oatbox/EventManagerTest.php</file>
		</testsuite>
	</testsuites>
</phpunit>
```