### PR TITLE
Fix/removing lg independent properties

### DIFF
--- a/core/kernel/persistence/smoothsql/class.Resource.php
+++ b/core/kernel/persistence/smoothsql/class.Resource.php
@@ -474,7 +474,7 @@ class core_kernel_persistence_smoothsql_Resource
         $returnValue = $this->getPersistence()->exec($sqlQuery, array (
         	$resource->getUri(),
         	$property->getUri(),
-        	$lg
+            ($property->isLgDependent() ? $lg : '')
         ));
         
     	if (!$returnValue){

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '4.1.0',
+    'version' => '4.1.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -390,7 +390,7 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('3.35.2');
         }
 
-        $this->skip('3.35.2', '4.1.0');
+        $this->skip('3.35.2', '4.1.1');
     }
     
     private function getReadableModelIds() {


### PR DESCRIPTION
Actually, this issue produces errors with duplicating IBN fields during the import.

How it happens.

- A user trying import package. Package uploaded, if item found - content replaced. 
- After, importer runs injecting metadata where IBN also exists. 
- Injector trying to find already existing properties (language dependent search) and replace them
- The first call trying to create language dependent property but property for IBN marked as language independent and value created without language.
- Second call trying to replace value by editPropertyValueByLg (it means removing old values and set new).
- But deleting method does not check is property language dependent or not and trying to remove the value for specific language when actually value doesn't have language.