### PR TITLE
Added check to ensure file is writeable before updating.

### DIFF
--- a/common/oatbox/filesystem/File.php
+++ b/common/oatbox/filesystem/File.php
@@ -140,11 +140,15 @@ class File extends FileSystemHandler
     public function update($mixed, $mimeType = null)
     {
         if (!$this->exists()) {
-            throw new \FileNotFoundException('File "' . $this->getPrefix() . '" not found."');
+            throw new \FileNotFoundException(sprintf('File "%s" not found."', $this->getPrefix()));
+        }
+
+        if (!$this->isWriteable()) {
+            throw new FileNotWritableException(sprintf('Unable to write to file "%s"', $this->getPrefix()));
         }
 
         \common_Logger::i('Writting in ' . $this->getPrefix());
-        $config = (is_null($mimeType)) ? [] : ['ContentType' => $mimeType];
+        $config = $mimeType === null ? [] : ['ContentType' => $mimeType];
 
         if (is_string($mixed)) {
             return $this->getFileSystem()->update($this->getPrefix(), $mixed, $config);
@@ -262,6 +266,16 @@ class File extends FileSystemHandler
         } catch (FileNotFoundException $e) {
         }
         return false;
+    }
+
+    /**
+     * Check if $this file exists and is writeable
+     *
+     * @return bool
+     */
+    public function isWriteable()
+    {
+        return $this->getFileSystem()->isWriteable($this->getPrefix());
     }
 
     /**

--- a/common/oatbox/filesystem/FileNotWritableException.php
+++ b/common/oatbox/filesystem/FileNotWritableException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace oat\oatbox\filesystem;
+
+/**
+ * Class FileNotWriteableException
+ *
+ * @author Martijn Swinkels <m.swinkels@taotesting.com>
+ */
+class FileNotWritableException extends \RuntimeException
+{
+
+}

--- a/common/oatbox/filesystem/utils/FileSystemWrapperTrait.php
+++ b/common/oatbox/filesystem/utils/FileSystemWrapperTrait.php
@@ -36,7 +36,6 @@ trait FileSystemWrapperTrait
         return $this->getFileSystem()->has($this->getFullPath($path));
     }
 
-
     /**
      * (non-PHPdoc)
      * @see \League\Flysystem\FilesystemInterface::read()
@@ -234,13 +233,22 @@ trait FileSystemWrapperTrait
         return $this->getFileSystem()->get($this->getFullPath($path), $handler);
     }
 
-
     /**
      * (non-PHPdoc)
      * @see \League\Flysystem\FilesystemInterface::addPlugin()
      */
     public function addPlugin(PluginInterface $plugin) {
         return $this->getFileSystem()->addPlugin($plugin);
+    }
+
+    /**
+     * Checks if a file exists and can be written to
+     *
+     * @param string $path
+     * @return bool
+     */
+    public function isWriteable($path) {
+        return is_writable($this->getFullPath($path));
     }
 
     /**


### PR DESCRIPTION
If a file can not be updated the call to `file_put_contents` causes a PHP warning. This warning is placed in the output buffer, and after this, there are several direct `header()` calls. This causes more warnings and causes the response to the front-end to be prepended with the PHP warnings (resulting in an unknown error).

In this PR a check is implemented to see if the file is indeed writable and if not a new exception is thrown.