### PR TITLE
fix/add_extension_id_to_MissingExtensionException

### DIFF
--- a/common/ext/class.Extension.php
+++ b/common/ext/class.Extension.php
@@ -451,7 +451,7 @@ class common_ext_Extension implements ServiceManagerAwareInterface
                 try {
                     $this->getExtensionManager()->getExtensionById($extId);
                 } catch (common_ext_ManifestNotFoundException $e) {
-                    throw new common_ext_MissingExtensionException($e->getExtensionId().' not found but required for '.$this->getId());
+                    throw new common_ext_MissingExtensionException($e->getExtensionId().' not found but required for '.$this->getId(), $e->getExtensionId());
                 }
             }
             

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return array(
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.6.0',
+    'version' => '12.6.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => array(),
     'models' => array(

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -475,6 +475,6 @@ class Updater extends common_ext_ExtensionUpdater
             }
             $this->setVersion('12.4.1');
         }
-        $this->skip('12.4.1', '12.6.0');
+        $this->skip('12.4.1', '12.6.1');
     }
 }


### PR DESCRIPTION
Without that fix during installation of extension with missed dependency the error message is the following:
```
An error occured during the installation of extension 'unknown'
```

With fix the message is the following:
```
An error occured during the installation of extension 'taoMonitoring'
```