### PR TITLE
Fix/tao 8584/sqlkvdriver integer values

### DIFF
--- a/common/persistence/class.SqlKvDriver.php
+++ b/common/persistence/class.SqlKvDriver.php
@@ -128,7 +128,9 @@ class common_persistence_SqlKvDriver implements common_persistence_KvDriver
             $sessionValue = $this->sqlPeristence->query($statement,array($id));
             while ($row = $sessionValue->fetch()) {
                 if ($row['kv_time'] == 0 || $row['kv_time'] >= time() ) {
-                    return preg_match('/^\d+$/', $row['kv_value']) ? (int)$row['kv_value'] : base64_decode($row['kv_value']);
+                    return filter_var($row['kv_value'], FILTER_VALIDATE_INT) !== false
+                        ? (int)$row['kv_value']
+                        : base64_decode($row['kv_value']);
                 }
             }
         }

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.5.6',
+    'version' => '12.5.7',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -475,6 +475,6 @@ class Updater extends common_ext_ExtensionUpdater
             }
             $this->setVersion('12.4.1');
         }
-        $this->skip('12.4.1', '12.5.6');
+        $this->skip('12.4.1', '12.5.7');
     }
 }


### PR DESCRIPTION
Pull request summary
 
Related to : https://oat-sa.atlassian.net/browse/TAO-8584
 
KvSqkl driver should not encode integers, because it leads to incorrect increment and decrement actions, also `get` method of the driver has to return integer, instead of string for integers values, because it expected by the code that uses this.
 
#### Steps to reproduce  (for bugs)
 - set SqlKvDriver as a kv storage for the delivery execution
 - try to run delivery execution twice (because firs can be passed as it is not need to increase anything, just insert a string)
  
#### How to test

after the fix it will work as expected
 