### PR TITLE
Feature/tao 8195/method not allowed param

### DIFF
--- a/common/exception/class.MethodNotAllowed.php
+++ b/common/exception/class.MethodNotAllowed.php
@@ -25,6 +25,30 @@
  */
 class common_exception_MethodNotAllowed extends common_exception_BadRequest
 {
+    /**
+     * @var string[]|null
+     */
+    protected $allowedMethods;
+
+    /**
+     * @param string|null $message
+     * @param int $code
+     * @param string[]|null $allowedMethods
+     */
+    public function __construct($message = null, int $code = 0, $allowedMethods = null)
+    {
+        parent::__construct($message, $code);
+        $this->allowedMethods = $allowedMethods;
+    }
+
+    /**
+     * @return string[]|null
+     */
+    public function getAllowedMethods()
+    {
+        return $this->allowedMethods;
+    }
+
     public function getUserMessage()
     {
         return __("Request method is not allowed.");

--- a/common/exception/class.MethodNotAllowed.php
+++ b/common/exception/class.MethodNotAllowed.php
@@ -35,7 +35,7 @@ class common_exception_MethodNotAllowed extends common_exception_BadRequest
      * @param int $code
      * @param string[]|null $allowedMethods
      */
-    public function __construct($message = null, $code = 0, $allowedMethods = null)
+    public function __construct($message = null, $code = 0, array $allowedMethods = null)
     {
         parent::__construct($message, $code);
         $this->allowedMethods = $allowedMethods;

--- a/common/exception/class.MethodNotAllowed.php
+++ b/common/exception/class.MethodNotAllowed.php
@@ -35,7 +35,7 @@ class common_exception_MethodNotAllowed extends common_exception_BadRequest
      * @param int $code
      * @param string[]|null $allowedMethods
      */
-    public function __construct($message = null, int $code = 0, $allowedMethods = null)
+    public function __construct($message = null, $code = 0, $allowedMethods = null)
     {
         parent::__construct($message, $code);
         $this->allowedMethods = $allowedMethods;

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '11.5.0',
+    'version' => '11.4.5',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '11.4.2',
+    'version' => '11.5.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/manifest.php
+++ b/manifest.php
@@ -31,7 +31,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '11.5.2',
+    'version' => '11.5.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -430,6 +430,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('11.3.2');
         }
 
-        $this->skip('11.3.2', '11.4.2');
+        $this->skip('11.3.2', '11.5.2');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -430,6 +430,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('11.3.2');
         }
 
-        $this->skip('11.3.2', '11.5.0');
+        $this->skip('11.3.2', '11.4.5');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -430,6 +430,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('11.3.2');
         }
 
-        $this->skip('11.3.2', '11.5.2');
+        $this->skip('11.3.2', '11.5.0');
     }
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/TAO-8195

Optional param `$allowedMethods` added to `common_exception_MethodNotAllowed`.
It's needed to provide valid 405 response with `Allow` header later according to RFC (https://tools.ietf.org/html/rfc7231#section-6.5.5)

Needed for: https://github.com/oat-sa/tao-core/pull/2201