### PR TITLE
Fix/prem 69 user id in cli

### DIFF
--- a/common/oatbox/user/AnonymousUser.php
+++ b/common/oatbox/user/AnonymousUser.php
@@ -29,6 +29,9 @@ class AnonymousUser implements User
      * @see \oat\oatbox\user\User::getIdentifier()
      */
     public function getIdentifier() {
+        if (PHP_SAPI === 'cli') {
+            return 'cli';
+        }
         return null;
     }
     

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '11.2.2',
+    'version' => '11.2.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -414,5 +414,7 @@ class Updater extends common_ext_ExtensionUpdater
             $this->getServiceManager()->register(LockService::SERVICE_ID, $service);
             $this->setVersion('11.2.2');
         }
+
+        $this->skip('11.2.2', '11.2.3');
     }
 }


### PR DESCRIPTION
In some places user id is required filed in the table.

During execution task in the task queue `\common_session_SessionManager::getSession()->getUser()` return instance of `AnonymousUser` class which returns `null` as a result of `getIdentifier()` method call.

It leads to constraint violation.