### PR TITLE
Fix/php7.2 compatibility

### DIFF
--- a/common/report/class.Report.php
+++ b/common/report/class.Report.php
@@ -26,7 +26,7 @@
  * @author Bertrand Chevrier, <bertrand.chevrier@tudor.lu>
  * @package generis
  */
-class common_report_Report implements IteratorAggregate, JsonSerializable
+class common_report_Report implements IteratorAggregate, JsonSerializable, Countable
 {
     const TYPE_SUCCESS = 'success';
     
@@ -337,4 +337,13 @@ class common_report_Report implements IteratorAggregate, JsonSerializable
             }, $this->elements)
         ]);
     }
+
+    /**
+     * @return int
+     */
+    public function count()
+    {
+        return $this->getIterator()->count();
+    }
+
 }

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '7.9.8',
+    'version' => '7.9.9',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -330,6 +330,6 @@ class Updater extends common_ext_ExtensionUpdater {
             $this->setVersion('7.2.0');
         }
 
-        $this->skip('7.2.0', '7.9.8');
+        $this->skip('7.2.0', '7.9.9');
     }
 }


### PR DESCRIPTION
As per changes in php 7.2
`An E_WARNING will now be emitted when attempting to count() non-countable types (this includes the sizeof() alias function).`
So in order to maximise compatibility with  following style https://github.com/oat-sa/generis/blob/b155a1c30ea08096e753d3d261dd459c5ad7c554/common/oatbox/extension/script/ScriptAction.php#L179

