### PR TITLE
Fix/tao 5717/implement kv session locking

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '6.10.0',
+    'version' => '6.11.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -448,7 +448,7 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('6.9.0');
         }
 
-        $this->skip('6.9.0', '6.10.0');
+        $this->skip('6.9.0', '6.11.0');
     }
 
     private function getReadableModelIds() {


### PR DESCRIPTION
From my investigation this bug it's only reproducible on prod where we are using a KeyValue Session handler. By Default the redis driver does not support a session locking yet compare with the file session handler which does and blocks the next request to wait until the session it's writing with success.

By default the locking will be disable, I plan to enable on prod to see if this it's gone fix our issue.