### PR TITLE
RestNotFound exception

### DIFF
--- a/common/exception/class.RestNotFound.php
+++ b/common/exception/class.RestNotFound.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA ;
+ */
+
+class common_exception_RestNotFound extends common_exception_ClientException
+{
+    /**
+     * @inheritdoc
+     */
+    public function getUserMessage()
+    {
+        if ($this->message === null) {
+            return 'Resource not found';
+        }
+
+        return $this->message;
+    }
+}

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '10.0.0',
+    'version' => '10.1.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -367,5 +367,7 @@ class Updater extends common_ext_ExtensionUpdater
             $this->getServiceManager()->unregister('generis/profiler');
             $this->setVersion('10.0.0');
         }
+
+        $this->skip('10.0.0', '10.1.0');
     }
 }


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/TAO-7607

Added a `common_exception_RestNotFound` in order to return user readable message in Rest error responses.