### PR TITLE
Feature/tao 6219 get request header

### DIFF
--- a/common/http/class.Request.php
+++ b/common/http/class.Request.php
@@ -156,6 +156,25 @@ class common_http_Request
     {
         return $this->headers;
     }
+
+    /**
+     * Get the value of an HTTP header
+     * The lookup is case insensitive.
+     * @param string $headerName the HTTP header name, 'Content-Type' for example
+     * @return boolean|string the value or false if not found
+     */
+    public function getHeaderValue($headerName)
+    {
+        if (is_string($headerName) && count($this->headers) > 0) {
+            $lowCaseHeaders = array_change_key_case($this->headers, CASE_LOWER);
+            $lowCaseHeaderName = strtolower($headerName);
+            if (isset($lowCaseHeaders[$lowCaseHeaderName])) {
+                return $lowCaseHeaders[$lowCaseHeaderName];
+            }
+        }
+        return false;
+    }
+
     /**
      * set request body to send
      */

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '7.5.1',
+    'version' => '7.6.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -330,6 +330,6 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('7.2.0');
         }
 
-        $this->skip('7.2.0', '7.5.1');
+        $this->skip('7.2.0', '7.6.0');
     }
 }

--- a/test/common/http/RequestTest.php
+++ b/test/common/http/RequestTest.php
@@ -27,7 +27,7 @@ use \common_http_Request;
  *
  * @author Bertrand Chevrier <bertrand@taotesting.com>
  */
-class ReqyestTest extends GenerisPhpUnitTestRunner {
+class RequestTest extends GenerisPhpUnitTestRunner {
 
     /**
      * Test the method getHeaderValue

--- a/test/common/http/RequestTest.php
+++ b/test/common/http/RequestTest.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\generis\test\common\http;
+
+use oat\generis\test\GenerisPhpUnitTestRunner;
+use \common_http_Request;
+
+/**
+ * Test the \common_http_Request class
+ *
+ * @author Bertrand Chevrier <bertrand@taotesting.com>
+ */
+class ReqyestTest extends GenerisPhpUnitTestRunner {
+
+    /**
+     * Test the method getHeaderValue
+     *
+     * @dataProvider headerProvider
+     */
+    public function testGetHeaderValue($headers, $headerName, $expect)
+    {
+        $request = new common_http_Request('http://foo.bar', 'POST', [], $headers);
+        $result  = $request->getHeaderValue($headerName);
+        $this->assertEquals($expect, $result);
+    }
+
+    /**
+     * Provides data for the getHeaderValue test case
+     * @return array the data
+     */
+    public function headerProvider()
+    {
+        return [
+            [ ['Content-Type' => 'application/json' ], 'Content-Type', 'application/json' ],
+            [ ['Content-Type' => 'application/json' ], 'Accept', false ],
+            [ ['Content-Type' => 'application/json' ], 'content-type', 'application/json' ],
+            [ ['ACCEPT' => 'application/json' ], 'Accept', 'application/json' ],
+            [ ['accept' => 'application/json' ], 'Accept', 'application/json' ],
+            [ ['Accept' => 'application/json' ], 'ACCEPT', 'application/json' ],
+        ];
+    }
+
+}


### PR DESCRIPTION
Allow you to get the value of a header by it's name, no matter the case.
HTTP headers are case insensitives as described by the [RFC 7230/RFC 2616, section 4.2](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2)  