### PR TITLE
Fix/tao 8534 lock service unit tests

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '11.4.2',
+    'version' => '11.4.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -430,6 +430,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('11.3.2');
         }
 
-        $this->skip('11.3.2', '11.4.2');
+        $this->skip('11.3.2', '11.4.3');
     }
 }

--- a/test/unit/oatbox/mutex/test_action.php
+++ b/test/unit/oatbox/mutex/test_action.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once __DIR__ . '/../../../../common/inc.extension.php';
+require(__DIR__ . '/../../../../../vendor/autoload.php');
 
 use oat\oatbox\mutex\LockService;
 use oat\oatbox\service\ServiceManager;


### PR DESCRIPTION
There is an error during launch tests in CI:
```
-test-package_product-ci_taoce/generis/common/../../config/generis.conf.php' for inclusion (include_path='.:/usr/local/lib/php') in /var/lib/jenkins/workspace/oy-test-package_product-ci_taoce/generis/common/class.Config.php on line 35

Call Stack:
    0.0001     368584   1. {main}() /var/lib/jenkins/workspace/oy-test-package_product-ci_taoce/generis/test/unit/oatbox/mutex/test_action.php:0
    0.0002     371824   2. require_once('/var/lib/jenkins/workspace/oy-test-package_product-ci_taoce/generis/common/inc.extension.php') /var/lib/jenkins/workspace/oy-test-package_product-ci_taoce/generis/test/unit/oatbox/mutex/test_action.php:3
    0.0003     377576   3. common_Config::load() /var/lib/jenkins/workspace/oy-test-package_product-ci_taoce/generis/common/inc.extension.php:44
```

This PR fixes that issue.