### PR TITLE
Phpdoc fix

### DIFF
--- a/common/oatbox/event/EventManager.php
+++ b/common/oatbox/event/EventManager.php
@@ -60,7 +60,7 @@ class EventManager extends ConfigurableService
      * Attach a Listener to one or multiple events
      * 
      * @param mixed $event either an Event object or a string
-     * @param Callable $callback
+     * @param callable $callback
      */
     public function attach($event, $callback) {
         $events = is_array($event) ? $event : array($event);


### PR DESCRIPTION
Calllable -> callable in phpdoc, makes possible for PhpStorm to find usages of passed method

Actually only 1 letter changed and line endings from CRLF to LF