### PR TITLE
Feature/tao 5250 5251/externalisation of task data

### DIFF
--- a/common/oatbox/TaskQueue/TaskLog.php
+++ b/common/oatbox/TaskQueue/TaskLog.php
@@ -1,0 +1,206 @@
+<?php
+
+namespace oat\oatbox\TaskQueue;
+
+use common_report_Report as Report;
+use Doctrine\DBAL\Query\QueryBuilder;
+use oat\oatbox\service\ConfigurableService;
+use oat\oatbox\log\LoggerAwareTrait;
+use oat\oatbox\task\Task;
+
+class TaskLog extends ConfigurableService implements TaskLogInterface
+{
+    use LoggerAwareTrait;
+
+    /**
+     * @var \common_persistence_SqlPersistence
+     */
+    protected $persistence;
+    protected $tablePrefix = 'tq';
+
+    /**
+     * @return string
+     */
+    protected function getTableName()
+    {
+        return strtolower($this->tablePrefix .'_'. $this->getOption(self::CONFIG_CONTAINER_NAME));
+    }
+
+    /**
+     * @return \common_persistence_Persistence|\common_persistence_SqlPersistence
+     */
+    protected function getPersistence()
+    {
+        if (is_null($this->persistence)) {
+            $this->persistence = \common_persistence_Manager::getPersistence($this->getOption(self::CONFIG_PERSISTENCE));
+        }
+
+        return $this->persistence;
+    }
+
+    /**
+     * Creates the new container.
+     * @return void
+     */
+    public function createContainer()
+    {
+        /** @var \common_persistence_sql_pdo_mysql_SchemaManager $schemaManager */
+        $schemaManager = $this->getPersistence()->getSchemaManager();
+
+        /** @var \Doctrine\DBAL\Schema\MySqlSchemaManager $sm */
+        $sm = $schemaManager->getSchemaManager();
+
+        // if our table does not exist, let's create it
+        if(false === $sm->tablesExist($this->getTableName())) {
+            $fromSchema = $schemaManager->createSchema();
+            $toSchema = clone $fromSchema;
+
+            $table = $toSchema->createTable($this->getTableName());
+            $table->addOption('engine', 'InnoDB');
+            $table->addColumn('id', 'string', ["notnull" => true, "length" => 255]);
+            $table->addColumn('task_name', 'string', ["notnull" => true, "length" => 255]);
+            $table->addColumn('status', 'string', ["notnull" => true, "length" => 50]);
+            $table->addColumn('owner', 'string', ["notnull" => false, "length" => 255, "default" => null]);
+            $table->addColumn('report', 'text', ["notnull" => false, "default" => null]);
+            $table->addColumn('created_at', 'datetime', ['notnull' => true]);
+            $table->addColumn('updated_at', 'datetime', ['notnull' => false]);
+            $table->setPrimaryKey(['id']);
+            $table->addIndex(['status'], 'IDX_status');
+
+            $queries = $this->persistence->getPlatForm()->getMigrateSchemaSql($fromSchema, $toSchema);
+            foreach ($queries as $query) {
+                $this->persistence->exec($query);
+            }
+        }
+    }
+
+    /**
+     * @param Task $task
+     * @return bool
+     */
+    public function add(Task $task)
+    {
+        $dateNow = $this->getPersistence()->getPlatForm()->getNowExpression();
+
+        try {
+            return (bool) $this->getPersistence()->insert($this->getTableName(), [
+                'id'   => (string) $task->getId(),
+                'task_name' => is_object($task->getInvocable()) ? get_class($task->getInvocable()) : (string) $task->getInvocable(),
+                'status' => $task->getStatus() ?: Task::STATUS_CREATED,
+                'owner' => (string) $task->getOwner(),
+                'created_at' => $task->getCreationDate() ?: $dateNow,
+                'updated_at' => $dateNow
+            ]);
+        } catch (\Exception $e) {
+            $this->logError('Adding log for task '. $task->getId() .' failed with MSG: '. $e->getMessage());
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $id
+     * @param string $newStatus
+     * @return int
+     */
+    public function setStatus($id, $newStatus)
+    {
+        try {
+            $qb = $this->getQueryBuilder()
+                ->update($this->getTableName())
+                ->set('status', ':status_new')
+                ->set('updated_at', ':updated_at')
+                ->where('id = :id')
+                ->setParameter('id', (string) $id)
+                ->setParameter('status_new', $newStatus)
+                ->setParameter('updated_at', $this->getPersistence()->getPlatForm()->getNowExpression());
+
+            return (int) $qb->execute();
+        } catch (\Exception $e) {
+            $this->logError('Setting the status for task '. $id .' failed with MSG: '. $e->getMessage());
+        }
+
+        return 0;
+    }
+
+    /**
+     * @param string $id
+     * @return string
+     */
+    public function getStatus($id)
+    {
+        try {
+            $qb = $this->getQueryBuilder()
+                ->select('status')
+                ->from($this->getTableName())
+                ->andWhere('id = :id')
+                ->setParameter('id', $id);
+
+            return $qb->execute()->fetchColumn();
+        } catch (\Exception $e) {
+            $this->logError('Getting status for task '. $id .' failed with MSG: '. $e->getMessage());
+        }
+
+        return '';
+    }
+
+    /**
+     * @param string $id
+     * @param Report $report
+     * @return bool
+     */
+    public function setReport($id, Report $report)
+    {
+        try{
+            $qb = $this->getQueryBuilder()
+                ->update($this->getTableName())
+                ->set('report', ':report')
+                ->set('updated_at', ':updated_at')
+                ->where('id = :id')
+                ->setParameter('id', (string) $id)
+                ->setParameter('report', json_encode($report))
+                ->setParameter('updated_at', $this->getPersistence()->getPlatForm()->getNowExpression());
+
+            return (bool) $qb->execute();
+        } catch (\Exception $e) {
+            $this->logError('Setting report for item '. $id .' failed with MSG: '. $e->getMessage());
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $id
+     * @return Report|null
+     */
+    public function getReport($id)
+    {
+        try{
+            $qb = $this->getQueryBuilder()
+                ->select('report')
+                ->from($this->getTableName())
+                ->where('id = :id')
+                ->setParameter('id', (string) $id);
+
+            if (($reportJson = $qb->execute()->fetchColumn())
+                && ($reportData = json_decode($reportJson, true)) !== null
+                && json_last_error() === JSON_ERROR_NONE
+            ) {
+                // if we have a valid JSON string and no JSON error, let's restore the report object
+                return Report::jsonUnserialize($reportData);
+            }
+        } catch (\Exception $e) {
+            $this->logError('Getting report for task '. $id .' failed with MSG: '. $e->getMessage());
+        }
+
+        return null;
+    }
+
+    /**
+     * @return QueryBuilder
+     */
+    private function getQueryBuilder()
+    {
+        return $this->getPersistence()->getPlatform()->getQueryBuilder();
+    }
+}

--- a/common/oatbox/TaskQueue/TaskLogInterface.php
+++ b/common/oatbox/TaskQueue/TaskLogInterface.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace oat\oatbox\TaskQueue;
+
+use common_report_Report as Report;
+use oat\oatbox\task\Task;
+use Psr\Log\LoggerAwareInterface;
+
+interface TaskLogInterface extends LoggerAwareInterface
+{
+    const SERVICE_ID = 'generis/TaskLog';
+
+    const CONFIG_PERSISTENCE = 'persistence';
+    const CONFIG_CONTAINER_NAME = 'container_name';
+
+    /**
+     * Creates the container where the task reports and metadata will be stored.
+     */
+    public function createContainer();
+
+    /**
+     * Inserts a new record with status for a task.
+     *
+     * @param Task $task
+     * @return bool
+     */
+    public function add(Task $task);
+
+    /**
+     * Set a status for a task.
+     *
+     * @param string $id
+     * @param string $newStatus
+     * @return int
+     */
+    public function setStatus($id, $newStatus);
+
+    /**
+     * Gets the status of a task.
+     *
+     * @param string $id
+     * @return string
+     */
+    public function getStatus($id);
+
+    /**
+     * Saves the report for a message.
+     *
+     * @param string $id
+     * @param Report $report
+     * @return bool
+     */
+    public function setReport($id, Report $report);
+
+    /**
+     * Gets the report for a message if that exists.
+     *
+     * @param string $id
+     * @return Report|null
+     */
+    public function getReport($id);
+}

--- a/common/oatbox/task/LegacyTaskLog.php
+++ b/common/oatbox/task/LegacyTaskLog.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace oat\oatbox\task;
+
+use common_report_Report as Report;
+use oat\oatbox\task\TaskInterface\TaskPersistenceInterface;
+use oat\oatbox\task\TaskInterface\TaskQueue;
+use oat\oatbox\TaskQueue\TaskLog;
+
+/**
+ * Class LegacyTaskLog
+ *
+ * Retrieves status and report from both container: the new one and the old queue
+ *
+ * @author Gyula Szucs <gyula@taotesting.com>
+ */
+final class LegacyTaskLog extends TaskLog
+{
+    /** @var  TaskPersistenceInterface */
+    private $getLegacyQueuePersistence;
+
+    /**
+     * @return TaskPersistenceInterface
+     */
+    private function getLegacyQueuePersistence()
+    {
+        if (is_null($this->getLegacyQueuePersistence)) {
+            /** @var TaskQueue $queue */
+            $queue = $this->getServiceManager()->get(Queue::SERVICE_ID);
+            $this->getLegacyQueuePersistence =  $queue->getPersistence();
+        }
+
+        return $this->getLegacyQueuePersistence;
+    }
+
+    /**
+     * @param string $id
+     * @return string
+     */
+    public function getStatus($id)
+    {
+        try {
+            // check the new storage first
+            if ($status = parent::getStatus($id)) {
+                return $status;
+            }
+
+            // if there is no task in the new storage, check the old one
+            if ($task = $this->getLegacyQueuePersistence()->get($id)) {
+                return $task->getStatus();
+            }
+        } catch (\Exception $e) {
+            $this->logError('Getting status for task '. $id .' failed with MSG: '. $e->getMessage());
+        }
+
+        return '';
+    }
+
+    /**
+     * @param string $id
+     * @return null|Report
+     */
+    public function getReport($id)
+    {
+        try {
+            // check the new storage first
+            if ($report = parent::getReport($id)) {
+                return $report;
+            }
+
+            // if there is no report in the new storage, check the old one
+            if ($task = $this->getLegacyQueuePersistence()->get($id)) {
+                return $task->getReport();
+            }
+        } catch (\Exception $e) {
+            $this->logError('Getting report for task '. $id .' failed with MSG: '. $e->getMessage());
+        }
+
+        return null;
+    }
+}

--- a/common/oatbox/task/implementation/SyncQueue.php
+++ b/common/oatbox/task/implementation/SyncQueue.php
@@ -23,6 +23,8 @@ namespace oat\oatbox\task\implementation;
 use oat\oatbox\task\AbstractQueue;
 use oat\oatbox\task\Task;
 use oat\oatbox\task\TaskRunner;
+use oat\oatbox\TaskQueue\TaskLog;
+use oat\oatbox\TaskQueue\TaskLogInterface;
 
 /**
  * Class SyncQueue
@@ -67,6 +69,10 @@ class SyncQueue extends AbstractQueue
         $task->setLabel($label);
         $task->setType($type);
         $this->getPersistence()->add($task);
+
+        // insert task data into task log as well
+        $this->getTaskLogService()->add($task);
+
         $this->runTask($task);
         return $task;
     }

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '4.1.4',
+    'version' => '4.2.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(
@@ -51,6 +51,7 @@ return array(
         'checks' => array(),
         'php' => array(
             oat\generis\scripts\install\TaskQueue::class,
+            oat\generis\scripts\install\TaskLogService::class,
         ),
     ),
     'update' => 'oat\\generis\\scripts\\update\\Updater',

--- a/scripts/TaskQueue/MigrateTaskData.php
+++ b/scripts/TaskQueue/MigrateTaskData.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace oat\generis\scripts\TaskQueue;
+
+use oat\oatbox\action\Action;
+use oat\oatbox\task\Queue;
+use oat\oatbox\task\Task;
+use oat\oatbox\TaskQueue\TaskLogInterface;
+use oat\Taskqueue\Persistence\RdsQueue;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorAwareTrait;
+
+/**
+ * Migrates the data (reports and metadata) of the already existing tasks from the queue storage
+ * into the new task log container
+ *
+ * ```
+ * $ sudo -u www-data php index.php 'oat\generis\scripts\TaskQueue\MigrateTaskData'
+ * ```
+ *
+ * @author Gyula Szucs <gyula@taotesting.com>
+ */
+class MigrateTaskData implements Action, ServiceLocatorAwareInterface
+{
+    use ServiceLocatorAwareTrait;
+
+    public function __invoke($params)
+    {
+        try {
+            /** @var RdsQueue $queue */
+            $queue = $this->getServiceLocator()->get(Queue::SERVICE_ID);
+
+            /** @var TaskLogInterface $taskLogService */
+            $taskLogService = $this->getServiceLocator()->get(TaskLogInterface::SERVICE_ID);
+
+            $i = 0;
+
+            foreach ($queue->getPersistence()->getAll() as $task) {
+                if($taskLogService->add($task)) {
+                    $i++;
+                }
+            }
+
+            return \common_report_Report::createSuccess('Migrated '. $i .' tasks');
+        } catch (\Exception $e) {
+            return \common_report_Report::createFailure($e->getMessage());
+        }
+    }
+}
+

--- a/scripts/install/TaskLogService.php
+++ b/scripts/install/TaskLogService.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\generis\scripts\install;
+
+use oat\oatbox\extension\InstallAction;
+use oat\oatbox\TaskQueue\TaskLog;
+
+/**
+ * Class TaskLogService
+ *
+ * Action to initialize task log service
+ *
+ * @package oat\generis\scripts\install
+ * @author Gyula Szucs <gyula@taotesting.com>
+ */
+class TaskLogService extends InstallAction
+{
+    /**
+     * Install action
+     */
+    public function __invoke($params)
+    {
+        // use the new storage for task reports and status for new install
+        $taskLogService = new TaskLog([
+            TaskLog::CONFIG_PERSISTENCE => 'default',
+            TaskLog::CONFIG_CONTAINER_NAME => 'task_log'
+        ]);
+        $this->registerService(TaskLog::SERVICE_ID, $taskLogService);
+
+        try{
+            $taskLogService->createContainer();
+        } catch (\Exception $e) {
+            return \common_report_Report::createFailure('Creating task log container failed');
+        }
+
+        return \common_report_Report::createSuccess('Task log service registered.');
+    }
+}

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -45,6 +45,7 @@ use oat\oatbox\service\ServiceNotFoundException;
 use oat\oatbox\task\implementation\InMemoryQueuePersistence;
 use oat\oatbox\task\implementation\SyncQueue;
 use oat\oatbox\task\implementation\TaskQueuePayload;
+use oat\oatbox\task\LegacyTaskLog;
 use oat\oatbox\task\Queue;
 use oat\oatbox\task\TaskRunner;
 use oat\taoWorkspace\model\generis\WrapperModel;
@@ -391,6 +392,19 @@ class Updater extends common_ext_ExtensionUpdater {
         }
 
         $this->skip('3.35.2', '4.1.4');
+
+        if ($this->isVersion('4.1.4')) {
+            $taskLogService = new LegacyTaskLog([
+                LegacyTaskLog::CONFIG_PERSISTENCE => 'default',
+                LegacyTaskLog::CONFIG_CONTAINER_NAME => 'task_log'
+            ]);
+
+            $taskLogService->createContainer();
+
+            $this->getServiceManager()->register(LegacyTaskLog::SERVICE_ID, $taskLogService);
+
+            $this->setVersion('4.2.0');
+        }
     }
     
     private function getReadableModelIds() {

--- a/test/oatbox/TaskQueue/TaskLogTest.php
+++ b/test/oatbox/TaskQueue/TaskLogTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace oat\generis\test\oatbox\TaskQueue;
+
+use oat\oatbox\task\Task;
+use oat\oatbox\TaskQueue\TaskLog;
+
+/**
+ * @backupGlobals disabled
+ * @backupStaticAttributes disabled
+ */
+class TaskLogTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var TaskLog
+     */
+    private $taskLog;
+
+
+    protected function setup()
+    {
+        $this->taskLog = new TaskLog([
+            TaskLog::CONFIG_CONTAINER_NAME => 'example_container',
+            TaskLog::CONFIG_PERSISTENCE => 'default'
+        ]);
+    }
+
+    protected function tearDown()
+    {
+        $this->taskLog = null;
+    }
+
+    public function provideInsertResult()
+    {
+        return [
+            'ForTrue' => [1, true],
+            'ForFalse' => [0, false]
+        ];
+    }
+
+    /**
+     * @dataProvider provideInsertResult
+     */
+    public function testAddNewTask($insertFixture, $expected)
+    {
+        $nowFixture = '2017-09-22 18:00:15';
+
+        $platformMock = $this->getMockBuilder(\common_persistence_sql_Platform::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getNowExpression'])
+            ->getMock();
+
+        $platformMock->expects($this->once())
+            ->method('getNowExpression')
+            ->willReturn($nowFixture);
+
+        $persistenceMock = $this->getMockBuilder(\common_persistence_SqlPersistence::class)
+            ->disableOriginalConstructor()
+            ->setMethods([
+                'getPlatForm', 'insert'
+            ])
+            ->getMock();
+
+        $persistenceMock->expects($this->once())
+            ->method('getPlatForm')
+            ->willReturn($platformMock);
+
+        $persistenceMock->expects($this->once())
+            ->method('insert')
+            ->willReturn($insertFixture);
+
+        $instanceMock = $this->getMockBuilder(TaskLog::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getPersistence', 'getTableName'])
+            ->getMock();
+
+        $instanceMock->expects($this->exactly(2))
+            ->method('getPersistence')
+            ->willReturn($persistenceMock);
+
+        $instanceMock->expects($this->once())
+            ->method('getTableName')
+            ->willReturn('table_example');
+
+
+        $this->assertEquals($expected, $instanceMock->add($this->getTask()));
+    }
+
+    public function testAddNewTaskForException()
+    {
+        $nowFixture = '2017-09-22 18:00:15';
+
+        $platformMock = $this->getMockBuilder(\common_persistence_sql_Platform::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getNowExpression'])
+            ->getMock();
+
+        $platformMock->expects($this->once())
+            ->method('getNowExpression')
+            ->willReturn($nowFixture);
+
+        $persistenceMock = $this->getMockBuilder(\common_persistence_SqlPersistence::class)
+            ->disableOriginalConstructor()
+            ->setMethods([
+                'getPlatForm', 'insert'
+            ])
+            ->getMock();
+
+        $persistenceMock->expects($this->once())
+            ->method('getPlatForm')
+            ->willReturn($platformMock);
+
+        $persistenceMock->expects($this->once())
+            ->method('insert')
+            ->willThrowException(new \RuntimeException());
+
+        $instanceMock = $this->getMockBuilder(TaskLog::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getPersistence', 'getTableName'])
+            ->getMock();
+
+        $instanceMock->expects($this->exactly(2))
+            ->method('getPersistence')
+            ->willReturn($persistenceMock);
+
+        $instanceMock->expects($this->once())
+            ->method('getTableName')
+            ->willReturn('table_example');
+
+        $this->assertFalse($instanceMock->add($this->getTask()));
+    }
+
+    private function getTask()
+    {
+        $taskMock = $this->getMockForAbstractClass(Task::class);
+
+        $taskMock->expects($this->atLeastOnce())
+            ->method('getId')
+            ->willReturn('1111');
+
+        $taskMock->expects($this->exactly(2))
+            ->method('getInvocable')
+            ->willReturn(\stdClass::class);
+
+        $taskMock->expects($this->once())
+            ->method('getStatus')
+            ->willReturn(Task::STATUS_CREATED);
+
+        $taskMock->expects($this->once())
+            ->method('getOwner')
+            ->willReturn('ME');
+
+        $taskMock->expects($this->once())
+            ->method('getCreationDate')
+            ->willReturn('2017-09-23 18:11:18');
+
+        return $taskMock;
+    }
+}


### PR DESCRIPTION
In order to move from the old queue to the new one we need a transition phase. In this phase we have to externalise the reports and the task data (name, status, owner, created and updated dates, etc) into an external storage in order to stay backward compatible, so later the new task queue system will be able to reach information for any task created by the old task queue and no data will be lost.

- For new installation the TaskLog service is used: it saves data into the new storage and reaches data from the new storage.
- For update the LegacyTaskLog service is used: it saves data into the new storage but reaches data from both storage, new one and the old queue.

In both cases, the reports and metadata are duplicated.

We have an optional script (MigrateTaskData) for migrating reports and metadata of every tasks except the achieved ones from the old queue into the new storage. 