### PR TITLE
DRAFT - DO NOT MERGE - Move to a uuid statements primary key

### DIFF
--- a/common/ext/class.GenerisInstaller.php
+++ b/common/ext/class.GenerisInstaller.php
@@ -48,12 +48,16 @@ class common_ext_GenerisInstaller extends common_ext_ExtensionInstaller
         }
  
         $this->installLoadDefaultConfig();
-        
+
+        // Id of the writable model.
+        $modelFactory = new \core_kernel_api_ModelFactory();
+        $userlandModelId = $modelFactory->getUniquePrimaryKey();
+
         $model = new \core_kernel_persistence_smoothsql_SmoothModel(array(
             \core_kernel_persistence_smoothsql_SmoothModel::OPTION_PERSISTENCE => 'default',
-            \core_kernel_persistence_smoothsql_SmoothModel::OPTION_READABLE_MODELS => array('1'),
-            \core_kernel_persistence_smoothsql_SmoothModel::OPTION_WRITEABLE_MODELS => array('1'),
-            \core_kernel_persistence_smoothsql_SmoothModel::OPTION_NEW_TRIPLE_MODEL => '1',
+            \core_kernel_persistence_smoothsql_SmoothModel::OPTION_READABLE_MODELS => [$userlandModelId],
+            \core_kernel_persistence_smoothsql_SmoothModel::OPTION_WRITEABLE_MODELS => [$userlandModelId],
+            \core_kernel_persistence_smoothsql_SmoothModel::OPTION_NEW_TRIPLE_MODEL => $userlandModelId,
             \core_kernel_persistence_smoothsql_SmoothModel::OPTION_SEARCH_SERVICE => ComplexSearchService::SERVICE_ID,
             \core_kernel_persistence_smoothsql_SmoothModel::OPTION_CACHE_SERVICE => common_cache_Cache::SERVICE_ID
         ));

--- a/common/ext/class.GenerisInstaller.php
+++ b/common/ext/class.GenerisInstaller.php
@@ -51,13 +51,13 @@ class common_ext_GenerisInstaller extends common_ext_ExtensionInstaller
 
         // Id of the writable model.
         $modelFactory = new \core_kernel_api_ModelFactory();
-        $userlandModelId = $modelFactory->getUniquePrimaryKey();
+        $writableModelId = $modelFactory->getModelId(LOCAL_NAMESPACE);
 
         $model = new \core_kernel_persistence_smoothsql_SmoothModel(array(
             \core_kernel_persistence_smoothsql_SmoothModel::OPTION_PERSISTENCE => 'default',
-            \core_kernel_persistence_smoothsql_SmoothModel::OPTION_READABLE_MODELS => [$userlandModelId],
-            \core_kernel_persistence_smoothsql_SmoothModel::OPTION_WRITEABLE_MODELS => [$userlandModelId],
-            \core_kernel_persistence_smoothsql_SmoothModel::OPTION_NEW_TRIPLE_MODEL => $userlandModelId,
+            \core_kernel_persistence_smoothsql_SmoothModel::OPTION_READABLE_MODELS => [$writableModelId],
+            \core_kernel_persistence_smoothsql_SmoothModel::OPTION_WRITEABLE_MODELS => [$writableModelId],
+            \core_kernel_persistence_smoothsql_SmoothModel::OPTION_NEW_TRIPLE_MODEL => $writableModelId,
             \core_kernel_persistence_smoothsql_SmoothModel::OPTION_SEARCH_SERVICE => ComplexSearchService::SERVICE_ID,
             \core_kernel_persistence_smoothsql_SmoothModel::OPTION_CACHE_SERVICE => common_cache_Cache::SERVICE_ID
         ));

--- a/common/ext/class.Namespace.php
+++ b/common/ext/class.Namespace.php
@@ -1,86 +1,66 @@
 <?php
-/**  
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
  * of the License (non-upgradable).
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * 
+ *
  * Copyright (c) 2008-2010 (original work) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
- * 
+ *
  */
 
 /**
  * Short description of class common_ext_Namespace
  *
- * @access public
- * @author Jerome Bogaerts, <jerome.bogaerts@tudor.lu>
+ * @access  public
+ * @author  Jerome Bogaerts, <jerome.bogaerts@tudor.lu>
  * @package generis
- 
  */
 class common_ext_Namespace
 {
-    // --- ASSOCIATIONS ---
-    // generateAssociationEnd : 
-
-    // --- ATTRIBUTES ---
-
     /**
      * A unique identifier of the namespace
      *
-     * @access protected
-     * @var int
+     * @var string
      */
-    protected $modelId = 0;
+    protected $modelId;
 
     /**
      * the namespace URI
      *
-     * @access protected
      * @var string
      */
-    protected $uri = '';
-
-    // --- OPERATIONS ---
+    protected $uri;
 
     /**
-     * Create a namespace instance
+     * Namespace constructor.
      *
-     * @access public
      * @author Jerome Bogaerts, <jerome.bogaerts@tudor.lu>
-     * @param  int id
+     *
+     * @param  string id
      * @param  string uri
-     * @return mixed
      */
-    public function __construct($id = 0, $uri = '')
+    public function __construct($id = '', $uri = '')
     {
-        
-        
-    	if($id > 0){
-    		$this->modelId = $id;
-    	}
-    	if(!empty($uri)){
-    		$this->uri = $uri;
-    	}
-    	
-        
+        $this->modelId = $id;
+        $this->uri = $uri;
     }
 
     /**
      * Get the identifier of the namespace instance
      *
-     * @access public
      * @author Jerome Bogaerts, <jerome.bogaerts@tudor.lu>
-     * @return int
+     * @return string
      */
     public function getModelId()
     {
@@ -90,72 +70,48 @@ class common_ext_Namespace
     /**
      * Get the namespace URI
      *
-     * @access public
      * @author Jerome Bogaerts, <jerome.bogaerts@tudor.lu>
      * @return string
      */
     public function getUri()
     {
-        $returnValue = (string) '';
-
-        
-        
-        $returnValue = $this->uri;
-        
-        
-
-        return (string) $returnValue;
+        return $this->uri;
     }
 
     /**
      * Magic method, return the Namespace URI
      *
-     * @access public
      * @author Jerome Bogaerts, <jerome.bogaerts@tudor.lu>
      * @return string
      */
     public function __toString()
     {
-        $returnValue = (string) '';
-
-        
-        
-        $returnValue = $this->getUri();
-        
-        
-
-        return (string) $returnValue;
+        return $this->getUri();
     }
 
     /**
      * Remove a namespace from the ontology. All triples bound to the model will
      * be removed.
      *
-     * @access public
      * @author Jerome Bogaerts, <jerome.bogaerts@tudor.lu>
+     *
      * @return boolean
+     * @throws core_kernel_persistence_Exception
      */
     public function remove()
     {
-        $returnValue = (bool) false;
-
-        
         $db = core_kernel_classes_DbWrapper::singleton();
-        if (false === $db->exec("DELETE FROM statements WHERE modelid = ?", array($this->getModelId()))){
-        	$returnValue = false;
-        }
-        else{
-        	if (false === $db->exec("DELETE FROM models WHERE modelid = ?", array($this->getModelId()))){
-        		$returnValue = false;
-        	}
-        	else{
-        		$returnValue = true;
-        	}
-        }
-        
-        
 
-        return (bool) $returnValue;
+        // TODO refactor this to use triple store abstraction.
+        if (false === $db->exec("DELETE FROM statements WHERE modelid = ?", [$this->getModelId()])) {
+            return false;
+        }
+
+        // TODO refactor this to use triple store abstraction.
+        if (false === $db->exec("DELETE FROM models WHERE modelid = ?", [$this->getModelId()])) {
+            return false;
+        }
+
+        return true;
     }
-
 }

--- a/common/ext/class.Namespace.php
+++ b/common/ext/class.Namespace.php
@@ -84,15 +84,7 @@ class common_ext_Namespace
      */
     public function getModelId()
     {
-        $returnValue = (int) 0;
-
-        
-        
-        $returnValue = $this->modelId;
-        
-        
-
-        return (int) $returnValue;
+        return $this->modelId;
     }
 
     /**

--- a/core/kernel/api/class.ModelFactory.php
+++ b/core/kernel/api/class.ModelFactory.php
@@ -24,6 +24,8 @@
  */
 class core_kernel_api_ModelFactory
 {
+    const DEFAULT_AUTHOR = 'http://www.tao.lu/Ontologies/TAO.rdf#installator';
+
     /** @var core_kernel_classes_DbWrapper */
     private $dbWrapper;
 
@@ -114,7 +116,7 @@ class core_kernel_api_ModelFactory
      *
      * @return bool Was a row added?
      */
-    public function addStatement($modelId, $subject, $predicate, $object, $lang = null, $author = 'http://www.tao.lu/Ontologies/TAO.rdf#installator')
+    public function addStatement($modelId, $subject, $predicate, $object, $lang = null, $author = self::DEFAULT_AUTHOR)
     {
         // TODO: refactor this to use a triple store abstraction.
         $result = $this->dbWrapper->query(
@@ -131,7 +133,7 @@ class core_kernel_api_ModelFactory
         return (bool) $this->dbWrapper->insert(
             'statements',
             [
-                'id' => $this->getNewSpannerPrimaryKey(),
+                'id' => $this->getUniquePrimaryKey(),
                 'modelid' => $modelId,
                 'subject' => $subject,
                 'predicate' => $predicate,
@@ -150,7 +152,7 @@ class core_kernel_api_ModelFactory
      *
      * @return string
      */
-    public function getNewSpannerPrimaryKey()
+    public function getUniquePrimaryKey()
     {
         return strrev(uniqid('', true));
     }

--- a/core/kernel/api/class.ModelFactory.php
+++ b/core/kernel/api/class.ModelFactory.php
@@ -93,7 +93,7 @@ class core_kernel_api_ModelFactory
 
         foreach ($data as $subjectUri => $propertiesValues) {
             foreach ($propertiesValues as $prop => $values) {
-                foreach ($values as $k => $v) {
+                foreach ($values as $v) {
                     $returnValue |= $this->addStatement($modelId, $subjectUri, $prop, $v['value'], isset($v['lang']) ? $v['lang'] : null);
                 }
             }

--- a/core/kernel/api/class.ModelFactory.php
+++ b/core/kernel/api/class.ModelFactory.php
@@ -146,9 +146,7 @@ class core_kernel_api_ModelFactory
     }
 
     /**
-     * Generates a unique primary key for gcp Spanner sharding.
-     *
-     * @TODO: confirm this is the optimal solution for gcp Spanner.
+     * Generates a unique, not auto-increment based, primary key.
      *
      * @return string
      */

--- a/core/kernel/api/class.ModelFactory.php
+++ b/core/kernel/api/class.ModelFactory.php
@@ -59,7 +59,7 @@ class core_kernel_api_ModelFactory
      */
     public function addNewModel($namespace)
     {
-        $modelId = $this->getNewSpannerPrimaryKey();
+        $modelId = $this->getUniquePrimaryKey();
         $this->dbWrapper->insert('models', ['modelid' => $modelId, 'modeluri' => $namespace]);
 
         return $modelId;

--- a/core/kernel/api/class.ModelFactory.php
+++ b/core/kernel/api/class.ModelFactory.php
@@ -44,6 +44,10 @@ class core_kernel_api_ModelFactory
      */
     public function getModelId($namespace)
     {
+        if (substr($namespace, -1) !== '#') {
+            $namespace .= '#';
+        }
+
         $query = 'SELECT modelid FROM models WHERE (modeluri = ?)';
         $results = $this->dbWrapper->query($query, [$namespace]);
 

--- a/core/kernel/api/class.ModelFactory.php
+++ b/core/kernel/api/class.ModelFactory.php
@@ -60,7 +60,11 @@ class core_kernel_api_ModelFactory
     public function addNewModel($namespace)
     {
         $modelId = $this->getUniquePrimaryKey();
-        $this->dbWrapper->insert('models', ['modelid' => $modelId, 'modeluri' => $namespace]);
+
+        $inserted = $this->dbWrapper->insert('models', ['modelid' => $modelId, 'modeluri' => $namespace]);
+        if ($inserted === false) {
+
+        }
 
         return $modelId;
     }
@@ -139,7 +143,7 @@ class core_kernel_api_ModelFactory
                 'predicate' => $predicate,
                 'object' => $object,
                 'l_language' => is_null($lang) ? '' : $lang,
-                'author' => $author,
+                'author' => is_null($author) ? '' : $author,
                 'epoch' => $date,
             ]
         );

--- a/core/kernel/api/class.ModelFactory.php
+++ b/core/kernel/api/class.ModelFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -16,112 +17,141 @@
  *
  * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
- * @author "Lionel Lecaque, <lionel@taotesting.com>"
+ * @author  "Lionel Lecaque, <lionel@taotesting.com>"
  * @license GPLv2
  * @package generis
- 
  *
  */
-class core_kernel_api_ModelFactory{
-    
-    
+class core_kernel_api_ModelFactory
+{
+    /** @var core_kernel_classes_DbWrapper */
+    private $dbWrapper;
+
+    public function __construct()
+    {
+        // @TODO: inject dbWrapper as a dependency.
+        $this->dbWrapper = core_kernel_classes_DbWrapper::singleton();
+    }
+
     /**
      * @author "Lionel Lecaque, <lionel@taotesting.com>"
+     *
      * @param string $namespace
+     *
      * @return string
      */
-    private function getModelId($namespace){
-        $dbWrapper = core_kernel_classes_DbWrapper::singleton();
-        
+    public function getModelId($namespace)
+    {
         $query = 'SELECT modelid FROM models WHERE (modeluri = ?)';
-        $results = $dbWrapper->query($query, array($namespace));
-       
-        return $results->fetchColumn(0);
+        $results = $this->dbWrapper->query($query, [$namespace]);
 
+        return $results->fetchColumn(0);
     }
-    
+
     /**
      * @author "Lionel Lecaque, <lionel@taotesting.com>"
+     *
      * @param string $namespace
+     *
+     * @return string new added model id
      */
-    private function addNewModel($namespace){
-        $dbWrapper = core_kernel_classes_DbWrapper::singleton();
-        $results = $dbWrapper->insert('models', array('modeluri' =>$namespace));
-        
-        
+    public function addNewModel($namespace)
+    {
+        $modelId = $this->getNewSpannerPrimaryKey();
+        $this->dbWrapper->insert('models', ['modelid' => $modelId, 'modeluri' => $namespace]);
+
+        return $modelId;
     }
-    
+
     /**
      * @author "Lionel Lecaque, <lionel@taotesting.com>"
+     *
      * @param string $namespace
      * @param string $data xml content
+     * @return bool Were triples added?
      */
-    public function createModel($namespace, $data){
-
+    public function createModel($namespace, $data)
+    {
         $modelId = $this->getModelId($namespace);
-        if($modelId === false){
-            common_Logger::d('modelId not found, need to add namespace '. $namespace);
-            $this->addNewModel($namespace);
-            //TODO bad way, need to find better
-            $modelId = $this->getModelId($namespace);
+        if ($modelId === false) {
+            common_Logger::d('modelId not found, need to add namespace ' . $namespace);
+            $modelId = $this->addNewModel($namespace);
         }
         $modelDefinition = new EasyRdf_Graph($namespace);
-        if(is_file($data)){
+        if (is_file($data)) {
             $modelDefinition->parseFile($data);
-        }else {
+        } else {
             $modelDefinition->parse($data);
         }
-        $graph = $modelDefinition->toRdfPhp();
-        $resources = $modelDefinition->resources();
         $format = EasyRdf_Format::getFormat('php');
-        
+
         $data = $modelDefinition->serialise($format);
-        
-        foreach ($data as $subjectUri => $propertiesValues){
-            foreach ($propertiesValues as $prop=>$values){
+
+        $returnValue = false;
+
+        foreach ($data as $subjectUri => $propertiesValues) {
+            foreach ($propertiesValues as $prop => $values) {
                 foreach ($values as $k => $v) {
-                    $this->addStatement($modelId, $subjectUri, $prop, $v['value'], isset($v['lang']) ? $v['lang'] : null);
+                    $returnValue |= $this->addStatement($modelId, $subjectUri, $prop, $v['value'], isset($v['lang']) ? $v['lang'] : null);
                 }
             }
         }
-        
-        return true;
+
+        return $returnValue;
     }
-    
+
     /**
      * Adds a statement to the ontology if it does not exist yet
-     * 
+     *
      * @author "Joel Bout, <joel@taotesting.com>"
-     * @param int $modelId
+     *
+     * @param int    $modelId
      * @param string $subject
      * @param string $predicate
      * @param string $object
      * @param string $lang
+     * @param string $author
+     *
+     * @return bool Was a row added?
      */
-    private function addStatement($modelId, $subject, $predicate, $object, $lang = null) {
-        $result = core_kernel_classes_DbWrapper::singleton()->query(
+    public function addStatement($modelId, $subject, $predicate, $object, $lang = null, $author = 'http://www.tao.lu/Ontologies/TAO.rdf#installator')
+    {
+        // TODO: refactor this to use a triple store abstraction.
+        $result = $this->dbWrapper->query(
             'SELECT count(*) FROM statements WHERE modelid = ? AND subject = ? AND predicate = ? AND object = ? AND l_language = ?',
-            array($modelId, $subject, $predicate, $object, (is_null($lang)) ? '' : $lang)
+            [$modelId, $subject, $predicate, $object, (is_null($lang)) ? '' : $lang]
         );
-        
-        if (intval($result->fetchColumn()) === 0) {
-            $dbWrapper = core_kernel_classes_DbWrapper::singleton();
-            $date = $dbWrapper->getPlatForm()->getNowExpression();
 
-            $dbWrapper->insert(
-                'statements',
-                array(
-                    'modelid' =>  $modelId,
-                    'subject' =>$subject,
-                    'predicate'=> $predicate,
-                    'object' => $object,
-                    'l_language' => is_null($lang) ? '' : $lang,
-                    'author' => 'http://www.tao.lu/Ontologies/TAO.rdf#installator',
-                    'epoch' => $date
-                )
-            );
+        if (intval($result->fetchColumn()) > 0) {
+            return false;
         }
-    }
-    
 
+        $date = $this->dbWrapper->getPlatForm()->getNowExpression();
+
+        return (bool) $this->dbWrapper->insert(
+            'statements',
+            [
+                'id' => $this->getNewSpannerPrimaryKey(),
+                'modelid' => $modelId,
+                'subject' => $subject,
+                'predicate' => $predicate,
+                'object' => $object,
+                'l_language' => is_null($lang) ? '' : $lang,
+                'author' => $author,
+                'epoch' => $date,
+            ]
+        );
+    }
+
+    /**
+     * Generates a unique primary key for gcp Spanner sharding.
+     *
+     * @TODO: confirm this is the optimal solution for gcp Spanner.
+     *
+     * @return string
+     */
+    public function getNewSpannerPrimaryKey()
+    {
+        return strrev(uniqid('', true));
+    }
 }

--- a/core/kernel/api/class.ModelFactory.php
+++ b/core/kernel/api/class.ModelFactory.php
@@ -61,10 +61,7 @@ class core_kernel_api_ModelFactory
     {
         $modelId = $this->getUniquePrimaryKey();
 
-        $inserted = $this->dbWrapper->insert('models', ['modelid' => $modelId, 'modeluri' => $namespace]);
-        if ($inserted === false) {
-
-        }
+        $this->dbWrapper->insert('models', ['modelid' => $modelId, 'modeluri' => $namespace]);
 
         return $modelId;
     }

--- a/core/kernel/classes/class.DbWrapper.php
+++ b/core/kernel/classes/class.DbWrapper.php
@@ -229,11 +229,12 @@ class core_kernel_classes_DbWrapper
      * @author "Lionel Lecaque, <lionel@taotesting.com>"
      * @param string $tableName
      * @param array $data
+     * @return int
      */
     public function insert($tableName, array $data){
     	$this->incrementNrOfQueries();
-        return $this->persistence->insert($tableName,$data);
 
+        return $this->persistence->insert($tableName,$data);
     }
 
     /**

--- a/core/kernel/classes/class.DbWrapper.php
+++ b/core/kernel/classes/class.DbWrapper.php
@@ -33,7 +33,7 @@ error_reporting(E_ALL);
  * @access public
  * @author Jerome Bogaerts, <jerome@taotesting.com>
  * @package generis
- 
+
  */
 class core_kernel_classes_DbWrapper
 {
@@ -95,20 +95,20 @@ class core_kernel_classes_DbWrapper
      * @var boolean
      */
     public $debug = false;
-    
+
     /**
-     * 
+     *
      * @var common_persistence_SqlPersistence
      */
     private $persistence = null;
 
     /**
-     * 
+     *
      * @var common_persistence_sql_Platform
      */
     private $platform = null;
     /**
-     * 
+     *
      * @var common_persistence_sql_SchemaManager
      */
     private $schemaManager = null;
@@ -189,14 +189,14 @@ class core_kernel_classes_DbWrapper
     {
         $returnValue = null;
 
-        
+
 //         $trace=debug_backtrace();
 //         $caller=array_shift($trace);
 //         $caller=array_shift($trace);
 //         common_Logger::d('trace : '. $caller['function'] .$caller['class'] );
 //         common_Logger::d($statement . implode('|', $params));
        	$sth = $this->persistence->query($statement,$params);
-		
+
         if (!empty($sth)){
         	$returnValue = $sth;
         }
@@ -218,13 +218,13 @@ class core_kernel_classes_DbWrapper
     public function exec($statement, $params = array())
     {
         $this->debug($statement);
-		
+
         $returnValue = $this->persistence->exec($statement,$params);
 
         $this->incrementNrOfQueries();
         return (int) $returnValue;
     }
-    
+
     /**
      * @author "Lionel Lecaque, <lionel@taotesting.com>"
      * @param string $tableName
@@ -234,7 +234,7 @@ class core_kernel_classes_DbWrapper
     public function insert($tableName, array $data){
     	$this->incrementNrOfQueries();
 
-        return $this->persistence->insert($tableName,$data);
+        return $this->persistence->insert($tableName, $data);
     }
 
     /**
@@ -251,8 +251,8 @@ class core_kernel_classes_DbWrapper
     }
 
 
-    
-    
+
+
     /**
      * Returns the column names of a given table
      *
@@ -370,7 +370,7 @@ class core_kernel_classes_DbWrapper
         }
         return $this->platform;
     }
-    
+
     /**
      * @author "Lionel Lecaque, <lionel@taotesting.com>"
      * return common_persistence_sql_SchemaManager
@@ -396,7 +396,7 @@ class core_kernel_classes_DbWrapper
     }
 
     /**
-     * 
+     *
      * @author Lionel Lecaque, lionel@taotesting.com
      */
      public function getColumnNotFoundErrorCode(){
@@ -466,7 +466,7 @@ class core_kernel_classes_DbWrapper
         $result->closeCursor();
         return (int) $returnValue;
     }
-    
+
     /**
      * Convenience access to lastInsertId.
      *
@@ -477,10 +477,10 @@ class core_kernel_classes_DbWrapper
     public function lastInsertId($name = null){
         return $this->persistence->lastInsertId($name);
     }
-    
+
     /**
      * Convenience access to platForm quote.
-     * 
+     *
      * @author Jerome Bogaerts, <jerome@taotesting.com>
      * @param string $parameter The parameter to quote.
      * @param int $parameter_type A PDO PARAM_XX constant.
@@ -489,7 +489,7 @@ class core_kernel_classes_DbWrapper
     public function quote($parameter){
     	return $this->persistence->quote($parameter);
     }
-    
+
     public function quoteIdentifier($parameter){
         return $this->persistence->getPlatForm()->quoteIdentifier($parameter);
     }

--- a/core/kernel/impl/class.ApiModelOO.php
+++ b/core/kernel/impl/class.ApiModelOO.php
@@ -339,37 +339,21 @@ class core_kernel_impl_ApiModelOO
      */
     public function setStatement($subject, $predicate, $object, $language)
     {
-        $returnValue = (bool) false;
+        $localNsManager = common_ext_NamespaceManager::singleton();
+        $modelId = $localNsManager->getLocalNamespace()->getModelId();
+        $currentUser = \common_session_SessionManager::getSession()->getUserUri();
 
-        
-        $dbWrapper 	= core_kernel_classes_DbWrapper::singleton();
-        $platform   = $dbWrapper->getPlatForm();
-        $localNs 	= common_ext_NamespaceManager::singleton()->getLocalNamespace();
-        $mask		= 'yyy[admin,administrators,authors]';	//now it's the default right mode
-        $query = 'INSERT INTO statements (modelid,subject,predicate,object,l_language,author,epoch)
-        			VALUES  (?, ?, ?, ?, ?, ? , ?);';
+        // TODO: inject ModelFactory
+        $modelFactory = new core_kernel_api_ModelFactory();
 
-        try{
-	        $returnValue = $dbWrapper->exec($query, array(
-	       		$localNs->getModelId(),
-	       		$subject,
-	       		$predicate,
-	       		$object,
-	       		$language,
-	       		\common_session_SessionManager::getSession()->getUserUri(),
-	            $platform->getNowExpression()
-	             
-	        ));
-        }
-        catch (DBALException $e){
-	        if($e->getCode() !== '00000'){
-				throw new common_Exception ("Unable to setStatement (SPO) {$subject}, {$predicate}, {$object} : " . $e->getMessage());
-			}
-        }
-        
-        
-
-        return (bool) $returnValue;
+        return $modelFactory->addStatement(
+            $modelId,
+            $subject,
+            $predicate,
+            $object,
+            $language,
+            $currentUser
+        );
     }
 
     /**

--- a/core/kernel/impl/class.ApiModelOO.php
+++ b/core/kernel/impl/class.ApiModelOO.php
@@ -19,12 +19,9 @@
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
  *               2017 (update and modification) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
-?>
-<?php
 
 use oat\generis\model\OntologyRdf;
 use oat\generis\model\OntologyRdfs;
-use Doctrine\DBAL\DBALException;
 
 error_reporting(E_ALL);
 
@@ -341,7 +338,7 @@ class core_kernel_impl_ApiModelOO
     {
         $localNsManager = common_ext_NamespaceManager::singleton();
         $modelId = $localNsManager->getLocalNamespace()->getModelId();
-        $currentUser = \common_session_SessionManager::getSession()->getUserUri();
+        $currentUser = common_session_SessionManager::getSession()->getUserUri();
 
         // TODO: inject ModelFactory
         $modelFactory = new core_kernel_api_ModelFactory();

--- a/core/kernel/persistence/file/FileModel.php
+++ b/core/kernel/persistence/file/FileModel.php
@@ -110,6 +110,7 @@ class FileModel
     // helper
     
     /**
+     *
      * @param string $file
      * @throws common_exception_Error
      */
@@ -121,7 +122,9 @@ class FileModel
         }
         $namespaceUri = (string) $attrs['base'];
         $modelId = null;
-        foreach (common_ext_NamespaceManager::singleton()->getAllNamespaces() as $namespace) {
+
+        $namespaceManager = \common_ext_NamespaceManager::singleton();
+        foreach ($namespaceManager->getAllNamespaces() as $namespace) {
             if ($namespace->getUri() == $namespaceUri) {
                 $modelId = $namespace->getModelId();
             }
@@ -129,14 +132,11 @@ class FileModel
         if (is_null($modelId)) {
             \common_Logger::d('modelId not found, need to add namespace '. $namespaceUri);
             
-            //TODO bad way, need to find better
-            $dbWrapper = \core_kernel_classes_DbWrapper::singleton();
-            $results = $dbWrapper->insert('models', array('modeluri' =>$namespaceUri));
-            $result = $dbWrapper->query('select modelid from models where modeluri = ?', array($namespaceUri));
-            $modelId = $result->fetch()['modelid'];
-            common_ext_NamespaceManager::singleton()->reset();
-            
+            $modelFactory = new \core_kernel_api_ModelFactory();
+            $modelId = $modelFactory->addNewModel($namespaceUri);
+            $namespaceManager->reset();
         }
+
         return $modelId;
     }
 }

--- a/core/kernel/persistence/file/FileModel.php
+++ b/core/kernel/persistence/file/FileModel.php
@@ -131,7 +131,8 @@ class FileModel
         }
         if (is_null($modelId)) {
             \common_Logger::d('modelId not found, need to add namespace '. $namespaceUri);
-            
+
+            // TODO: inject ModelFactory as a dependency.
             $modelFactory = new \core_kernel_api_ModelFactory();
             $modelId = $modelFactory->addNewModel($namespaceUri);
             $namespaceManager->reset();

--- a/core/kernel/persistence/smoothsql/class.Resource.php
+++ b/core/kernel/persistence/smoothsql/class.Resource.php
@@ -66,12 +66,12 @@ class core_kernel_persistence_smoothsql_Resource
 
     protected function getModelReadSqlCondition()
     {
-        return 'modelid IN (' . implode(',', $this->model->getReadableModels()) . ')';
+        return 'modelid IN (' . implode(',', array_map(function ($a) { return "'" . $a . "'"; }, $this->model->getReadableModels())) . ')';
     }
 
     protected function getModelWriteSqlCondition()
     {
-        return 'modelid IN (' . implode(',', $this->model->getWritableModels()) . ')';
+        return 'modelid IN (' . implode(',', array_map(function ($a) { return "'" . $a . "'"; }, $this->model->getWritableModels())) . ')';
     }
 
     protected function getNewTripleModelId()

--- a/core/kernel/persistence/smoothsql/class.Resource.php
+++ b/core/kernel/persistence/smoothsql/class.Resource.php
@@ -1,25 +1,26 @@
 <?php
-/**  
+/**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
  * of the License (non-upgradable).
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- * 
+ *
  * Copyright (c) 2002-2008 (original work) Public Research Centre Henri Tudor & University of Luxembourg (under the project TAO & TAO2);
  *               2008-2010 (update and modification) Deutsche Institut für Internationale Pädagogische Forschung (under the project TAO-TRANSFER);
  *               2009-2012 (update and modification) Public Research Centre Henri Tudor (under the project TAO-SUSTAIN & TAO-DEV);
  *               2017 (update and modification) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 
+use core_kernel_api_ModelFactory as ModelFactory;
 use oat\generis\model\OntologyRdf;
 use oat\oatbox\session\SessionService;
 use oat\oatbox\user\UserLanguageServiceInterface;
@@ -27,73 +28,81 @@ use oat\oatbox\user\UserLanguageServiceInterface;
 /**
  * Short description of class core_kernel_persistence_smoothsql_Resource
  *
- * @access public
- * @author Joel Bout, <joel.bout@tudor.lu>
+ * @access  public
+ * @author  Joel Bout, <joel.bout@tudor.lu>
  * @package generis
- 
  */
 class core_kernel_persistence_smoothsql_Resource
     extends core_kernel_persistence_PersistenceImpl
-        implements core_kernel_persistence_ResourceInterface
+    implements core_kernel_persistence_ResourceInterface
 {
+    /** @var ModelFactory */
+    protected $modelFactory;
 
     /**
      * @var core_kernel_persistence_smoothsql_SmoothModel
      */
     private $model;
-    
-    public function __construct(core_kernel_persistence_smoothsql_SmoothModel $model) {
+
+    public function __construct(core_kernel_persistence_smoothsql_SmoothModel $model)
+    {
+        // TODO: inject ModelFactory
+        $this->modelFactory = new ModelFactory();
         $this->model = $model;
     }
-    
-    protected function getModel() {
+
+    protected function getModel()
+    {
         return $this->model;
     }
-    
+
     /**
      * @return common_persistence_SqlPersistence
      */
-    protected function getPersistence() {
+    protected function getPersistence()
+    {
         return $this->model->getPersistence();
     }
-    
-    protected function getModelReadSqlCondition() {
-        return 'modelid IN ('.implode(',', $this->model->getReadableModels()).')';
+
+    protected function getModelReadSqlCondition()
+    {
+        return 'modelid IN (' . implode(',', $this->model->getReadableModels()) . ')';
     }
-    
-    protected function getModelWriteSqlCondition() {
-        return 'modelid IN ('.implode(',',$this->model->getWritableModels()).')';
+
+    protected function getModelWriteSqlCondition()
+    {
+        return 'modelid IN (' . implode(',', $this->model->getWritableModels()) . ')';
     }
-    
-    protected function getNewTripleModelId() {
+
+    protected function getNewTripleModelId()
+    {
         return $this->model->getNewTripleModelId();
     }
-    
-    
-    
+
     /**
      * returns an array of types the ressource has
      *
      * @access public
      * @author Joel Bout, <joel.bout@tudor.lu>
+     *
      * @param  Resource resource
+     *
      * @return array
      */
-    public function getTypes( core_kernel_classes_Resource $resource)
+    public function getTypes(core_kernel_classes_Resource $resource)
     {
-        $returnValue = array();
+        $returnValue = [];
 
-        
-		$sqlQuery = 'SELECT object FROM statements WHERE subject = ? and predicate = ?';
-        $sth = $this->getPersistence()->query($sqlQuery,array($resource->getUri(), OntologyRdf::RDF_TYPE));
+        // TODO: refactor this to use a triple retrieving method.
+        $sqlQuery = 'SELECT object FROM statements WHERE subject = ? and predicate = ?';
+        $sth = $this->getPersistence()->query($sqlQuery, [$resource->getUri(), OntologyRdf::RDF_TYPE]);
 
-        while ($row = $sth->fetch()){
+        while ($row = $sth->fetch()) {
             $uri = $this->getPersistence()->getPlatForm()->getPhpTextValue($row['object']);
             $returnValue[$uri] = new core_kernel_classes_Class($uri);
-        }        
-        
+        }
 
-        return (array) $returnValue;
+        return (array)$returnValue;
     }
 
     /**
@@ -101,65 +110,66 @@ class core_kernel_persistence_smoothsql_Resource
      *
      * @access public
      * @author Joel Bout, <joel.bout@tudor.lu>
-     * @param  Resource resource
-     * @param  Property property
+     *
+     * @param  core_kernel_classes_Resource resource
+     * @param  core_kernel_classes_Property property
      * @param  array options
+     *
      * @return array
+     * @throws core_kernel_persistence_Exception
      */
-    public function getPropertyValues( core_kernel_classes_Resource $resource,  core_kernel_classes_Property $property, $options = array())
+    public function getPropertyValues(core_kernel_classes_Resource $resource, core_kernel_classes_Property $property, $options = [])
     {
-        $returnValue = array();
+        $returnValue = [];
 
-        
         $one = isset($options['one']) && $options['one'] == true ? true : false;
         if (isset($options['last'])) {
             throw new core_kernel_persistence_Exception('Option \'last\' no longer supported');
         }
-		$platform = $this->getPersistence()->getPlatForm();
-		
-    	// Define language if required
-		$lang = '';
-		$defaultLg = '';
-		if (isset($options['lg'])) {
-			$lang = $options['lg'];
-		} else {
+        $platform = $this->getPersistence()->getPlatForm();
+
+        // Define language if required
+        $defaultLg = '';
+        if (isset($options['lg'])) {
+            $lang = $options['lg'];
+        } else {
             $lang = $this->getServiceLocator()->get(SessionService::SERVICE_ID)->getCurrentSession()->getDataLanguage();
             $default = $this->getServiceLocator()->get(UserLanguageServiceInterface::SERVICE_ID)->getDefaultLanguage();
             $defaultLg = ' OR l_language = ' . $this->getPersistence()->quote($default);
-		}
-		
-        $query =  'SELECT object, l_language
+        }
+
+        // TODO: refactor this to use a triple retrieving method.
+        $query = 'SELECT object, l_language
         			FROM statements 
 		    		WHERE subject = ? 
 		    		AND predicate = ?
 					AND (l_language = ? OR l_language = ' . $this->getPersistence()->quote('') . $defaultLg . ')
-		    		AND '.$this->getModelReadSqlCondition();
-        
-    	
-		if ($one) {
+		    		AND ' . $this->getModelReadSqlCondition();
+
+        if ($one) {
             // Select first
-			$query .= ' ORDER BY id DESC';
-			$query = $platform->limitStatement($query, 1, 0);
-			$result = $this->getPersistence()->query($query,array($resource->getUri(), $property->getUri(), $lang));
-		} else {
+            $query .= ' ORDER BY epoch DESC';
+            $query = $platform->limitStatement($query, 1, 0);
+            $result = $this->getPersistence()->query($query, [$resource->getUri(), $property->getUri(), $lang]);
+        } else {
             // Select All
-			$result = $this->getPersistence()->query($query,array($resource->getUri(), $property->getUri(), $lang));
-		}
-        
-		// Treat the query result
+            $result = $this->getPersistence()->query($query, [$resource->getUri(), $property->getUri(), $lang]);
+        }
+
+        // Treat the query result
         if ($result == true) {
-        	if (isset($options['lg'])) {
+            if (isset($options['lg'])) {
                 // If a language has been defined, do not filter result by language
-		    	while ($row = $result->fetch()) {
-					$returnValue[] = $this->getPersistence()->getPlatForm()->getPhpTextValue($row['object']);
-				}
-        	} else {
+                while ($row = $result->fetch()) {
+                    $returnValue[] = $this->getPersistence()->getPlatForm()->getPhpTextValue($row['object']);
+                }
+            } else {
                 // Filter result by language and return one set of values (User language in top priority, default language in second and the fallback language (null) in third)
                 $returnValue = core_kernel_persistence_smoothsql_Utils::filterByLanguage($this->getPersistence(), $result->fetchAll(), 'l_language', $lang, $default);
-        	}
+            }
         }
-        
-        return (array) $returnValue;
+
+        return (array)$returnValue;
     }
 
     /**
@@ -167,27 +177,23 @@ class core_kernel_persistence_smoothsql_Resource
      *
      * @access public
      * @author Joel Bout, <joel.bout@tudor.lu>
-     * @param  Resource resource
-     * @param  Property property
+     *
+     * @param  core_kernel_classes_Resource resource
+     * @param  core_kernel_classes_Property property
      * @param  string lg
+     *
      * @return core_kernel_classes_ContainerCollection
      */
-    public function getPropertyValuesByLg( core_kernel_classes_Resource $resource,  core_kernel_classes_Property $property, $lg)
+    public function getPropertyValuesByLg(core_kernel_classes_Resource $resource, core_kernel_classes_Property $property, $lg)
     {
         $returnValue = null;
 
-        
-        
-        $options = array (
-        	'lg' => $lg
-        );
-        
+        $options = ['lg' => $lg];
+
         $returnValue = new core_kernel_classes_ContainerCollection($resource);
-        foreach ($this->getPropertyValues($resource, $property, $options) as $value){
+        foreach ($this->getPropertyValues($resource, $property, $options) as $value) {
             $returnValue->add(common_Utils::toResource($value));
         }
-        
-        
 
         return $returnValue;
     }
@@ -197,43 +203,37 @@ class core_kernel_persistence_smoothsql_Resource
      *
      * @access public
      * @author Joel Bout, <joel.bout@tudor.lu>
-     * @param  Resource resource
-     * @param  Property property
+     *
+     * @param  core_kernel_classes_Resource resource
+     * @param  core_kernel_classes_Property property
      * @param  string object
      * @param  string lg
+     *
      * @return boolean
      */
-    public function setPropertyValue( core_kernel_classes_Resource $resource,  core_kernel_classes_Property $property, $object, $lg = null)
+    public function setPropertyValue(core_kernel_classes_Resource $resource, core_kernel_classes_Property $property, $object, $lg = null)
     {
         $userId = $this->getServiceLocator()->get(SessionService::SERVICE_ID)->getCurrentUser()->getIdentifier();
-        $object  = $object instanceof core_kernel_classes_Resource ? $object->getUri() : (string) $object;
-    	$platform = $this->getPersistence()->getPlatForm();
-        $lang = "";
+        $object = $object instanceof core_kernel_classes_Resource ? $object->getUri() : (string)$object;
+
         // Define language if required
-        if ($property->isLgDependent()){
-        	if ($lg!=null){
-        		$lang = $lg;
-        	} else {
+        $lang = '';
+        if ($property->isLgDependent()) {
+            if ($lg != null) {
+                $lang = $lg;
+            } else {
                 $lang = $this->getServiceLocator()->get(SessionService::SERVICE_ID)->getCurrentSession()->getDataLanguage();
-        	}
+            }
         }
-        
-        $query = 'INSERT INTO statements (modelid, subject, predicate, object, l_language, author,epoch)
-        			VALUES  (?, ?, ?, ?, ?, ? , ?)';
 
-        $returnValue = $this->getPersistence()->exec($query, array(
-       		$this->getNewTripleModelId(),
-       		$resource->getUri(),
-       		$property->getUri(),
-       		$object,
-       		$lang,
-            $userId,
-            $platform->getNowExpression()
-        ));
-        
-        
-
-        return (bool) $returnValue;
+        return $this->modelFactory->addStatement(
+            $this->getNewTripleModelId(),
+            $resource->getUri(),
+            $property->getUri(),
+            $object,
+            $lang,
+            $userId
+        );
     }
 
     /**
@@ -241,56 +241,51 @@ class core_kernel_persistence_smoothsql_Resource
      *
      * @access public
      * @author Joel Bout, <joel.bout@tudor.lu>
-     * @param  Resource resource
+     *
+     * @param  core_kernel_classes_Resource resource
      * @param  array properties
+     *
      * @return boolean
      */
-    public function setPropertiesValues( core_kernel_classes_Resource $resource, $properties)
+    public function setPropertiesValues(core_kernel_classes_Resource $resource, $properties)
     {
-        $returnValue = (bool) false;
+        $returnValue = false;
 
-    	if (is_array($properties) && count($properties) > 0) {
-        		
+        if (is_array($properties) && count($properties) > 0) {
             $session = $this->getServiceLocator()->get(SessionService::SERVICE_ID)->getCurrentSession();
-            $platform = $this->getPersistence()->getPlatForm();
+            $author = $session->getUser()->getIdentifier();
 
-            $valuesToInsert = [];
+            $modelId = $this->getNewTripleModelId();
+            $subject = $resource->getUri();
 
             foreach ($properties as $propertyUri => $value) {
-                
                 $property = new core_kernel_classes_Property($propertyUri);
-                
+
                 $lang = ($property->isLgDependent() ? $session->getDataLanguage() : '');
                 $formatedValues = [];
-                
+
+                // @TODO: refactor this
                 if ($value instanceof core_kernel_classes_Resource) {
                     $formatedValues[] = $value->getUri();
-                    
                 } elseif (is_array($value)) {
-                    foreach($value as $val){
-                        $formatedValues[] = ($val instanceof core_kernel_classes_Resource) ? $val->getUri() : $val;
+                    foreach ($value as $val) {
+                        $formatedValues[] = $val instanceof core_kernel_classes_Resource
+                            ? $val->getUri()
+                            : $val;
                     }
                 } else {
                     $formatedValues[] = ($value == null) ? '' : $value;
                 }
-                
+
+                $predicate = $property->getUri();
+
                 foreach ($formatedValues as $object) {
-                    $valuesToInsert[] = [
-                        'modelid' => $this->getNewTripleModelId(),
-                        'subject' => $resource->getUri(),
-                        'predicate' => $property->getUri(),
-                        'object' => $object,
-                        'l_language' => $lang,
-                        'author' => $session->getUser()->getIdentifier(),
-                        'epoch' => $platform->getNowExpression()
-                    ];
+                    $returnValue |= $this->modelFactory->addStatement($modelId, $subject, $predicate, $object, $lang, $author);
                 }
             }
-
-            $returnValue = $this->getPersistence()->insertMultiple('statements', $valuesToInsert);
         }
-        
-        return (bool) $returnValue;
+
+        return $returnValue;
     }
 
     /**
@@ -298,37 +293,26 @@ class core_kernel_persistence_smoothsql_Resource
      *
      * @access public
      * @author Joel Bout, <joel.bout@tudor.lu>
-     * @param  Resource resource
-     * @param  Property property
+     *
+     * @param  core_kernel_classes_Resource resource
+     * @param  core_kernel_classes_Property property
      * @param  string value
      * @param  string lg
+     *
      * @return boolean
      */
-    public function setPropertyValueByLg( core_kernel_classes_Resource $resource,  core_kernel_classes_Property $property, $value, $lg)
+    public function setPropertyValueByLg(core_kernel_classes_Resource $resource, core_kernel_classes_Property $property, $value, $lg)
     {
-        $returnValue = (bool) false;
+        $userId = $this->getServiceLocator()->get(SessionService::SERVICE_ID)->getCurrentUser()->getIdentifier();
 
-        
-
-		$platform = $this->getPersistence()->getPlatForm();
-		$userId = $this->getServiceLocator()->get(SessionService::SERVICE_ID)->getCurrentUser()->getIdentifier();
-        
-        $query = 'INSERT INTO statements (modelid,subject,predicate,object,l_language,author,epoch)
-        			VALUES  (?, ?, ?, ?, ?, ?, ?)';
-
-        $returnValue = $this->getPersistence()->exec($query, array(
-       		$this->getNewTripleModelId(),
-       		$resource->getUri(),
-       		$property->getUri(),
-       		$value,
-       		($property->isLgDependent() ? $lg : ''),
-       		$userId,
-            $platform->getNowExpression()
-        ));
-		
-        
-
-        return (bool) $returnValue;
+        return $this->modelFactory->addStatement(
+            $this->getNewTripleModelId(),
+            $resource->getUri(),
+            $property->getUri(),
+            $value,
+            ($property->isLgDependent() ? $lg : ''),
+            $userId
+        );
     }
 
     /**
@@ -336,70 +320,72 @@ class core_kernel_persistence_smoothsql_Resource
      *
      * @access public
      * @author Joel Bout, <joel.bout@tudor.lu>
-     * @param  Resource resource
-     * @param  Property property
+     *
+     * @param  core_kernel_classes_Resource resource
+     * @param  core_kernel_classes_Property property
      * @param  array options
+     *
      * @return boolean
      */
-    public function removePropertyValues( core_kernel_classes_Resource $resource,  core_kernel_classes_Property $property, $options = array())
+    public function removePropertyValues(core_kernel_classes_Resource $resource, core_kernel_classes_Property $property, $options = [])
     {
-        $returnValue = (bool) false;
+        $returnValue = (bool)false;
 
-		// Optional params
+        // Optional params
         $pattern = isset($options['pattern']) && !is_null($options['pattern']) ? $options['pattern'] : null;
         $like = isset($options['like']) && $options['like'] == true ? true : false;
-		
-		//build query:
-		$query =  'DELETE FROM statements WHERE subject = ? AND predicate = ?';
-		$objectType = $this->getPersistence()->getPlatForm()->getObjectTypeCondition();
-		$conditions = array();
-		if (is_string($pattern)) {
-			if (!is_null($pattern)) {
-				$searchPattern = core_kernel_persistence_smoothsql_Utils::buildSearchPattern($this->getPersistence(), $pattern, $like);
-				$conditions[] = '( '.$objectType . ' ' .$searchPattern.' )';
-			}
-		} elseif (is_array($pattern)) {
-			if (count($pattern) > 0) {
-				$multiCondition =  "( ";
-				foreach($pattern as $i => $patternToken) {
-					$searchPattern = core_kernel_persistence_smoothsql_Utils::buildSearchPattern($this->getPersistence(), $patternToken, $like);
-					if ($i > 0) {
+
+        // TODO: refactor this to use a triple store abstraction
+        //build query:
+        $query = 'DELETE FROM statements WHERE subject = ? AND predicate = ?';
+        $objectType = $this->getPersistence()->getPlatForm()->getObjectTypeCondition();
+        $conditions = [];
+        if (is_string($pattern)) {
+            if (!is_null($pattern)) {
+                $searchPattern = core_kernel_persistence_smoothsql_Utils::buildSearchPattern($this->getPersistence(), $pattern, $like);
+                $conditions[] = '( ' . $objectType . ' ' . $searchPattern . ' )';
+            }
+        } elseif (is_array($pattern)) {
+            if (count($pattern) > 0) {
+                $multiCondition = "( ";
+                foreach ($pattern as $i => $patternToken) {
+                    $searchPattern = core_kernel_persistence_smoothsql_Utils::buildSearchPattern($this->getPersistence(), $patternToken, $like);
+                    if ($i > 0) {
                         $multiCondition .= " OR ";
                     }
-					$multiCondition .= '('.$objectType. ' ' .$searchPattern.' )';
-				}
-				$conditions[] = "{$multiCondition} ) ";
-			}
-		}
-			
+                    $multiCondition .= '(' . $objectType . ' ' . $searchPattern . ' )';
+                }
+                $conditions[] = "{$multiCondition} ) ";
+            }
+        }
+
         foreach ($conditions as $i => $additionalCondition) {
-			$query .= " AND ( {$additionalCondition} ) ";
-		}
-        
-		//be sure the property we try to remove is included in an updatable model
-		$query .= ' AND '.$this->getModelWriteSqlCondition();
-		
+            $query .= " AND ( {$additionalCondition} ) ";
+        }
+
+        //be sure the property we try to remove is included in an updatable model
+        $query .= ' AND ' . $this->getModelWriteSqlCondition();
+
         if ($property->isLgDependent()) {
-        	
-        	$query .=  ' AND (l_language = ? OR l_language = ?) ';
-        	$returnValue = $this->getPersistence()->exec($query,array(
-	        		$resource->getUri(),
-	        		$property->getUri(),
-                    '',
-                    $this->getServiceLocator()->get(SessionService::SERVICE_ID)->getCurrentSession()->getDataLanguage()
-	        ));
-        } else{
-        	$returnValue = $this->getPersistence()->exec($query,array(
-	        		$resource->getUri(),
-	        		$property->getUri()
-	        ));   
+            $query .= ' AND (l_language = ? OR l_language = ?) ';
+            $returnValue = $this->getPersistence()->exec($query, [
+                $resource->getUri(),
+                $property->getUri(),
+                '',
+                $this->getServiceLocator()->get(SessionService::SERVICE_ID)->getCurrentSession()->getDataLanguage(),
+            ]);
+        } else {
+            $returnValue = $this->getPersistence()->exec($query, [
+                $resource->getUri(),
+                $property->getUri(),
+            ]);
         }
-        
+
         if (!$returnValue) {
-        	$returnValue = false;
+            $returnValue = false;
         }
-        
-        return (bool) $returnValue;
+
+        return (bool)$returnValue;
     }
 
     /**
@@ -407,33 +393,28 @@ class core_kernel_persistence_smoothsql_Resource
      *
      * @access public
      * @author Joel Bout, <joel.bout@tudor.lu>
-     * @param  Resource resource
-     * @param  Property property
+     *
+     * @param  core_kernel_classes_Resource resource
+     * @param  core_kernel_classes_Property property
      * @param  string lg
      * @param  array options
+     *
      * @return boolean
      */
-    public function removePropertyValueByLg( core_kernel_classes_Resource $resource,  core_kernel_classes_Property $property, $lg, $options = array())
+    public function removePropertyValueByLg(core_kernel_classes_Resource $resource, core_kernel_classes_Property $property, $lg, $options = [])
     {
-        $returnValue = (bool) false;
-
+        // TODO: refactor this to use a triple store abstraction
         $sqlQuery = 'DELETE FROM statements WHERE subject = ? and predicate = ? and l_language = ?';
         //be sure the property we try to remove is included in an updatable model
-		$sqlQuery .= ' AND '.$this->getModelWriteSqlCondition();
-        
-        $returnValue = $this->getPersistence()->exec($sqlQuery, array (
-        	$resource->getUri(),
-        	$property->getUri(),
-            ($property->isLgDependent() ? $lg : '')
-        ));
-        
-    	if (!$returnValue){
-        	$returnValue = false;
-        }
-        
-        
+        $sqlQuery .= ' AND ' . $this->getModelWriteSqlCondition();
 
-        return (bool) $returnValue;
+        $returnValue = $this->getPersistence()->exec($sqlQuery, [
+            $resource->getUri(),
+            $property->getUri(),
+            ($property->isLgDependent() ? $lg : ''),
+        ]);
+
+        return (bool)$returnValue;
     }
 
     /**
@@ -441,16 +422,19 @@ class core_kernel_persistence_smoothsql_Resource
      *
      * @access public
      * @author Joel Bout, <joel@taotesting.com>
+     *
      * @param  core_kernel_classes_Resource resource
+     *
      * @return core_kernel_classes_ContainerCollection
      */
-    public function getRdfTriples( core_kernel_classes_Resource $resource)
+    public function getRdfTriples(core_kernel_classes_Resource $resource)
     {
         $returnValue = null;
-        
-        $query = 'SELECT * FROM statements WHERE subject = ? AND '.$this->getModelReadSqlCondition().' ORDER BY predicate';
-        $result = $this->getPersistence()->query($query, array($resource->getUri()));
-        
+
+        // TODO: refactor this to use a triple store abstraction
+        $query = 'SELECT * FROM statements WHERE subject = ? AND ' . $this->getModelReadSqlCondition() . ' ORDER BY predicate';
+        $result = $this->getPersistence()->query($query, [$resource->getUri()]);
+
         $returnValue = new core_kernel_classes_ContainerCollection(new common_Object(__METHOD__));
         while ($statement = $result->fetch()) {
             $triple = new core_kernel_classes_Triple();
@@ -473,30 +457,29 @@ class core_kernel_persistence_smoothsql_Resource
      *
      * @access public
      * @author Joel Bout, <joel.bout@tudor.lu>
-     * @param  Resource resource
-     * @param  Property property
+     *
+     * @param  core_kernel_classes_Resource resource
+     * @param  core_kernel_classes_Property property
+     *
      * @return array
      */
-    public function getUsedLanguages( core_kernel_classes_Resource $resource,  core_kernel_classes_Property $property)
+    public function getUsedLanguages(core_kernel_classes_Resource $resource, core_kernel_classes_Property $property)
     {
-        $returnValue = array();
+        $returnValue = [];
 
-        
-        
-    	$sqlQuery = 'SELECT l_language FROM statements WHERE subject = ? AND predicate = ? ';
-        $sqlResult = $this->getPersistence()->query($sqlQuery, array (
-        	$resource->getUri(),
-        	$property->getUri()
-        ));
+        // TODO: refactor this to use a triple store abstraction
+        $sqlQuery = 'SELECT l_language FROM statements WHERE subject = ? AND predicate = ? ';
+        $sqlResult = $this->getPersistence()->query($sqlQuery, [
+            $resource->getUri(),
+            $property->getUri(),
+        ]);
         while ($row = $sqlResult->fetch()) {
             if (!empty($row['l_language'])) {
                 $returnValue[] = $row['l_language'];
             }
         }
-        
-        
 
-        return (array) $returnValue;
+        return (array)$returnValue;
     }
 
     /**
@@ -504,42 +487,44 @@ class core_kernel_persistence_smoothsql_Resource
      *
      * @access public
      * @author Joel Bout, <joel.bout@tudor.lu>
-     * @param  Resource resource
+     *
+     * @param  core_kernel_classes_Resource resource
      * @param  array excludedProperties
-     * @return core_kernel_classes_Resource
+     *
+     * @return core_kernel_classes_Resource|null
+     * @throws common_exception_Error
      */
-    public function duplicate( core_kernel_classes_Resource $resource, $excludedProperties = array())
+    public function duplicate(core_kernel_classes_Resource $resource, $excludedProperties = [])
     {
-        $returnValue = null;
-    	$newUri = common_Utils::getNewUri();
-    	$collection = $this->getRdfTriples($resource);
-        
-    	if ($collection->count() > 0) {
-    		
-    		$platform = $this->getPersistence()->getPlatForm();
-            $user = $this->getServiceLocator()->get(SessionService::SERVICE_ID)->getCurrentUser()->getIdentifier();
-            $valuesToInsert = [];
-    		
-    		foreach ($collection->getIterator() as $triple) {
-    			if (!in_array($triple->predicate, $excludedProperties)) {
-                    $valuesToInsert[] = [
-                        'modelid' => $this->getNewTripleModelId(),
-                        'subject' => $newUri,
-                        'predicate'=> $triple->predicate,
-                        'object' => ($triple->object == null) ? '' : $triple->object,
-                        'l_language' => ($triple->lg == null) ? '' : $triple->lg,
-                        'author' => $user,
-                        'epoch' => $platform->getNowExpression()
-                    ];
-    			}
-	    	}
-	    	
-        	if ($this->getPersistence()->insertMultiple('statements', $valuesToInsert)) {
-        		$returnValue = new core_kernel_classes_Resource($newUri);
-        	}
-    	}
-        
-        return $returnValue;
+        $newUri = common_Utils::getNewUri();
+        $collection = $this->getRdfTriples($resource);
+
+        if ($collection->count() === 0) {
+            return null;
+        }
+
+        $user = $this->getServiceLocator()->get(SessionService::SERVICE_ID)->getCurrentUser()->getIdentifier();
+        $modelId = $this->getNewTripleModelId();
+        $addedRows = false;
+
+        foreach ($collection->getIterator() as $triple) {
+            if (!in_array($triple->predicate, $excludedProperties)) {
+                $addedRows |= $this->modelFactory->addStatement(
+                    $modelId,
+                    $newUri,
+                    $triple->predicate,
+                    ($triple->object == null) ? '' : $triple->object,
+                    ($triple->lg == null) ? '' : $triple->lg,
+                    $user
+                );
+            }
+        }
+
+        if ($addedRows) {
+            return new core_kernel_classes_Resource($newUri);
+        }
+
+        return null;
     }
 
     /**
@@ -547,32 +532,34 @@ class core_kernel_persistence_smoothsql_Resource
      *
      * @access public
      * @author Joel Bout, <joel.bout@tudor.lu>
-     * @param  Resource resource
+     *
+     * @param  core_kernel_classes_Resource resource
      * @param  boolean deleteReference
+     *
      * @return boolean
      */
-    public function delete( core_kernel_classes_Resource $resource, $deleteReference = false)
+    public function delete(core_kernel_classes_Resource $resource, $deleteReference = false)
     {
-        $returnValue = (bool) false;
-
-		$query = 'DELETE FROM statements WHERE subject = ? AND '.$this->getModelWriteSqlCondition();
-        $returnValue = $this->getPersistence()->exec($query, array($resource->getUri()));
+        // TODO: refactor this to use a triple store abstraction
+        $query = 'DELETE FROM statements WHERE subject = ? AND ' . $this->getModelWriteSqlCondition();
+        $returnValue = $this->getPersistence()->exec($query, [$resource->getUri()]);
 
         //if no rows affected return false
-        if (!$returnValue){
-        	$returnValue = false;
-        } 
-        else if($deleteReference){
-        	$sqlQuery = 'DELETE FROM statements WHERE ' . $this->getPersistence()->getPlatForm()->getObjectTypeCondition() . ' = ? AND '.$this->getModelWriteSqlCondition();
-        	$return = $this->getPersistence()->exec($sqlQuery, array ($resource->getUri()));
-        	
-        	if ($return !== false){
-        		$returnValue = true;
-        	}
-        }
-        
+        if (!$returnValue) {
+            $returnValue = false;
+        } else {
+            if ($deleteReference) {
+                // TODO: refactor this to use a triple store abstraction
+                $sqlQuery = 'DELETE FROM statements WHERE ' . $this->getPersistence()->getPlatForm()->getObjectTypeCondition() . ' = ? AND ' . $this->getModelWriteSqlCondition();
+                $return = $this->getPersistence()->exec($sqlQuery, [$resource->getUri()]);
 
-        return (bool) $returnValue;
+                if ($return !== false) {
+                    $returnValue = true;
+                }
+            }
+        }
+
+        return (bool)$returnValue;
     }
 
     /**
@@ -580,63 +567,65 @@ class core_kernel_persistence_smoothsql_Resource
      *
      * @access public
      * @author Joel Bout, <joel.bout@tudor.lu>
-     * @param  Resource resource
+     *
+     * @param  core_kernel_classes_Resource resource
      * @param  array properties
+     *
      * @return array
+     * @throws common_exception_Error
      */
-    public function getPropertiesValues( core_kernel_classes_Resource $resource, $properties)
+    public function getPropertiesValues(core_kernel_classes_Resource $resource, $properties)
     {
-        $returnValue = array();
+        $returnValue = [];
 
-        
         // check whenever or not properties is empty
         if (count($properties) == 0) {
-        	return array();
+            return [];
         }
-        
+
         /*foreach($properties as $property){
         	$returnValue[$property->getUri()] = $this->getPropertyValues($resource, $property);
         }*/
-        
-    	$predicatesQuery = '';
-    	//build the predicate query
-       	//$predicatesQuery = implode(',', $properties);
-		foreach ($properties as $property) {
-			$uri = (is_string($property) ? $property : $property->getUri());
-			$returnValue[$uri] = array();
-			$predicatesQuery .= ", " . $this->getPersistence()->quote($uri) ;
-		}
-    	$predicatesQuery=substr($predicatesQuery, 1);
+
+        $predicatesQuery = '';
+        //build the predicate query
+        //$predicatesQuery = implode(',', $properties);
+        foreach ($properties as $property) {
+            $uri = (is_string($property) ? $property : $property->getUri());
+            $returnValue[$uri] = [];
+            $predicatesQuery .= ", " . $this->getPersistence()->quote($uri);
+        }
+        $predicatesQuery = substr($predicatesQuery, 1);
 
         $platform = $this->getPersistence()->getPlatForm();
         $lang = $this->getServiceLocator()->get(SessionService::SERVICE_ID)->getCurrentSession()->getDataLanguage();
         $default = $this->getServiceLocator()->get(UserLanguageServiceInterface::SERVICE_ID)->getDefaultLanguage();
+
+        // TODO: refactor this to use a triple store abstraction
         //the unique sql query
-        $query =  'SELECT predicate, object, l_language 
+        $query = 'SELECT predicate, object, l_language 
             FROM statements 
             WHERE 
-                subject = '.$this->getPersistence()->quote($resource->getUri()).' 
-                AND predicate IN ('.$predicatesQuery.')
-                AND (l_language = ' . $this->getPersistence()->quote('') . 
-                    ' OR l_language = '.$this->getPersistence()->quote($default).
-                    ' OR l_language = '.$this->getPersistence()->quote($lang).')
-                AND '.$this->getModelReadSqlCondition();
-        $result	= $this->getPersistence()->query($query);
-        
+                subject = ' . $this->getPersistence()->quote($resource->getUri()) . ' 
+                AND predicate IN (' . $predicatesQuery . ')
+                AND (l_language = ' . $this->getPersistence()->quote('') .
+            ' OR l_language = ' . $this->getPersistence()->quote($default) .
+            ' OR l_language = ' . $this->getPersistence()->quote($lang) . ')
+                AND ' . $this->getModelReadSqlCondition();
+        $result = $this->getPersistence()->query($query);
+
         $rows = $result->fetchAll();
         $sortedByLg = core_kernel_persistence_smoothsql_Utils::sortByLanguage($this->getPersistence(), $rows, 'l_language', $lang, $default);
         $identifiedLg = core_kernel_persistence_smoothsql_Utils::identifyFirstLanguage($sortedByLg);
 
-        foreach($rows as $row){
-        	$value = $platform->getPhpTextValue($row['object']);
-			$returnValue[$row['predicate']][] = common_Utils::isUri($value)
-				? new core_kernel_classes_Resource($value)
-				: new core_kernel_classes_Literal($value);
+        foreach ($rows as $row) {
+            $value = $platform->getPhpTextValue($row['object']);
+            $returnValue[$row['predicate']][] = common_Utils::isUri($value)
+                ? new core_kernel_classes_Resource($value)
+                : new core_kernel_classes_Literal($value);
         }
-        
-        
 
-        return (array) $returnValue;
+        return (array)$returnValue;
     }
 
     /**
@@ -644,14 +633,15 @@ class core_kernel_persistence_smoothsql_Resource
      *
      * @access public
      * @author Joel Bout, <joel.bout@tudor.lu>
-     * @param  Resource resource
-     * @param  Class class
+     *
+     * @param  core_kernel_classes_Resource resource
+     * @param  core_kernel_classes_Class class
+     *
      * @return boolean
      */
-    public function setType( core_kernel_classes_Resource $resource,  core_kernel_classes_Class $class)
+    public function setType(core_kernel_classes_Resource $resource, core_kernel_classes_Class $class)
     {
-        $returnValue = $this->setPropertyValue($resource, $this->getModel()->getProperty(OntologyRdf::RDF_TYPE), $class);
-        return (bool) $returnValue;
+        return $this->setPropertyValue($resource, $this->getModel()->getProperty(OntologyRdf::RDF_TYPE), $class);
     }
 
     /**
@@ -659,33 +649,30 @@ class core_kernel_persistence_smoothsql_Resource
      *
      * @access public
      * @author Joel Bout, <joel.bout@tudor.lu>
-     * @param  Resource resource
-     * @param  Class class
+     *
+     * @param  core_kernel_classes_Resource resource
+     * @param  core_kernel_classes_Class class
+     *
      * @return boolean
      */
-    public function removeType( core_kernel_classes_Resource $resource,  core_kernel_classes_Class $class)
+    public function removeType(core_kernel_classes_Resource $resource, core_kernel_classes_Class $class)
     {
-        $returnValue = (bool) false;
+        // TODO: refactor this to use a triple store abstraction
+        $query = 'DELETE FROM statements 
+		    		WHERE subject = ? AND predicate = ? AND ' . $this->getPersistence()->getPlatForm()->getObjectTypeCondition() . ' = ?';
 
-        
-        
-        $query =  'DELETE FROM statements 
-		    		WHERE subject = ? AND predicate = ? AND '. $this->getPersistence()->getPlatForm()->getObjectTypeCondition() .' = ?';
-        
         //be sure the property we try to remove is included in an updatable model
-		$query .= ' AND '.$this->getModelWriteSqlCondition();
-        
-        $returnValue = $this->getPersistence()->exec($query,array(
-        	$resource->getUri(),
-			OntologyRdf::RDF_TYPE,
-        	$class->getUri()
-        ));
-        
-        $returnValue = true;
-        
-        
+        $query .= ' AND ' . $this->getModelWriteSqlCondition();
 
-        return (bool) $returnValue;
+        $returnValue = $this->getPersistence()->exec($query, [
+            $resource->getUri(),
+            OntologyRdf::RDF_TYPE,
+            $class->getUri(),
+        ]);
+
+        $returnValue = true;
+
+        return (bool)$returnValue;
     }
 
     /**
@@ -701,12 +688,13 @@ class core_kernel_persistence_smoothsql_Resource
      *
      * @access public
      * @author Joel Bout, <joel.bout@tudor.lu>
-     * @param  Resource resource
+     *
+     * @param  core_kernel_classes_Resource resource
+     *
      * @return boolean
      */
-    public function isValidContext( core_kernel_classes_Resource $resource)
+    public function isValidContext(core_kernel_classes_Resource $resource)
     {
         return true;
     }
-
 }

--- a/core/kernel/persistence/smoothsql/class.SmoothIterator.php
+++ b/core/kernel/persistence/smoothsql/class.SmoothIterator.php
@@ -33,9 +33,10 @@ class core_kernel_persistence_smoothsql_SmoothIterator
      * @param array $modelIds
      */
     public function __construct(common_persistence_SqlPersistence $persistence, $modelIds = null) {
+        // TODO: refactor this to use a triple store abstraction.
         $query = 'SELECT * FROM statements '
             .(is_null($modelIds) ? '' : 'WHERE modelid IN ('.implode(',', $modelIds).') ')
-            .'ORDER BY id';
+            .'ORDER BY epoch';
         parent::__construct($persistence, $query);
     }
     
@@ -46,7 +47,8 @@ class core_kernel_persistence_smoothsql_SmoothIterator
      */
     function current() {
         $statement = parent::current();
-        
+
+        // TODO: create a constructor
         $triple = new core_kernel_classes_Triple();
         $triple->modelid = $statement["modelid"];
         $triple->subject = $statement["subject"];

--- a/core/kernel/persistence/smoothsql/class.SmoothRdf.php
+++ b/core/kernel/persistence/smoothsql/class.SmoothRdf.php
@@ -56,7 +56,7 @@ class core_kernel_persistence_smoothsql_SmoothRdf
     }
 
     /**
-     * (non-PHPdoc)git
+     * (non-PHPdoc)
      * @see \oat\generis\model\data\RdfInterface::add()
      */
     public function add(\core_kernel_classes_Triple $triple) {

--- a/core/kernel/persistence/smoothsql/install/SmoothRdsModel.php
+++ b/core/kernel/persistence/smoothsql/install/SmoothRdsModel.php
@@ -17,43 +17,45 @@
  * Copyright (c) 2018 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
-namespace   oat\generis\model\kernel\persistence\smoothsql\install;
+
+namespace oat\generis\model\kernel\persistence\smoothsql\install;
 
 use Doctrine\DBAL\Schema\Schema;
+
 /**
  * Helper to setup the required tables for generis smoothsql
  */
-class SmoothRdsModel {
-
+class SmoothRdsModel
+{
     /**
-     * 
+     *
      * @param Schema $schema
+     *
      * @return \Doctrine\DBAL\Schema\Schema
      */
     public static function addSmoothTables(Schema $schema)
     {
-        $table = $schema->createTable("models");
-        $table->addColumn('modelid', "integer",array("notnull" => true,"autoincrement" => true));
-        $table->addColumn('modeluri', "string", array("length" => 255,"default" => null));
-        $table->addOption('engine' , 'MyISAM');
-        $table->setPrimaryKey(array('modelid'));
+        $table = $schema->createTable('models');
+        $table->addColumn('modelid', 'string', ['length' => 25, 'notnull' => true]);
+        $table->addColumn('modeluri', 'string', ['length' => 255]);
+        $table->setPrimaryKey(['modelid']);
 
-        $table = $schema->createTable("statements");
-        $table->addColumn("modelid", "integer",array("notnull" => true,"default" => 0));
-        $table->addColumn("subject", "string",array("length" => 255,"default" => null));
-        $table->addColumn("predicate", "string",array("length" => 255,"default" => null));
-        $table->addColumn("object", "text", array("default" => null,"notnull" => false));
-            
-        $table->addColumn("l_language", "string",array("length" => 255,"default" => null,"notnull" => false));
-        $table->addColumn("id", "integer",array("notnull" => true,"autoincrement" => true));
-        $table->addColumn("author", "string",array("length" => 255,"default" => null,"notnull" => false));
-        $table->setPrimaryKey(array("id"));
-        $table->addOption('engine' , 'MyISAM');
-        $table->addColumn("epoch", "string" , array("notnull" => null));
-            
-        $table->addIndex(array("subject","predicate"),"k_sp");
-        $table->addIndex(array("predicate","object"),"k_po");
-        
+        $table = $schema->createTable('statements');
+        $table->addColumn('id', 'string', ['length' => 25, 'notnull' => true]);
+
+        $table->addColumn('modelid', 'string', ['notnull' => true]);
+        $table->addColumn('subject', 'string', ['length' => 255]);
+        $table->addColumn('predicate', 'string', ['length' => 255]);
+        $table->addColumn('object', 'text', ['default' => null]);
+        $table->addColumn('l_language', 'string', ['length' => 255]);
+
+        $table->addColumn('author', 'string', ['length' => 255]);
+        $table->addColumn('epoch', 'timestamp');    // Spanner timestamp type
+
+        $table->setPrimaryKey(['id']);
+        $table->addIndex(['subject', 'predicate'], 'k_sp');
+        $table->addIndex(['predicate', 'object'], 'k_po');
+
         return $schema;
     }
 }

--- a/core/kernel/persistence/smoothsql/install/SmoothRdsModel.php
+++ b/core/kernel/persistence/smoothsql/install/SmoothRdsModel.php
@@ -46,11 +46,11 @@ class SmoothRdsModel
         $table->addColumn('modelid', 'string', ['notnull' => true]);
         $table->addColumn('subject', 'string', ['length' => 255]);
         $table->addColumn('predicate', 'string', ['length' => 255]);
-        $table->addColumn('object', 'text', ['default' => null]);
+        $table->addColumn('object', 'text');
         $table->addColumn('l_language', 'string', ['length' => 255]);
 
         $table->addColumn('author', 'string', ['length' => 255]);
-        $table->addColumn('epoch', 'timestamp');    // Spanner timestamp type
+        $table->addColumn('epoch', 'string');    // timestamp type to be modified for benchmark on spanner
 
         $table->setPrimaryKey(['id']);
         $table->addIndex(['subject', 'predicate'], 'k_sp');

--- a/core/kernel/persistence/smoothsql/install/SmoothRdsModel.php
+++ b/core/kernel/persistence/smoothsql/install/SmoothRdsModel.php
@@ -35,26 +35,30 @@ class SmoothRdsModel
      */
     public static function addSmoothTables(Schema $schema)
     {
+        // Models table.
         $table = $schema->createTable('models');
         $table->addColumn('modelid', 'string', ['length' => 25, 'notnull' => true]);
         $table->addColumn('modeluri', 'string', ['length' => 255]);
         $table->setPrimaryKey(['modelid']);
+        $table->addOption('engine' , 'MyISAM');
 
+        // Statements table.
         $table = $schema->createTable('statements');
         $table->addColumn('id', 'string', ['length' => 25, 'notnull' => true]);
 
-        $table->addColumn('modelid', 'string', ['notnull' => true]);
+        $table->addColumn('modelid', 'string', ['length' => 25, 'notnull' => true]);
         $table->addColumn('subject', 'string', ['length' => 255]);
         $table->addColumn('predicate', 'string', ['length' => 255]);
         $table->addColumn('object', 'text');
         $table->addColumn('l_language', 'string', ['length' => 255]);
 
         $table->addColumn('author', 'string', ['length' => 255]);
-        $table->addColumn('epoch', 'string');    // timestamp type to be modified for benchmark on spanner
+        $table->addColumn('epoch', 'string', ['notnull' => true]);
 
         $table->setPrimaryKey(['id']);
         $table->addIndex(['subject', 'predicate'], 'k_sp');
         $table->addIndex(['predicate', 'object'], 'k_po');
+        $table->addOption('engine' , 'MyISAM');
 
         return $schema;
     }

--- a/core/user/AuthAdapter.php
+++ b/core/user/AuthAdapter.php
@@ -96,7 +96,6 @@ class AuthAdapter extends Configurable implements LoginAdapter
     	$options = array('like' => false, 'recursive' => true);
     	$users = $userClass->searchInstances($filters, $options);
     	
-    	
     	if (count($users) > 1){
     		// Multiple users matching
     		throw new common_exception_InconsistentData("Multiple Users found with the same login '".$this->username."'.");

--- a/test/integration/NamespaceTest.php
+++ b/test/integration/NamespaceTest.php
@@ -43,7 +43,7 @@ class NamespaceTest extends \PHPUnit_Framework_TestCase
 		
 		//$this->assertReference($namespaceManager, common_ext_NamespaceManager::singleton());
 		
-		$tempNamesapce = new common_ext_Namespace();
+		$tempNamesapce = new common_ext_Namespace('','');
 		$this->assertInstanceOf('common_ext_Namespace', $tempNamesapce);
 	}
 	


### PR DESCRIPTION
**DRAFT - DO NOT MERGE YET**

**Requires https://github.com/oat-sa/generis/pull/630
Requires https://github.com/oat-sa/lib-generis-search/pull/21/
Requires https://github.com/oat-sa/tao-core/pull/2167**

Refactoring the `statements` and `models` table primary keys to not use an auto-increment field, which is not supported by Spanner.

Most of the queries where not directly refactored but factorized in ModelFactory.
The factorized addStatement is placed here because it was previously existing. There might be a better place but I didn't find any (maybe I didn't go deep enough).

Refactor in addStatement consists mainly of creating an uuid for primary key (discussed in comments of https://oat-sa.atlassian.net/browse/NEX-84) and using epoch (set to a spanner TIMESTAMP data type) for chronological ORDERing.

I also wrote a lot of TODOs for future thinking...

Testing locally implies creating the model with the changes in SmoothRdsModel.
Testing on spanner will require to change the `epoch` field type to be changed to TIMESTAMP spanner data type. But since the schema management was not part of the scope of the first draft of the lib-dbal-spanner, the schema creation has to be performed manually on spanner so SmoothRdsModel won't be changed anyway. A solution will have to be found to perform the creation for later use in production.