### PR TITLE
Upgraded dbal to version 2.9 and required doctrine/annotations.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,8 @@
   "require": {
     "clearfw/clearfw": "~1.2.0",
     "easyrdf/easyrdf": "^0.9.0",
-    "doctrine/dbal": "~2.5.0",
+    "doctrine/dbal": "^2.9.0",
+    "doctrine/annotations": "1.*",
     "zendframework/zend-servicemanager": "~2.5.0",
     "league/flysystem": "~1.0",
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '11.4.2',
+    'version' => '11.5.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -430,6 +430,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('11.3.2');
         }
 
-        $this->skip('11.3.2', '11.4.2');
+        $this->skip('11.3.2', '11.5.0');
     }
 }


### PR DESCRIPTION
How to test:
```
git clone git@github.com:oat-sa/package-tao.git
cd package-tao
git checkout develop
```
In `composer.json` at line 45, replace `"oat-sa/generis" : "dev-develop"` with `"oat-sa/generis" : "dev-feature/NEX-121/upgrade-dbal"`
```
composer install
```
This should install `doctrine/dbal` v 2.9.x and `doctrine/annotations` v 1.7.x.
Perform a standard installation of Tao and run it in your browser. It should behave normally.
