### PR TITLE
add database index to the redis configuration

### DIFF
--- a/common/persistence/class.PhpRedisDriver.php
+++ b/common/persistence/class.PhpRedisDriver.php
@@ -76,6 +76,10 @@ class common_persistence_PhpRedisDriver implements common_persistence_AdvKvDrive
         } else {
             $this->connection->connect($host , $port , $timeout);
         }
+
+        if (isset($params['database'])) {
+            $this->connection->select($params['database']);
+        }
     }
 
     /**


### PR DESCRIPTION
This option will allow to select database. More information can be found here:
https://redis.io/commands/select

config example:
```php
'redis' => array(
    'driver' => 'phpredis',
    'host' => '127.0.0.1',
    'port' => 6379,
    'database' => 1
),
```