### PR TITLE
Fix/udi 53 safe handling php shotdown

### DIFF
--- a/common/class.Logger.php
+++ b/common/class.Logger.php
@@ -458,10 +458,10 @@ class common_Logger
      */
     public function handlePHPShutdown()
     {
-        
         $error = error_get_last();
-        if (($error['type'] & (E_COMPILE_ERROR | E_ERROR | E_PARSE | E_CORE_ERROR)) != 0) {
-            $msg = (isset($error['file']) && isset($error['line']))
+
+        if ($error !== null && ($error['type'] & (E_COMPILE_ERROR | E_ERROR | E_PARSE | E_CORE_ERROR)) !== 0) {
+            $msg = (isset($error['file'], $error['line']))
                ? 'php error(' . $error['type'] . ') in ' . $error['file'] . '@' . $error['line'] . ': ' . $error['message']
                : 'php error(' . $error['type'] . '): ' . $error['message'];
             self::singleton()->log(self::FATAL_LEVEL, $msg, ['PHPERROR']);

--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.12.0',
+    'version' => '12.12.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'models' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -492,5 +492,7 @@ class Updater extends common_ext_ExtensionUpdater
             }
             $this->setVersion('12.12.0');
         }
+
+        $this->skip('12.12.0', '12.12.1');
     }
 }


### PR DESCRIPTION
Related to task https://oat-sa.atlassian.net/browse/UDI-53

These changes fix the issue when PHP shutdown handler was triggered, but there were not any errors, in this case `$error` in null, but in code, it tries to get index 'type' of null object, that raises new warning in the log. It adds a more safe check for $error variable.