### PR TITLE
Fix/sql platform now expression

### DIFF
--- a/common/persistence/sql/class.Platform.php
+++ b/common/persistence/sql/class.Platform.php
@@ -151,7 +151,7 @@ class common_persistence_sql_Platform {
      * @return string
      */
     public function getNowExpression(){
-        $datetime = new DateTime();
+        $datetime = new DateTime('now', new \DateTimeZone('UTC'));
         $date = $datetime->format('Y-m-d H:i:s');
        // return $this->dbalPlatform->getNowExpression();
        return $date;

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '6.2.0',
+    'version' => '6.2.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -410,7 +410,7 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('4.4.1');
         }
 
-        $this->skip('4.4.1', '6.2.0');
+        $this->skip('4.4.1', '6.2.1');
     }
     
     private function getReadableModelIds() {


### PR DESCRIPTION
I found that on ACT prod server all the time values in task queue tables (such as `tq_background`, `tq_task_log` etc) are stored in their local timezone. It's better to have all the time values in UTC in the database to avoid confusion.