### PR TITLE
Fix/tao 8727/get adapter method visibility

### DIFF
--- a/common/oatbox/filesystem/FileSystem.php
+++ b/common/oatbox/filesystem/FileSystem.php
@@ -20,6 +20,7 @@
 
 namespace oat\oatbox\filesystem;
 
+use common_Exception;
 use League\Flysystem\FilesystemInterface;
 use oat\oatbox\filesystem\utils\FileSystemWrapperTrait;
 use League\Flysystem\AdapterInterface;
@@ -50,7 +51,8 @@ class FileSystem implements FilesystemInterface
      * Filesystem constructor.
      *
      * @param $id
-     * @param $adapter
+     * @param FilesystemInterface $flySystem
+     * @param $prefix
      */
     public function __construct($id, FilesystemInterface $flySystem, $prefix)
     {
@@ -80,12 +82,17 @@ class FileSystem implements FilesystemInterface
      * Get the Adapter.
      *
      * @return AdapterInterface adapter
+     * @throws common_Exception
      */
-    private function getAdapter()
+    public function getAdapter()
     {
         return $this->getFileSystem()->getAdapter();
     }
 
+    /**
+     * @param $path
+     * @return string
+     */
     protected function getFullPath($path)
     {
         return $this->prefix . '/' . $path;

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.5.2',
+    'version' => '12.5.3',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -475,6 +475,6 @@ class Updater extends common_ext_ExtensionUpdater
             }
             $this->setVersion('12.4.1');
         }
-        $this->skip('12.4.1', '12.5.2');
+        $this->skip('12.4.1', '12.5.3');
     }
 }


### PR DESCRIPTION
I need to revert `getAdapter` method visibility to be change to `public`
This change was made in [PR](https://github.com/oat-sa/generis/pull/656)
in [commit](https://github.com/oat-sa/generis/commit/d5b4069d52918abd7982004a07e72ca5ca93d470)

**My Task**
https://github.com/oat-sa/extension-tao-depp/pull/196