### PR TITLE
platform specific getNowExpression() is not usable.

### DIFF
--- a/common/persistence/sql/class.Platform.php
+++ b/common/persistence/sql/class.Platform.php
@@ -160,9 +160,7 @@ class common_persistence_sql_Platform {
         // correct format to be inserted in db.
 
         $datetime = new \DateTime('now', new \DateTimeZone('UTC'));
-        $date = $datetime->format($this->dbalPlatform->getDateTimeTzFormatString());
-
-        return $date;
+        return $datetime->format($this->dbalPlatform->getDateTimeTzFormatString());
     }
 
     /**

--- a/common/persistence/sql/class.Platform.php
+++ b/common/persistence/sql/class.Platform.php
@@ -160,7 +160,7 @@ class common_persistence_sql_Platform {
         // correct format to be inserted in db.
 
         $datetime = new \DateTime('now', new \DateTimeZone('UTC'));
-        return $datetime->format($this->dbalPlatform->getDateTimeFormatString());
+        return $datetime->format($this->getDateTimeFormatString());
     }
 
     /**

--- a/common/persistence/sql/class.Platform.php
+++ b/common/persistence/sql/class.Platform.php
@@ -160,7 +160,16 @@ class common_persistence_sql_Platform {
         // correct format to be inserted in db.
 
         $datetime = new \DateTime('now', new \DateTimeZone('UTC'));
-        return $datetime->format($this->dbalPlatform->getDateTimeTzFormatString());
+        return $datetime->format($this->dbalPlatform->getDateTimeFormatString());
+    }
+
+    /**
+     * Returns platform specific date formatting with timezone to store datetime field.
+     * @return string
+     */
+    public function getDateTimeFormatString()
+    {
+        return $this->dbalPlatform->getDateTimeFormatString();
     }
 
     /**

--- a/common/persistence/sql/class.Platform.php
+++ b/common/persistence/sql/class.Platform.php
@@ -152,7 +152,17 @@ class common_persistence_sql_Platform {
      * @return string
      */
     public function getNowExpression(){
-        return $this->dbalPlatform->getNowExpression();
+        // We can't use $this->dbalPlatform->getNowExpression() because sqlite,
+        // at least used for the tests, returns `datetime('now')` which can
+        // not be parsed as a regular date.
+        // We instead generate a date with php and the format it with
+        // $this->dbalPlatform->getDateTimeTzFormatString(), to still have the
+        // correct format to be inserted in db.
+
+        $datetime = new \DateTime('now', new \DateTimeZone('UTC'));
+        $date = $datetime->format($this->dbalPlatform->getDateTimeTzFormatString());
+
+        return $date;
     }
 
     /**

--- a/common/persistence/sql/class.Platform.php
+++ b/common/persistence/sql/class.Platform.php
@@ -146,16 +146,31 @@ class common_persistence_sql_Platform {
     public function getName(){
         return $this->dbalPlatform->getName();
     }
+
     /**
-     * 
      * @author Lionel Lecaque, lionel@taotesting.com
      * @return string
      */
     public function getNowExpression(){
-        $datetime = new DateTime('now', new \DateTimeZone('UTC'));
-        $date = $datetime->format('Y-m-d H:i:s');
-       // return $this->dbalPlatform->getNowExpression();
-       return $date;
+        return $this->dbalPlatform->getNowExpression();
+    }
+
+    /**
+     * Returns platform specific date formatting to store datetime field.
+     * @return string
+     */
+    public function getDateTimeFormatString()
+    {
+        return $this->dbalPlatform->getDateTimeFormatString();
+    }
+
+    /**
+     * Returns platform specific date formatting with timezone to store datetime field.
+     * @return string
+     */
+    public function getDateTimeTzFormatString()
+    {
+        return $this->dbalPlatform->getDateTimeTzFormatString();
     }
 
     /**

--- a/common/persistence/sql/class.Platform.php
+++ b/common/persistence/sql/class.Platform.php
@@ -164,15 +164,6 @@ class common_persistence_sql_Platform {
     }
 
     /**
-     * Returns platform specific date formatting to store datetime field.
-     * @return string
-     */
-    public function getDateTimeFormatString()
-    {
-        return $this->dbalPlatform->getDateTimeFormatString();
-    }
-
-    /**
      * Returns platform specific date formatting with timezone to store datetime field.
      * @return string
      */

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '11.4.3',
+    'version' => '11.4.5',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '11.4.5',
+    'version' => '11.4.6',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -430,6 +430,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('11.3.2');
         }
 
-        $this->skip('11.3.2', '11.4.3');
+        $this->skip('11.3.2', '11.4.5');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -430,6 +430,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('11.3.2');
         }
 
-        $this->skip('11.3.2', '11.4.5');
+        $this->skip('11.3.2', '11.4.6');
     }
 }

--- a/test/unit/common/persistence/sql/PlatformTest.php
+++ b/test/unit/common/persistence/sql/PlatformTest.php
@@ -19,6 +19,8 @@
 
 namespace oat\generis\test\unit\common\persistence\sql\dbal;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
 use oat\generis\test\TestCase;
 
 class PlatformTest extends TestCase
@@ -42,6 +44,27 @@ class PlatformTest extends TestCase
         $service = $this->getPersistenceManager();
         $service->registerPersistence('notMysql', ['driver' => 'dbal', 'connection' => ['driver' => 'pdo_not_mysql']]);
         $this->assertArrayNotHasKey('charset',$service->getOption('persistences')['notMysql']['connection']);
+    }
+
+    public function testGetNowExpression()
+    {
+        $format = 'm:i:d:H:Y:s';
+        $dbalPlatform = $this->getMockBuilder(AbstractPlatform::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getDateTimeTzFormatString'])
+            ->getMockForAbstractClass();
+        $dbalPlatform->method('getDateTimeTzFormatString')->willReturn($format);
+
+        /** @var Connection|\PHPUnit_Framework_MockObject_MockObject $dbalConnection */
+        $dbalConnection = $this->getMockBuilder(Connection::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getDatabasePlatform'])
+            ->getMock();
+        $dbalConnection->method('getDatabasePlatform')->willReturn($dbalPlatform);
+
+        $platform = new \common_persistence_sql_Platform($dbalConnection);
+        $datetime = (new \DateTime('now', new \DateTimeZone('UTC')))->format($format);
+        $this->assertEquals($datetime, $platform->getNowExpression());
     }
 
     /**

--- a/test/unit/common/persistence/sql/PlatformTest.php
+++ b/test/unit/common/persistence/sql/PlatformTest.php
@@ -51,9 +51,9 @@ class PlatformTest extends TestCase
         $format = 'm:i:d:H:Y:s';
         $dbalPlatform = $this->getMockBuilder(AbstractPlatform::class)
             ->disableOriginalConstructor()
-            ->setMethods(['getDateTimeTzFormatString'])
+            ->setMethods(['getDateTimeFormatString'])
             ->getMockForAbstractClass();
-        $dbalPlatform->method('getDateTimeTzFormatString')->willReturn($format);
+        $dbalPlatform->method('getDateTimeFormatString')->willReturn($format);
 
         /** @var Connection|\PHPUnit_Framework_MockObject_MockObject $dbalConnection */
         $dbalConnection = $this->getMockBuilder(Connection::class)


### PR DESCRIPTION
Changed platform proxy to use platform specific date formatting function instead of getNowExpression.
We can't use $this->dbalPlatform->getNowExpression() because sqlite, used in the tests for instance, returns `datetime('now')` which can not be parsed as a regular date.
We instead generate a date with php and then format it with $this->dbalPlatform->getDateTimeTzFormatString(), to still have the correct format to be inserted in db depending on the platform.