### PR TITLE
Tao 8802/fix/adv key value persistence hset

### DIFF
--- a/common/persistence/class.InMemoryAdvKvDriver.php
+++ b/common/persistence/class.InMemoryAdvKvDriver.php
@@ -22,6 +22,14 @@ class common_persistence_InMemoryAdvKvDriver extends common_persistence_InMemory
 {
     const HPREFIX = 'hPrfx_';
 
+    /**
+     *
+     * @see common_persistence_Driver::connect()
+     */
+    function connect($id, array $params){
+        return new \common_persistence_AdvKeyValuePersistence($params, $this);
+    }
+
     public function hmSet($key, $fields)
     {
         if (!is_array($fields)) {
@@ -40,11 +48,9 @@ class common_persistence_InMemoryAdvKvDriver extends common_persistence_InMemory
 
     public function hSet($key, $field, $value)
     {
-        if (! isset($this->persistence[$key])) {
-            return false;
-        }
+        $result = !isset($this->persistence[$key][self::HPREFIX . $field]);
         $this->persistence[$key][self::HPREFIX . $field] = $value;
-        return true;
+        return $result;
     }
 
     public function hGet($key, $field)

--- a/common/persistence/class.Manager.php
+++ b/common/persistence/class.Manager.php
@@ -54,7 +54,8 @@ class common_persistence_Manager extends ConfigurableService
         'phpredis'   => 'common_persistence_PhpRedisDriver',
         'phpfile'    => 'common_persistence_PhpFileDriver',
         'SqlKvWrapper' => 'common_persistence_SqlKvDriver',
-        'no_storage' => 'common_persistence_InMemoryKvDriver'
+        'no_storage' => 'common_persistence_InMemoryKvDriver',
+        'no_storage_adv' => 'common_persistence_InMemoryAdvKvDriver'
     );
     
     /**

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.0.2',
+    'version' => '12.1.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -438,6 +438,6 @@ class Updater extends common_ext_ExtensionUpdater
 
             $this->setVersion('11.6.0');
         }
-        $this->skip('11.6.0', '12.0.2');
+        $this->skip('11.6.0', '12.1.0');
     }
 }

--- a/test/unit/common/persistence/AdvKeyValuePersistenceTest.php
+++ b/test/unit/common/persistence/AdvKeyValuePersistenceTest.php
@@ -62,6 +62,14 @@ class AdvKeyValuePersistenceTest extends TestCase
         $this->largeValuePersistence->hSet('test', 'fixture', 'value');
     }
 
+    public function testHset()
+    {
+        $this->assertTrue($this->largeValuePersistence->hSet('test', 'hset1', 'value'));
+        $this->assertTrue($this->largeValuePersistence->hSet('test', 'hset2', 'value'));
+        $this->assertFalse($this->largeValuePersistence->hSet('test', 'hset1', 'value2'));
+        $this->assertEquals('value2', $this->largeValuePersistence->hGet('test', 'hset1'));
+    }
+
     public function testLargeHmsetHget()
     {
         $bigValue = $this->get100000bytesValue();


### PR DESCRIPTION
Current implementation of `common_persistence_InMemoryAdvKvDriver ::hset()` is wrong.
According to redis documentation: 
>1 if field is a new field in the hash and value was set.
>0 if field already exists in the hash and the value was updated.