### PR TITLE
TTD-18 Tests extends from `generis\test\TestCase`. All mock objects e…

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.4.4',
+    'version' => '12.5.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -475,6 +475,6 @@ class Updater extends common_ext_ExtensionUpdater
             }
             $this->setVersion('12.4.1');
         }
-        $this->skip('12.4.1', '12.4.4');
+        $this->skip('12.4.1', '12.5.0');
     }
 }

--- a/test/MockObject.php
+++ b/test/MockObject.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\generis\test;
+
+use PHPUnit_Framework_MockObject_MockObject;
+
+interface MockObject extends PHPUnit_Framework_MockObject_MockObject
+{
+}

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -23,8 +23,10 @@ use Prophecy\Argument;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use common_persistence_Manager;
 use common_persistence_sql_dbal_Driver;
+use PHPUnit\Framework\TestCase as UnitTestCase;
+use oat\generis\test\MockObject;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends UnitTestCase
 {
     /**
      * Forward compatibility function for PHPUnit 7.0
@@ -75,7 +77,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
      * Returns a test double for the specified class.
      *
      * @param string $originalClassName
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      * @throws \PHPUnit_Framework_Exception
      * @since Method available since Release 5.4.0
      */
@@ -95,7 +97,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
      *
      * @param string $originalClassName
      * @param array $methods
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return MockObject
      * @since Method available since Release 5.4.0
      */
     protected function createPartialMock($originalClassName, array $methods = [])

--- a/test/integration/NamespaceTest.php
+++ b/test/integration/NamespaceTest.php
@@ -28,7 +28,10 @@
  * @package generis
  
  */
-class NamespaceTest extends \PHPUnit_Framework_TestCase
+
+use oat\generis\test\TestCase;
+
+class NamespaceTest extends TestCase
 {
 	
 	public function setUp(){

--- a/test/integration/RegistryTest.php
+++ b/test/integration/RegistryTest.php
@@ -21,9 +21,10 @@
 namespace oat\generis\test\integration;
 
 
+use oat\generis\test\TestCase;
 use oat\oatbox\BasicRegistry;
 
-class RegistryTest extends \PHPUnit_Framework_TestCase
+class RegistryTest extends TestCase
 {
     /**
      *

--- a/test/integration/rules/ExpressionTest.php
+++ b/test/integration/rules/ExpressionTest.php
@@ -23,8 +23,9 @@ use oat\generis\model\RulesRdf;
  * 
  */
 
+use oat\generis\test\TestCase;
 
-class ExpressionTest extends \PHPUnit_Framework_TestCase
+class ExpressionTest extends TestCase
 {
 
     public function testEvaluate(){

--- a/test/unit/common/persistence/sql/PlatformTest.php
+++ b/test/unit/common/persistence/sql/PlatformTest.php
@@ -22,6 +22,7 @@ namespace oat\generis\test\unit\common\persistence\sql\dbal;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use oat\generis\test\TestCase;
+use oat\generis\test\MockObject;
 
 class PlatformTest extends TestCase
 {
@@ -55,7 +56,7 @@ class PlatformTest extends TestCase
             ->getMockForAbstractClass();
         $dbalPlatform->method('getDateTimeFormatString')->willReturn($format);
 
-        /** @var Connection|\PHPUnit_Framework_MockObject_MockObject $dbalConnection */
+        /** @var Connection|MockObject $dbalConnection */
         $dbalConnection = $this->getMockBuilder(Connection::class)
             ->disableOriginalConstructor()
             ->setMethods(['getDatabasePlatform'])


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/TTD-18
All tests extends `generis\test\TestCase` instead of `\PHPUnit_Framework_TestCase`
All Mock objects instances of `generis\test\MockObject` instead of `\PHPUnit_Framework_MockObject_MockObject`. Mocks was used only in phpdoc.
Possible way to test:
1) run unit tests.
2) update code.
3) run unit tests again. result should be the same as in 1.