### PR TITLE
Added proxy for transactional execution of closure.

### DIFF
--- a/common/persistence/class.SqlPersistence.php
+++ b/common/persistence/class.SqlPersistence.php
@@ -123,4 +123,18 @@ class common_persistence_SqlPersistence extends common_persistence_Persistence
       public function lastInsertId($name = null){
           return $this->getDriver()->lastInsertId($name);
       }
+
+    /**
+     * Execute a function within a transaction.
+     *
+     * @param Closure $func The function to execute transactionally.
+     *
+     * @return mixed The value returned by $func
+     *
+     * @throws Throwable
+     */
+    public function transactional(Closure $func)
+    {
+        return $this->getDriver()->transactional($func);
+    }
 }

--- a/common/persistence/sql/dbal/class.Driver.php
+++ b/common/persistence/sql/dbal/class.Driver.php
@@ -243,4 +243,19 @@ class common_persistence_sql_dbal_Driver implements common_persistence_sql_Drive
     {
         return $this->connection->getDatabase();
     }
+
+    /**
+     * Execute a function within a transaction.
+     *
+     * @param Closure $func The function to execute transactionally.
+     *
+     * @return mixed The value returned by $func
+     *
+     * @throws Exception
+     * @throws Throwable
+     */
+    public function transactional(Closure $func)
+    {
+        return $this->connection->transactional($func);
+    }
 }


### PR DESCRIPTION
This adds the ability to run a transaction against the persistence with a closure.
This is required by https://github.com/oat-sa/extension-tao-task-queue/pull/104.