### PR TITLE
Feature/ontology auth pattern

### DIFF
--- a/config/default/auth.conf.php
+++ b/config/default/auth.conf.php
@@ -24,11 +24,7 @@
 return array(
     array(
         'driver' => 'oat\\generis\\model\\user\\AuthAdapter',
-        'user_factory' => 'generis/userFactory',
-        'hash' => array(
-            'algorithm' => 'sha256',
-            'salt' => 10
-        )
+        'user_factory' => 'generis/userFactory'
     ),
     /*
     array(

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '7.6.0',
+    'version' => '7.7.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -330,6 +330,6 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('7.2.0');
         }
 
-        $this->skip('7.2.0', '7.6.0');
+        $this->skip('7.2.0', '7.7.0');
     }
 }


### PR DESCRIPTION
Aims at filtering user login via pattern. Example configuration:

```php
<?php
return new oat\oatbox\config\ConfigurationService(array(
    'config' => array(
        array(
            'driver' => 'oat\\generis\\model\\user\\AuthAdapter',
            'hash' => array(
                'algorithm' => 'sha256',
                'salt' => 11
            ),
            // Only authenticate users with logins beginning by 'a'
            'pattern' => '/^a/'
        )
    )
));

```