### PR TITLE
Composer required-dev php-mock to mock global functions.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,6 +72,7 @@
   "require-dev": {
     "mikey179/vfsstream": "1.4.0",
     "phpunit/phpunit": "^4.8",
+    "php-mock/php-mock": "^2.0",
     "symfony/cache": "~4.1"
   },
   "autoload": {

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.0.1',
+    'version' => '12.0.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -438,6 +438,6 @@ class Updater extends common_ext_ExtensionUpdater
 
             $this->setVersion('11.6.0');
         }
-        $this->skip('11.6.0', '12.0.1');
+        $this->skip('11.6.0', '12.0.2');
     }
 }


### PR DESCRIPTION
php-mock/php-mock allows us to mock global functions if they are call from a namespaced code without leading \.
This is *very* useful for unit testing of legacy code.