### PR TITLE
destroy logger file to release files

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '7.1.0',
+    'version' => '7.1.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -322,6 +322,6 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('6.17.0');
         }
         
-        $this->skip('6.17.0', '7.1.0');
+        $this->skip('6.17.0', '7.1.1');
     }
 }

--- a/test/LogTest.php
+++ b/test/LogTest.php
@@ -105,12 +105,15 @@ class LogTest extends GenerisPhpUnitTestRunner {
         $this->assertEntriesInFile($efile, 2);
         $this->assertEntriesInFile($cfile, 1);
 
+        //destroy logger object to release files
+        unset($logger);
+
         unlink($dfile);
         unlink($ifile);
         unlink($wfile);
         unlink($efile);
         unlink($cfile);
-	}
+    }
 	
 	public function testLogTags()
 	{
@@ -144,6 +147,8 @@ class LogTest extends GenerisPhpUnitTestRunner {
 
         $logger->logDebug('message', array('WRONGTAG', 'WRONGTAG2'));
 		$this->assertEntriesInFile($dfile, 2);
+        //destroy logger object to release files
+        unset($logger);
 
         unlink($dfile);
     }


### PR DESCRIPTION
Test fails because files cannot be deleted as they a blocked by `SingleFileAppender`:
![image](https://user-images.githubusercontent.com/11025793/38188838-55168fb0-3666-11e8-8d96-e618d6bff2d2.png)
