### PR TITLE
Feature/nex 683/add primary key uui

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,8 @@
     "monolog/monolog": "^1.23.0",
     "fluent/logger": "^1.0.1",
     "symfony/lock": "^3.4",
-    "psr/container": "^1.0.0"
+    "psr/container": "^1.0.0",
+    "ramsey/uuid": "^3.8"
   },
   "require-dev": {
     "mikey179/vfsstream": "1.4.0",

--- a/helpers/UuidPrimaryKeyTrait.php
+++ b/helpers/UuidPrimaryKeyTrait.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @author "Julien Sébire, <julien@taotesting.com>"
+ */
+
+namespace oat\generis\Helper;
+
+use Exception;
+use Ramsey\Uuid\Uuid;
+
+trait UuidPrimaryKeyTrait
+{
+    /**
+     * Generates a unique, not auto-increment based, primary key.
+     *
+     * @return string
+     * @throws Exception
+     */
+    public function getUniquePrimaryKey()
+    {
+        return (string)Uuid::uuid4();
+    }
+}

--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.7.0',
+    'version' => '12.8.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'models' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -475,6 +475,6 @@ class Updater extends common_ext_ExtensionUpdater
             }
             $this->setVersion('12.4.1');
         }
-        $this->skip('12.4.1', '12.7.0');
+        $this->skip('12.4.1', '12.8.0');
     }
 }

--- a/test/unit/helpers/UuidPrimaryKeyHelperTest.php
+++ b/test/unit/helpers/UuidPrimaryKeyHelperTest.php
@@ -15,26 +15,26 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
  *
- * @author "Julien Sébire, <julien@taotesting.com>"
+ * @author Moyon Camille <camille@taotesting.com>
  */
 
-namespace oat\generis\Helper;
+namespace oat\generis\test\unit\helpers;
 
-use Exception;
-use Ramsey\Uuid\Uuid;
+use oat\generis\Helper\UuidPrimaryKeyTrait;
+use oat\generis\test\TestCase;
 
-trait UuidPrimaryKeyTrait
+class UuidPrimaryKeyTraitTest extends TestCase
 {
-    /**
-     * Generates a unique, not auto-increment based, primary key.
-     *
-     * @return string
-     * @throws Exception
-     */
-    public function getUniquePrimaryKey()
+    public function testGetUniquePrimaryKey()
     {
-        return (string)Uuid::uuid4();
+        $fixture = new class {
+            use UuidPrimaryKeyTrait;
+        };
+
+        $uuid = $fixture->getUniquePrimaryKey();
+        $this->assertTrue(is_string($fixture->getUniquePrimaryKey()));
+        $this->assertEquals(36, strlen($uuid));
     }
 }


### PR DESCRIPTION
This PR aims to offer to trait to easily use uuid for primary key. For that purpose, external library is used to generate: ```"ramsey/uuid": "^3.8"```