### PR TITLE
LF + setTransactionIsolation

### DIFF
--- a/common/persistence/sql/class.Platform.php
+++ b/common/persistence/sql/class.Platform.php
@@ -19,10 +19,20 @@
  * @author "Lionel Lecaque, <lionel@taotesting.com>"
  * @license GPLv2
  * @package generis
- 
  *
  */
+
+use Doctrine\DBAL\Connection;
+
 class common_persistence_sql_Platform{
+    
+    const TRANSACTION_READ_UNCOMMITTED = Connection::TRANSACTION_READ_UNCOMMITTED;
+    
+    const TRANSACTION_READ_COMMITTED = Connection::TRANSACTION_READ_COMMITTED;
+    
+    const TRANSACTION_REPEATABLE_READ = Connection::TRANSACTION_REPEATABLE_READ;
+    
+    const TRANSACTION_SERIALIZABLE = Connection::TRANSACTION_SERIALIZABLE;
     
     protected  $dbalPlatform;
 
@@ -177,6 +187,18 @@ class common_persistence_sql_Platform{
     public function beginTransaction()
     {
         $this->dbalConnection->beginTransaction();
+    }
+    
+    /**
+     * Sets the transaction isolation level.
+     *
+     * @param integer $level The level to set.
+     *
+     * @return integer
+     */
+    public function setTransactionIsolation($level)
+    {
+        $this->dbalConnection->setTransactionIsolation($level);
     }
 
     /**

--- a/common/persistence/sql/class.Platform.php
+++ b/common/persistence/sql/class.Platform.php
@@ -191,6 +191,10 @@ class common_persistence_sql_Platform {
      * * TRANSACTION_READ_COMMITTED
      * * TRANSACTION_REPEATABLE_READ
      * * TRANSACTION_SERIALIZABLE
+     * 
+     * Developer's note: We know that we could use DBAL's setTransactionIsolation method. Unfortunately,
+     * it sets a global isolation level for the entire session, which could be dangerous in case of error
+     * or developer absent-mindedness.
      *
      * @param integer $level (optional) A Transaction level. Defaults to platform default.
      * @return void

--- a/common/persistence/sql/class.SerializationException.php
+++ b/common/persistence/sql/class.SerializationException.php
@@ -1,0 +1,6 @@
+<?php
+
+class common_persistence_sql_SerializationException extends common_Exception
+{
+    
+}

--- a/common/persistence/sql/class.SerializationException.php
+++ b/common/persistence/sql/class.SerializationException.php
@@ -1,5 +1,30 @@
 <?php
-
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+ 
+/**
+ * SQL Serialization Exception
+ * 
+ * This exception class represents the typical error when concurrent
+ * transactions using the SERIALIZATION Isolation Level are producing
+ * conflicts (SQLSTATE 40001).
+ */
 class common_persistence_sql_SerializationException extends common_Exception
 {
     

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '5.3.1',
+    'version' => '5.4.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -409,7 +409,7 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('4.4.1');
         }
 
-        $this->skip('4.4.1', '5.3.1');
+        $this->skip('4.4.1', '5.4.0');
     }
     
     private function getReadableModelIds() {


### PR DESCRIPTION
I'm sorry, it will be difficult to detect the changes in class `common_persistence_sql_Platform`. Indeed, it was still using Windows like (CR LF) new lines, and I changed it to Unix like (LF).

Major changes for this class are:

- class constants
- `common_persistence_sql_Platform::beginTransaction` (isolation levels)
- `common_persistence_sql_Platform::commit` (capture serialization failures)
- `common_persistence_sql_Platform::setTransactionIsolation`
- `common_persistence_sql_Platform::getTransactionIsolation`
- `common_persistence_sql_Platform::isTransactionActive`
