### PR TITLE
Feature/ablility to tao setup kv session

### DIFF
--- a/common/session/php/class.KeyValueSessionHandler.php
+++ b/common/session/php/class.KeyValueSessionHandler.php
@@ -17,7 +17,7 @@
  * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
-use oat\oatbox\Configurable;
+use oat\oatbox\service\ConfigurableService;
 
 /**
  * Session implementation as a Key Value storage and using the persistence
@@ -25,7 +25,7 @@ use oat\oatbox\Configurable;
  * @author Joel Bout <joel@taotesting.com>
  * @package generis
  */
-class common_session_php_KeyValueSessionHandler extends Configurable
+class common_session_php_KeyValueSessionHandler extends ConfigurableService
     implements common_session_php_SessionHandler
 {
     const OPTION_PERSISTENCE = 'persistence'; 

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '5.5.0',
+    'version' => '5.6.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '5.4.0',
+    'version' => '5.5.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -409,7 +409,7 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('4.4.1');
         }
 
-        $this->skip('4.4.1', '5.4.0');
+        $this->skip('4.4.1', '5.5.0');
     }
     
     private function getReadableModelIds() {

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -409,7 +409,7 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('4.4.1');
         }
 
-        $this->skip('4.4.1', '5.5.0');
+        $this->skip('4.4.1', '5.6.0');
     }
     
     private function getReadableModelIds() {


### PR DESCRIPTION
Ability to set session from taoSetup
To test it, install the platform from a taoSetup.json that contains:

> "generis": {
>       "persistences": {
>          [...]
> 	"session": {
>           "driver": "phpredis",
>           "host": "127.0.0.1",
>           "port": 6379
>         }
>     }
> }
> 

and 

> 
> "tao": {
>       "session": {
>         "type" : "configurableService",
>         "class" : "common_session_php_KeyValueSessionHandler",
>         "options": {
>           "persistence": "session"
>         } 
>       }
>   }
