### PR TITLE
Fix/system helper file upload limit

### DIFF
--- a/helpers/SystemHelper.php
+++ b/helpers/SystemHelper.php
@@ -29,14 +29,17 @@ class SystemHelper
      */
     public static function getFileUploadLimit()
     {
+        $limits = [
+            self::toBytes(ini_get('upload_max_filesize')),
+            self::toBytes(ini_get('post_max_size'))
+        ];
 
-        $max_upload = self::toBytes(ini_get('upload_max_filesize'));
-        $max_post = self::toBytes(ini_get('post_max_size'));
-        $memory_limit = self::toBytes(ini_get('memory_limit'));
+        if (($memory_limit = self::toBytes(ini_get('memory_limit'))) !== -1) {
+            $limits[] = $memory_limit;
+        }
+        $returnValue = min($limits);
 
-        $returnValue = min($max_upload, $max_post, $memory_limit);
-
-        return (int)$returnValue;
+        return $returnValue;
     }
 
 
@@ -97,6 +100,6 @@ class SystemHelper
                     $val *= 1024;
             }
         }
-        return $val;
+        return (int)$val;
     }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.4.4',
+    'version' => '12.4.5',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -475,6 +475,6 @@ class Updater extends common_ext_ExtensionUpdater
             }
             $this->setVersion('12.4.1');
         }
-        $this->skip('12.4.1', '12.4.4');
+        $this->skip('12.4.1', '12.4.5');
     }
 }


### PR DESCRIPTION
Fixed calculation of upload file size limit. It's based on the composition of minimal value of 3 arguments. One of them is `php` setting `memory_limit` which could be equal to '-1'.
So we'll get an error on import operations.