### PR TITLE
PHP 7.2 compatibility for ResourceCollection

### DIFF
--- a/core/resource/ResourceCollection.php
+++ b/core/resource/ResourceCollection.php
@@ -187,6 +187,10 @@ class ResourceCollection implements Iterator, Countable
      */
     public function count()
     {
+        if (!is_array($this->resources) && !$this->resources instanceof Countable) {
+            return 0;
+        }
+
         return count($this->resources);
     }
 

--- a/core/resource/ResourceCollection.php
+++ b/core/resource/ResourceCollection.php
@@ -187,7 +187,7 @@ class ResourceCollection implements Iterator, Countable
      */
     public function count()
     {
-        if (!is_array($this->resources) && !$this->resources instanceof Countable) {
+        if (!is_array($this->resources) || !$this->resources instanceof Countable) {
             return 0;
         }
 

--- a/core/resource/ResourceCollection.php
+++ b/core/resource/ResourceCollection.php
@@ -187,7 +187,7 @@ class ResourceCollection implements Iterator, Countable
      */
     public function count()
     {
-        if (!is_array($this->resources) || !$this->resources instanceof Countable) {
+        if (!is_array($this->resources) && !$this->resources instanceof Countable) {
             return 0;
         }
 

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '9.0.0',
+    'version' => '9.0.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -361,6 +361,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('8.0.0');
         }
 
-        $this->skip('8.0.0', '9.0.0');
+        $this->skip('8.0.0', '9.0.1');
     }
 }


### PR DESCRIPTION
The `count()` function throws a warning since PHP 7.2 if the given parameter is not an array, or an object that implements `\Countable`