### PR TITLE
PreConditionFailure exception::getUserMessage()

### DIFF
--- a/common/exception/class.PreConditionFailure.php
+++ b/common/exception/class.PreConditionFailure.php
@@ -16,43 +16,15 @@
  *
  *
  */
-/**
- * Generis Object Oriented API - common/exception/class.InvalidArgumentType.php
- *
- * $Id$
- *
- * This file is part of Generis Object Oriented API.
- *
- * Automatically generated on 30.01.2012, 16:44:05 with ArgoUML PHP module
- * (last revised $Date: 2010-01-12 20:14:42 +0100 (Tue, 12 Jan 2010) $)
- *
- * @author patrick,
- * @package generis
- 
- */
-
-
-
-/* user defined includes */
-
-
-
-/* user defined constants */
-
-
 
 /**
- * a useful exception
  * @access public
  * @author Patrick Plichart
  * @package generis
- 
  */
-class common_exception_PreConditionFailure
-    extends common_exception_ClientException
+class common_exception_PreConditionFailure extends common_exception_ClientException
 {
-  
-       public function getUserMessage() {
-	return __("One of the precondition for this type of request was not satisfied");
+    public function getUserMessage() {
+	    return $this->getMessage();
     }
 } 

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '8.2.1',
+    'version' => '8.2.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -361,6 +361,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('8.0.0');
         }
 
-        $this->skip('8.0.0', '8.2.1');
+        $this->skip('8.0.0', '8.2.2');
     }
 }


### PR DESCRIPTION
As I discover, common_exception_PreConditionFailure mostly used in REST controllers, and doesn't contain sensitive information

I need to show internal message to user because it contains information of unique field name - a reason why new instance of testtaker could not be created, for example

https://oat-sa.atlassian.net/browse/TAO-7390