### PR TITLE
Fix/event manager and autowiring

### DIFF
--- a/common/oatbox/event/EventManager.php
+++ b/common/oatbox/event/EventManager.php
@@ -14,14 +14,13 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2015 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2015-2019 (original work) Open Assessment Technologies SA;
  *
  */
 
 namespace oat\oatbox\event;
 
 use oat\oatbox\service\ConfigurableService;
-use oat\tao\model\resources\ResourceWatcher;
 
 /**
  * The simple placeholder ServiceManager
@@ -43,8 +42,10 @@ class EventManager extends ConfigurableService
      *
      * @param mixed $event either an Event object or a string
      * @param array $params
+     * @throws \oat\oatbox\service\exception\InvalidServiceManagerException
      */
-    public function trigger($event, $params = array()) {
+    public function trigger($event, $params = array())
+    {
         $eventObject = is_object($event) ? $event : new GenericEvent($event, $params);
         foreach ($this->getListeners($eventObject) as $callback) {
             if (is_array($callback) && count($callback) == 2) {
@@ -67,7 +68,8 @@ class EventManager extends ConfigurableService
      * @param mixed $event either an Event object or a string
      * @param callable $callback
      */
-    public function attach($event, $callback) {
+    public function attach($event, $callback)
+    {
         $events = is_array($event) ? $event : array($event);
         $listeners = $this->getOption(self::OPTION_LISTENERS);
         foreach ($events as $event) {
@@ -86,15 +88,16 @@ class EventManager extends ConfigurableService
     /**
      * remove listener from an event and delete event if it dosn't have any listeners
      * @param array $listeners
-     * @param string $eventName
+     * @param $eventObject
      * @param callable $callback
      * @return array
      */
-    protected function removeListener(array $listeners , $eventObject , $callback) {
+    protected function removeListener(array $listeners, $eventObject, $callback)
+    {
         if (isset($listeners[$eventObject->getName()])) {
             if (($index = array_search($callback, $listeners[$eventObject->getName()])) !== false) {
                 unset($listeners[$eventObject->getName()][$index]);
-                if(empty($listeners[$eventObject->getName()])) {
+                if (empty($listeners[$eventObject->getName()])) {
                     unset($listeners[$eventObject->getName()]);
                 } else {
                     $listeners[$eventObject->getName()] = array_values($listeners[$eventObject->getName()]);
@@ -111,7 +114,8 @@ class EventManager extends ConfigurableService
      * @param mixed $event either an Event object or a string
      * @param Callable $callback
      */
-    public function detach($event, $callback){
+    public function detach($event, $callback)
+    {
         $events = is_array($event) ? $event : array($event);
         $listeners = $this->getOption(self::OPTION_LISTENERS);
         foreach ($events as $event) {
@@ -127,7 +131,8 @@ class EventManager extends ConfigurableService
      * @param Event $eventObject
      * @return Callable[] listeners associated with this event
      */
-    protected function getListeners(Event $eventObject) {
+    protected function getListeners(Event $eventObject)
+    {
         $listeners = $this->getOption(self::OPTION_LISTENERS);
         return isset($listeners[$eventObject->getName()])
             ? $listeners[$eventObject->getName()]

--- a/common/oatbox/event/EventManager.php
+++ b/common/oatbox/event/EventManager.php
@@ -21,6 +21,8 @@
 namespace oat\oatbox\event;
 
 use oat\oatbox\service\ConfigurableService;
+use oat\tao\model\resources\ResourceWatcher;
+
 /**
  * The simple placeholder ServiceManager
  * @author Joel Bout <joel@taotesting.com>
@@ -33,12 +35,12 @@ class EventManager extends ConfigurableService
      * @deprecated use SERVICE_ID
      */
     const CONFIG_ID = 'generis/event';
-    
+
     const OPTION_LISTENERS = 'listeners';
-    
+
     /**
      * Dispatch an event and trigger its listeners
-     * 
+     *
      * @param mixed $event either an Event object or a string
      * @param array $params
      */
@@ -47,7 +49,10 @@ class EventManager extends ConfigurableService
         foreach ($this->getListeners($eventObject) as $callback) {
             if (is_array($callback) && count($callback) == 2) {
                 list($key, $function) = $callback;
-                if (is_string($key) && !class_exists($key) && $this->getServiceManager()->has($key)) {
+                if (!is_string($key)) {
+                    continue;
+                }
+                if ($this->getServiceManager()->has($key) || is_subclass_of($key, ConfigurableService::class, true)) {
                     $service = $this->getServiceManager()->get($key);
                     $callback = [$service, $function];
                 }
@@ -55,10 +60,10 @@ class EventManager extends ConfigurableService
             call_user_func($callback, $eventObject);
         }
     }
-    
+
     /**
      * Attach a Listener to one or multiple events
-     * 
+     *
      * @param mixed $event either an Event object or a string
      * @param callable $callback
      */
@@ -77,7 +82,7 @@ class EventManager extends ConfigurableService
         }
         $this->setOption(self::OPTION_LISTENERS, $listeners);
     }
-    
+
     /**
      * remove listener from an event and delete event if it dosn't have any listeners
      * @param array $listeners
@@ -115,10 +120,10 @@ class EventManager extends ConfigurableService
         }
         $this->setOption(self::OPTION_LISTENERS, $listeners);
     }
-    
+
     /**
      * Get all Listeners listening to this kind of event
-     * 
+     *
      * @param Event $eventObject
      * @return Callable[] listeners associated with this event
      */

--- a/common/oatbox/event/EventManager.php
+++ b/common/oatbox/event/EventManager.php
@@ -50,10 +50,7 @@ class EventManager extends ConfigurableService
         foreach ($this->getListeners($eventObject) as $callback) {
             if (is_array($callback) && count($callback) == 2) {
                 list($key, $function) = $callback;
-                if (!is_string($key)) {
-                    continue;
-                }
-                if ($this->getServiceManager()->has($key) || is_subclass_of($key, ConfigurableService::class, true)) {
+                if (is_string($key) && $this->getServiceManager()->has($key)) {
                     $service = $this->getServiceManager()->get($key);
                     $callback = [$service, $function];
                 }

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '9.1.2',
+    'version' => '9.2.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -361,6 +361,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('8.0.0');
         }
 
-        $this->skip('8.0.0', '9.1.2');
+        $this->skip('8.0.0', '9.2.0');
     }
 }

--- a/test/unit/common/oatbox/event/EventManagerTest.php
+++ b/test/unit/common/oatbox/event/EventManagerTest.php
@@ -1,4 +1,22 @@
 <?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ *
+ */
 
 namespace oat\generis\test\unit\common\oatbox\event;
 

--- a/test/unit/common/oatbox/event/EventManagerTest.php
+++ b/test/unit/common/oatbox/event/EventManagerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace oat\generis\test\unit\common\oatbox\event;
+
+use oat\generis\test\TestCase;
+use oat\oatbox\event\EventManager;
+use oat\oatbox\event\GenericEvent;
+use oat\oatbox\service\ConfigurableService;
+use oat\oatbox\service\ServiceManager;
+
+class EventManagerTest extends TestCase
+{
+    public function testTriggerEventWithRegisteredService()
+    {
+        $listeners = [
+            'fixture-event' => [
+                [
+                    EventListenerMock::SERVICE_ID, 'listen'
+                ]
+            ]
+        ];
+
+        $eventManager = $this->getEventManager($listeners);
+        $eventManager->getServiceLocator()->register(EventListenerMock::SERVICE_ID, new EventListenerMock());
+
+        $eventManager->trigger(new FixtureEvent());
+        $this->assertTrue(EventListenerMock::$listened);
+    }
+
+    public function testTriggerEventWithClassName()
+    {
+        $listeners = [
+            'fixture-event' => [
+                [
+                    EventListenerMock::class, 'listen'
+                ]
+            ]
+        ];
+        $this->getEventManager($listeners)->trigger(new FixtureEvent());
+        $this->assertTrue(EventListenerMock::$listened);
+    }
+
+    protected function getEventManager(array $listeners)
+    {
+        $eventManager = new EventManager([
+            EventManager::OPTION_LISTENERS => $listeners
+        ]);
+        $eventManager->setServiceLocator(new ServiceManager(new \common_persistence_InMemoryKvDriver()));
+        return $eventManager;
+    }
+}
+
+class EventListenerMock extends ConfigurableService
+{
+    const SERVICE_ID = 'fixture/toto';
+
+    public static $listened = false;
+
+    static public function listen()
+    {
+        self::$listened = true;
+    }
+}
+
+class FixtureEvent extends GenericEvent
+{
+    public function __construct()
+    {
+        parent::__construct('fixture-event');
+    }
+}

--- a/test/unit/common/oatbox/event/EventManagerTest.php
+++ b/test/unit/common/oatbox/event/EventManagerTest.php
@@ -33,16 +33,16 @@ class EventManagerTest extends TestCase
         $listeners = [
             'fixture-event' => [
                 [
-                    EventListenerMock::SERVICE_ID, 'listen'
+                    ConfigurableEventListenerMock::SERVICE_ID, 'listen'
                 ]
             ]
         ];
 
         $eventManager = $this->getEventManager($listeners);
-        $eventManager->getServiceLocator()->register(EventListenerMock::SERVICE_ID, new EventListenerMock());
+        $eventManager->getServiceLocator()->register(ConfigurableEventListenerMock::SERVICE_ID, new ConfigurableEventListenerMock());
 
         $eventManager->trigger(new FixtureEvent());
-        $this->assertTrue(EventListenerMock::$listened);
+        $this->assertTrue(ConfigurableEventListenerMock::$listened);
     }
 
     public function testTriggerEventWithClassName()
@@ -50,14 +50,31 @@ class EventManagerTest extends TestCase
         $listeners = [
             'fixture-event' => [
                 [
-                    EventListenerMock::class, 'listen'
+                    ConfigurableEventListenerMock::class, 'listen'
                 ]
             ]
         ];
         $this->getEventManager($listeners)->trigger(new FixtureEvent());
-        $this->assertTrue(EventListenerMock::$listened);
+        $this->assertTrue(ConfigurableEventListenerMock::$listened);
     }
 
+    public function testTriggerEventWithNotConfigurableClassName()
+    {
+        $listeners = [
+            'fixture-event' => [
+                [
+                    WildEventListenerMock::class, 'staticListen'
+                ]
+            ]
+        ];
+        $this->getEventManager($listeners)->trigger(new FixtureEvent());
+        $this->assertTrue(WildEventListenerMock::$listened);
+    }
+
+    /**
+     * @param array $listeners
+     * @return EventManager
+     */
     protected function getEventManager(array $listeners)
     {
         $eventManager = new EventManager([
@@ -68,7 +85,17 @@ class EventManagerTest extends TestCase
     }
 }
 
-class EventListenerMock extends ConfigurableService
+class WildEventListenerMock
+{
+    public static $listened = false;
+
+    static public function staticListen()
+    {
+        self::$listened = true;
+    }
+}
+
+class ConfigurableEventListenerMock extends ConfigurableService
 {
     const SERVICE_ID = 'fixture/toto';
 

--- a/test/unit/oatbox/service/ServiceManagerTest.php
+++ b/test/unit/oatbox/service/ServiceManagerTest.php
@@ -32,24 +32,58 @@ use Psr\Container\NotFoundExceptionInterface;
  */
 class ServiceManagerTest extends TestCase
 {
-    public function testGet()
+    /**
+     * @dataProvider getExpectedServicesProvider
+     * @param $serviceKey
+     * @param $serviceClass
+     * @throws \common_Exception
+     */
+    public function testGet($serviceKey, $serviceClass)
     {
         $config = new \common_persistence_KeyValuePersistence([], new \common_persistence_InMemoryKvDriver());
         $serviceManager = new ServiceManager($config);
         $serviceManager->register(TestServiceInterface1::SERVICE_ID, new TestService1());
         $serviceManager->register(TestService2_2::SERVICE_ID, new TestService2_2());
-        $this->assertTrue($serviceManager->get(TestServiceInterface1::SERVICE_ID) instanceof TestService1);
-        $this->assertTrue($serviceManager->get(TestServiceInterface1::class) instanceof TestService1);
-        $this->assertTrue($serviceManager->get(TestService1::class) instanceof TestService1);
-        $this->assertTrue($serviceManager->get(TestService2_2::class) instanceof TestService2_2);
-        $this->assertTrue($serviceManager->get(TestService2_2::SERVICE_ID) instanceof TestService2_2);
+        $this->assertTrue($serviceManager->get($serviceKey) instanceof $serviceClass);
     }
 
+    /**
+     * @dataProvider getExpectedServicesProvider
+     * @param $serviceKey
+     * @param $serviceClass
+     * @throws \common_Exception
+     */
+    public function testHas($serviceKey, $serviceClass)
+    {
+        $config = new \common_persistence_KeyValuePersistence([], new \common_persistence_InMemoryKvDriver());
+        $serviceManager = new ServiceManager($config);
+        $serviceManager->register(TestServiceInterface1::SERVICE_ID, new TestService1());
+        $serviceManager->register(TestService2_2::SERVICE_ID, new TestService2_2());
+        $this->assertTrue($serviceManager->has($serviceKey), "$serviceKey => $serviceClass : ". get_class($serviceManager->get($serviceKey)));
+     }
+
+    public function getExpectedServicesProvider()
+    {
+        return [
+            [TestServiceInterface1::SERVICE_ID, TestService1::class],
+            [TestServiceInterface1::class, TestService1::class],
+            [TestService1::class, TestService1::class],
+            [TestService2_2::class, TestService2_2::class],
+            [TestService2_2::SERVICE_ID, TestService2_2::class],
+        ];
+    }
     public function testGetAutowire()
     {
         $config = new \common_persistence_KeyValuePersistence([], new \common_persistence_InMemoryKvDriver());
         $serviceManager = new ServiceManager($config);
         $this->assertTrue($serviceManager->get(TestService3::class) instanceof TestService3);
+    }
+
+    public function testHasAutowire()
+    {
+        $config = new \common_persistence_KeyValuePersistence([], new \common_persistence_InMemoryKvDriver());
+        $serviceManager = new ServiceManager($config);
+        $this->assertTrue($serviceManager->has(TestService3::class));
     }
 
     public function testWithoutAutowire()


### PR DESCRIPTION
The goal of this PR is to be able to use autowired service as event listener. As discussed with Joel we are not implementing autowiring detection in service manager `has()` method but explicitly in eventmanager itself