### PR TITLE
Add type declaration for array parameter in methods of logger helper

### DIFF
--- a/common/class.Logger.php
+++ b/common/class.Logger.php
@@ -265,7 +265,7 @@ class common_Logger
      * @param  array $tags
      * @return mixed
      */
-    public static function t($message, $tags = array())
+    public static function t($message, array $tags = array())
     {
         
 		self::singleton()->log(self::TRACE_LEVEL, $message, $tags);
@@ -281,7 +281,7 @@ class common_Logger
      * @param  array $tags
      * @return mixed
      */
-    public static function d($message, $tags = array())
+    public static function d($message, array $tags = array())
     {
         
 		self::singleton()->log(self::DEBUG_LEVEL, $message, $tags);
@@ -299,7 +299,7 @@ class common_Logger
      * @param  array $tags
      * @return mixed
      */
-    public static function i($message, $tags = array())
+    public static function i($message, array $tags = array())
     {
         
 		self::singleton()->log(self::INFO_LEVEL, $message, $tags);
@@ -315,7 +315,7 @@ class common_Logger
      * @param  array $tags
      * @return mixed
      */
-    public static function w($message, $tags = array())
+    public static function w($message, array $tags = array())
     {
         
 		self::singleton()->log(self::WARNING_LEVEL, $message, $tags);
@@ -331,7 +331,7 @@ class common_Logger
      * @param  array $tags
      * @return mixed
      */
-    public static function e($message, $tags = array())
+    public static function e($message, array $tags = array())
     {
         self::singleton()->log(self::ERROR_LEVEL, $message, self::addTrace($tags));
     }
@@ -359,7 +359,7 @@ class common_Logger
      * @param  array $tags
      * @return mixed
      */
-    public static function f($message, $tags = array())
+    public static function f($message, array $tags = array())
     {
 		self::singleton()->log(self::FATAL_LEVEL, $message, self::addTrace($tags));
     }

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.4.3',
+    'version' => '12.4.4',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -475,6 +475,6 @@ class Updater extends common_ext_ExtensionUpdater
             }
             $this->setVersion('12.4.1');
         }
-        $this->skip('12.4.1', '12.4.3');
+        $this->skip('12.4.1', '12.4.4');
     }
 }


### PR DESCRIPTION
It fixes issues when somebody can pass a string instead of an array and it will break logger implementation that awaits array as a third parameter.

Changes done during work on https://oat-sa.atlassian.net/browse/TAO-9273 but not strongly required.