### PR TITLE
Required php ^7.1.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
     "zendframework/zend-servicemanager": "~2.5.0",
     "league/flysystem": "~1.0",
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-    "php": ">=5.6.6",
+    "php": "^7.1",
     "psr/log": "~1.0",
     "oat-sa/lib-generis-search": "^2.0.1",
     "monolog/monolog": "^1.23.0",

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '11.4.2',
+    'version' => '12.0.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -430,6 +430,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('11.3.2');
         }
 
-        $this->skip('11.3.2', '11.4.2');
+        $this->skip('11.3.2', '12.0.0');
     }
 }


### PR DESCRIPTION
Required php ^7.1 explicitly on generis.
To test:
```
git clone git@github.com:oat-sa/package-tao.git
cd package-tao
git checkout develop
```
In composer.json, replace `"oat-sa/generis" : "dev-develop"` with `"oat-sa/generis" : "dev-feature/NEX-121/upgrade-php71"`.
```
composer install
```
Make a standard installation.
Check that it seamlessly works.

Only impediment should be on old spielplatz.
