### PR TITLE
Feature/add cloud watch logger formatter

### DIFF
--- a/common/oatbox/log/logger/formatter/CloudWatchJsonFormatter.php
+++ b/common/oatbox/log/logger/formatter/CloudWatchJsonFormatter.php
@@ -22,8 +22,6 @@ namespace oat\oatbox\log\logger\formatter;
 
 
 use Monolog\Formatter\FormatterInterface;
-use oat\oatbox\log\logger\processor\BacktraceProcessor;
-use oat\oatbox\log\logger\processor\EnvironmentProcessorAbstract;
 
 /**
  * Json log formatter.
@@ -32,45 +30,6 @@ use oat\oatbox\log\logger\processor\EnvironmentProcessorAbstract;
  */
 class CloudWatchJsonFormatter implements FormatterInterface
 {
-    /**
-     * Used datetime format.
-     */
-    const DATETIME_FORMAT = 'd/m/Y:H:i:s O';
-
-    /**
-     * Datetime offset in the generated output.
-     */
-    const DATETIME_OFFSET = 'datetime';
-
-    /**
-     * Stack offset in the generated output.
-     */
-    const STACK_OFFSET    = 'stack';
-
-    /**
-     * Severity offset in the generated output.
-     */
-    const SEVERITY_OFFSET = 'severity';
-
-    /**
-     * Line offset in the generated output.
-     */
-    const LINE_OFFSET     = 'line';
-
-    /**
-     * File offset in the generated output.
-     */
-    const FILE_OFFSET     = 'file';
-
-    /**
-     * Content/message offset in the generated output.
-     */
-    const CONTENT_OFFSET  = 'content';
-
-    /**
-     * Backtrace offset in the generated output.
-     */
-    const TRACE_OFFSET    = 'trace';
 
     /**
      * @inheritdoc

--- a/common/oatbox/log/logger/formatter/CloudWatchJsonFormatter.php
+++ b/common/oatbox/log/logger/formatter/CloudWatchJsonFormatter.php
@@ -32,6 +32,11 @@ class CloudWatchJsonFormatter implements FormatterInterface
 {
 
     /**
+     * Used datetime format.
+     */
+    const DATETIME_FORMAT = 'd/m/Y:H:i:s O';
+
+    /**
      * @inheritdoc
      *
      * @throws \RuntimeException

--- a/common/oatbox/log/logger/formatter/CloudWatchJsonFormatter.php
+++ b/common/oatbox/log/logger/formatter/CloudWatchJsonFormatter.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2018 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\oatbox\log\logger\formatter;
+
+
+use Monolog\Formatter\FormatterInterface;
+use oat\oatbox\log\logger\processor\BacktraceProcessor;
+use oat\oatbox\log\logger\processor\EnvironmentProcessorAbstract;
+
+/**
+ * Json log formatter.
+ *
+ * @package oat\oatbox\log\logger\formatter
+ */
+class CloudWatchJsonFormatter implements FormatterInterface
+{
+    /**
+     * Used datetime format.
+     */
+    const DATETIME_FORMAT = 'd/m/Y:H:i:s O';
+
+    /**
+     * Datetime offset in the generated output.
+     */
+    const DATETIME_OFFSET = 'datetime';
+
+    /**
+     * Stack offset in the generated output.
+     */
+    const STACK_OFFSET    = 'stack';
+
+    /**
+     * Severity offset in the generated output.
+     */
+    const SEVERITY_OFFSET = 'severity';
+
+    /**
+     * Line offset in the generated output.
+     */
+    const LINE_OFFSET     = 'line';
+
+    /**
+     * File offset in the generated output.
+     */
+    const FILE_OFFSET     = 'file';
+
+    /**
+     * Content/message offset in the generated output.
+     */
+    const CONTENT_OFFSET  = 'content';
+
+    /**
+     * Backtrace offset in the generated output.
+     */
+    const TRACE_OFFSET    = 'trace';
+
+    /**
+     * @inheritdoc
+     *
+     * @throws \RuntimeException
+     */
+    public function format(array $record)
+    {
+        $jsonString = json_encode($this->getOutputRecord($record));
+
+        if ($jsonString === false) {
+            throw new \RuntimeException('Error happened during the log format process! (json encode error)');
+        }
+
+        return $jsonString . PHP_EOL;
+    }
+
+    /**
+     * @inheritdoc
+     *
+     * @throws \ErrorException
+     */
+    public function formatBatch(array $records)
+    {
+        foreach ($records as $key => $record) {
+            $records[$key] = $this->format($record);
+        }
+
+        return $records;
+    }
+
+    /**
+     * Returns the customized record.
+     *
+     * @param array $record
+     *
+     * @return array
+     */
+    protected function getOutputRecord(array $record)
+    {
+        // Adds the basic log details.
+        $output = [
+            'datetime' => $record['datetime']->format(static::DATETIME_FORMAT),
+            'severity' => $record['level_name'],
+            'message' => $record['message'],
+            'tag' => $record['context'],
+        ];
+
+        if (isset($record['extra']['trace'])) {
+            $output['trace'] = $record['extra']['trace'];
+        }
+        if (isset($record['user_id'])) {
+            $output['user_id'] = $record['user_id'];
+        }
+
+        return $output;
+    }
+}

--- a/common/oatbox/log/logger/formatter/CloudWatchJsonFormatter.php
+++ b/common/oatbox/log/logger/formatter/CloudWatchJsonFormatter.php
@@ -46,7 +46,7 @@ class CloudWatchJsonFormatter implements FormatterInterface
         $jsonString = json_encode($this->getOutputRecord($record));
 
         if ($jsonString === false) {
-            throw new \RuntimeException('Error happened during the log format process! (json encode error)');
+            throw new \RuntimeException('Error happened during the log format process! ' . json_last_error_msg());
         }
 
         return $jsonString . PHP_EOL;

--- a/common/oatbox/log/logger/handler/FluentdHandler.php
+++ b/common/oatbox/log/logger/handler/FluentdHandler.php
@@ -62,7 +62,6 @@ class FluentdHandler extends AbstractProcessingHandler
             $logRecord['level'] = Logger::getLevelName($record['level']);
             $logRecord['message'] = $record['message'];
         }
-
         $this->logger->post($record['channel'], $logRecord);
     }
 }

--- a/common/oatbox/log/logger/processor/UserIdProcessor.php
+++ b/common/oatbox/log/logger/processor/UserIdProcessor.php
@@ -20,7 +20,7 @@
 
 namespace oat\oatbox\log\logger\processor;
 
-use Psr\Log\LogLevel;
+use Monolog\Logger;
 
 /**
  * Class UserIdProcessor
@@ -35,11 +35,10 @@ class UserIdProcessor
     protected $level;
 
     /**
-     * EnvironmentProcessor constructor.
-     *
-     * @param string $level
+     * UserIdProcessor constructor.
+     * @param int $level
      */
-    public function __construct($level = LogLevel::DEBUG)
+    public function __construct($level = Logger::DEBUG)
     {
         $this->level = $level;
     }

--- a/common/oatbox/log/logger/processor/UserIdProcessor.php
+++ b/common/oatbox/log/logger/processor/UserIdProcessor.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2017 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\oatbox\log\logger\processor;
+
+use Psr\Log\LogLevel;
+
+/**
+ * Class UserIdProcessor
+ *
+ * @package oat\oatbox\log\logger\processor
+ */
+class UserIdProcessor
+{
+    /**
+     * @var string
+     */
+    protected $level;
+
+    /**
+     * EnvironmentProcessor constructor.
+     *
+     * @param string $level
+     */
+    public function __construct($level = LogLevel::DEBUG)
+    {
+        $this->level = $level;
+    }
+
+    /**
+     * @param array $record
+     * @return array
+     * @throws \common_exception_Error
+     */
+    public function __invoke(array $record)
+    {
+        // No action required when the log level is too low.
+        if ($record['level'] < $this->level) {
+            return $record;
+        }
+
+        $record['user_id'] = $this->getUserId();
+
+        return $record;
+    }
+
+    /**
+     * @return string
+     * @throws \common_exception_Error
+     */
+    private function getUserId()
+    {
+        return \common_session_SessionManager::getSession()->getUser()->getIdentifier();
+    }
+}

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.5.6',
+    'version' => '12.6.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -475,6 +475,6 @@ class Updater extends common_ext_ExtensionUpdater
             }
             $this->setVersion('12.4.1');
         }
-        $this->skip('12.4.1', '12.5.6');
+        $this->skip('12.4.1', '12.6.0');
     }
 }


### PR DESCRIPTION
Configuration example:
1. `config/generis/log.conf.php`:
``` 
return new oat\oatbox\log\LoggerService(array(
    'logger' => array(
        'class' => 'oat\\oatbox\\log\\logger\\TaoMonolog',
        'options' => array(
            'name' => 'tao.log',
            'handlers' => array(
                array(
                    'class' => \oat\oatbox\log\logger\handler\FluentdHandler::class,
                    'options' => [
                        new \Fluent\Logger\FluentLogger(
                            \Fluent\Logger\FluentLogger::DEFAULT_ADDRESS,
                            24224
                        ),
                        200
                    ],
                    'processors' => array(
                        array(
                            'class' => \oat\oatbox\log\logger\processor\UserIdProcessor::class,
                            'options' => array(
                                100
                            )
                        ),
                        array(
                            'class' => \oat\oatbox\log\logger\processor\BacktraceProcessor::class,
                            'options' => array(
                                400, // Monolog level e.q. error
                                true,
                            )
                        )
                    ),
                    'formatter' => array(
                        'class' => \oat\oatbox\log\logger\formatter\CloudWatchJsonFormatter::class,
                    ),
                ),
            ),
        )
    )
));
```

2. `/etc/td-agent/fluent.conf`
```
<source>
  @type forward
</source>
<match tao.log>
  @type cloudwatch_logs
  flush_interval 5s
  buffer_chunk_limit 1m
  buffer_queue_limit 256
  log_group_name "#{ENV['STACK']}"
  log_stream_name "#{ENV['HOST_TYPE']}/tao-log-fluent"
  auto_create_stream true
</match>
```