### PR TITLE
Fix/tao 8587/phpfile check

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.2.0',
+    'version' => '12.2.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/RegisterDefaultKvPersistence.php
+++ b/scripts/update/RegisterDefaultKvPersistence.php
@@ -100,8 +100,9 @@ class RegisterDefaultKvPersistence extends InstallAction
     {
         /** @var common_persistence_Manager $persistenceManager */
         $persistenceManager = $this->getServiceManager()->get(common_persistence_Manager::SERVICE_ID);
-
-        if (!$persistenceManager->hasPersistence($persistenceId)) {
+        $persistencesConfig = $persistenceManager->getOption('persistences');
+        if (!$persistenceManager->hasPersistence($persistenceId)
+            || $persistencesConfig[$persistenceId]['driver'] == 'phpfile') {
             return false;
         }
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -375,7 +375,7 @@ class Updater extends common_ext_ExtensionUpdater
 
         $this->skip('10.0.0', '10.1.0');
 
-        if ($this->isVersion('10.1.0')) {
+        if ($this->isBetween('10.1.0','11.0.0')) {
             /** @var \common_persistence_Manager $persistenceManager */
             $persistenceManager = $this->getServiceManager()->get(\common_persistence_Manager::SERVICE_ID);
 
@@ -442,7 +442,7 @@ class Updater extends common_ext_ExtensionUpdater
 
         $this->skip('11.6.0', '12.1.0');
 
-        if ($this->isVersion('12.1.0')) {
+        if ($this->isBetween('12.1.0','12.2.0')) {
             $fs = $this->getServiceManager()->get(FileSystemService::SERVICE_ID);
             $adapters = $fs->getOption(FileSystemService::OPTION_ADAPTERS);
             if (!isset($adapters['default'])) {
@@ -460,5 +460,6 @@ class Updater extends common_ext_ExtensionUpdater
             }
             $this->setVersion('12.2.0');
         }
+        $this->skip('12.2.0', '12.2.1');
     }
 }


### PR DESCRIPTION
Related to: 
https://oat-sa.atlassian.net/browse/TAO-8587
https://oat-sa.atlassian.net/browse/TAO-8966

Updater adopt for backports.
Check persistence driver `!='phpfile'` 
To test:
1) in file `config/generis/persistences.conf.php` remove `default_kv` if exists
2) run `php index.php '\oat\generis\scripts\update\RegisterDefaultKvPersistence'`
3) check in file `config/generis/persistences.conf.php` that new `default_kv` added and it is redis or sql