### PR TITLE
Fix/getting rid of unknown extension while installing platform

### DIFF
--- a/common/ext/class.ExtensionHandler.php
+++ b/common/ext/class.ExtensionHandler.php
@@ -78,7 +78,9 @@ abstract class common_ext_ExtensionHandler
             }
             $report = call_user_func($action, array());
         } else {
-            throw new common_ext_InstallationException('Unable to run install script '.$script);
+            $error = new common_ext_InstallationException('Unable to run install script '.$script);
+            $error->setExtensionId($this->getExtension()->getId());
+            throw $error;
         }
     }
 

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '7.2.4',
+    'version' => '7.2.5',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -329,6 +329,6 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->getServiceManager()->register(UserLanguageService::SERVICE_ID, new UserLanguageService());
             $this->setVersion('7.2.0');
         }
-        $this->skip('7.2.0', '7.2.4');
+        $this->skip('7.2.0', '7.2.5');
     }
 }


### PR DESCRIPTION
Now the extension name should be shown, if there would be any error during platform install, not `unknown`.