### PR TITLE
Create an EnvironmentVariable class to hold environment variabl usage through serialize/unserialize process.

### DIFF
--- a/common/oatbox/service/EnvironmentVariable.php
+++ b/common/oatbox/service/EnvironmentVariable.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\oatbox\service;
+
+use oat\oatbox\PhpSerializable;
+
+class EnvironmentVariable implements PhpSerializable
+{
+    /** @var string */
+    private $name;
+
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+
+    public function __toPhpCode()
+    {
+        return 'new ' . __CLASS__ . '(' . $this->name . ')';
+    }
+
+    public function __toString()
+    {
+        return (string) $_ENV[$this->name];
+    }
+}

--- a/common/oatbox/service/EnvironmentVariable.php
+++ b/common/oatbox/service/EnvironmentVariable.php
@@ -19,6 +19,8 @@
 
 namespace oat\oatbox\service;
 
+use common_Utils as Utils;
+use InvalidArgumentException;
 use oat\oatbox\PhpSerializable;
 
 class EnvironmentVariable implements PhpSerializable
@@ -28,12 +30,16 @@ class EnvironmentVariable implements PhpSerializable
 
     public function __construct($name)
     {
+        if(!is_string($name)) {
+            throw new InvalidArgumentException('Environment variable name must be a string.');
+        }
+
         $this->name = $name;
     }
 
     public function __toPhpCode()
     {
-        return 'new ' . __CLASS__ . '(' . $this->name . ')';
+        return 'new ' . __CLASS__ . '(' . Utils::toPHPVariableString($this->name) . ')';
     }
 
     public function __toString()

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.0.2',
+    'version' => '12.1.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -438,6 +438,6 @@ class Updater extends common_ext_ExtensionUpdater
 
             $this->setVersion('11.6.0');
         }
-        $this->skip('11.6.0', '12.0.2');
+        $this->skip('11.6.0', '12.1.0');
     }
 }

--- a/test/unit/oatbox/service/EnvironmentVariableTest.php
+++ b/test/unit/oatbox/service/EnvironmentVariableTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\generis\test\unit\oatbox\service;
+
+use oat\generis\test\TestCase;
+use oat\oatbox\service\EnvironmentVariable;
+
+class EnvironmentVariableTest extends TestCase
+{
+    const VAR_NAME = 'name of the variable';
+
+    /** @var EnvironmentVariable */
+    private $subject;
+
+    public function setUp()
+    {
+        $this->subject = new EnvironmentVariable(self::VAR_NAME);
+    }
+
+    public function testConstructor()
+    {
+        $this->assertInstanceOf(EnvironmentVariable::class, $this->subject);
+
+        $property = new \ReflectionProperty(EnvironmentVariable::class, 'name');
+        $property->setAccessible(true);
+        $this->assertSame(self::VAR_NAME, $property->getValue($this->subject));
+    }
+
+    public function testToPhpCode()
+    {
+        $this->assertSame('new ' . EnvironmentVariable::class . '(' . self::VAR_NAME . ')', $this->subject->__toPhpCode());
+    }
+
+    public function testToString()
+    {
+        $_ENV[self::VAR_NAME] = 1012;
+
+        $this->assertSame('1012', (string) $this->subject) ;
+    }
+}

--- a/test/unit/oatbox/service/EnvironmentVariableTest.php
+++ b/test/unit/oatbox/service/EnvironmentVariableTest.php
@@ -19,12 +19,14 @@
 
 namespace oat\generis\test\unit\oatbox\service;
 
+use common_Utils as Utils;
+use InvalidArgumentException;
 use oat\generis\test\TestCase;
 use oat\oatbox\service\EnvironmentVariable;
 
 class EnvironmentVariableTest extends TestCase
 {
-    const VAR_NAME = 'name of the variable';
+    const VAR_NAME = 'That\'s the variable\'s name.';
 
     /** @var EnvironmentVariable */
     private $subject;
@@ -43,15 +45,21 @@ class EnvironmentVariableTest extends TestCase
         $this->assertSame(self::VAR_NAME, $property->getValue($this->subject));
     }
 
+    public function testConstructorWithNonStringKeyThrowsException()
+    {
+        $this->setExpectedException(InvalidArgumentException::class, 'Environment variable name must be a string.');
+        new EnvironmentVariable([]);
+    }
+
     public function testToPhpCode()
     {
-        $this->assertSame('new ' . EnvironmentVariable::class . '(' . self::VAR_NAME . ')', $this->subject->__toPhpCode());
+        $this->assertSame('new ' . EnvironmentVariable::class . '(' . Utils::toPHPVariableString(self::VAR_NAME) . ')', $this->subject->__toPhpCode());
     }
 
     public function testToString()
     {
         $_ENV[self::VAR_NAME] = 1012;
 
-        $this->assertSame('1012', (string) $this->subject) ;
+        $this->assertSame('1012', (string)$this->subject);
     }
 }


### PR DESCRIPTION
By storing the name of the environment variable instead of its translated value, this allows for php serialization/unserialization in configuration.