### PR TITLE
Fix/ACTP-295/Return correct message in common_exception_ValidationFailed excaption

### DIFF
--- a/common/exception/class.ValidationFailed.php
+++ b/common/exception/class.ValidationFailed.php
@@ -21,7 +21,6 @@
  * @access public
  * @author Gyula Szucs, <gyula@taotesting.com>
  * @package generis
-
  */
 class common_exception_ValidationFailed extends common_exception_BadRequest
 {
@@ -32,12 +31,21 @@ class common_exception_ValidationFailed extends common_exception_BadRequest
      */
     private $field;
 
+    /**
+     * common_exception_ValidationFailed constructor.
+     *
+     * @param string $field
+     * @param string|null $message
+     * @param int $code
+     */
     public function __construct($field, $message = null, $code = 0)
     {
         $this->field = $field;
-        if (! $message) {
-            $message = printf("Validation for field '%s' has failed.", $field);
+
+        if (!$message) {
+            $message = sprintf("Validation for field '%s' has failed.", $field);
         }
+
         parent::__construct($message, $code);
     }
 
@@ -49,6 +57,9 @@ class common_exception_ValidationFailed extends common_exception_BadRequest
         return $this->field;
     }
 
+    /**
+     * @return string
+     */
     public function getUserMessage()
     {
         return __("Validation for field '%s' has failed.", $this->field);

--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.12.1',
+    'version' => '12.12.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'models' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -493,6 +493,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('12.12.0');
         }
 
-        $this->skip('12.12.0', '12.12.1');
+        $this->skip('12.12.0', '12.12.2');
     }
 }


### PR DESCRIPTION
API's call has bad JSON data in response.
 
Related to: [https://oat-sa.atlassian.net/browse/ACTP-295](https://oat-sa.atlassian.net/browse/ACTP-295)
 
#### Changes:
- `printf` function was replaced with `sprintf`.
 
#### Steps to reproduce (with Postman):
- method: **POST**
- Request URL: `[[ API_URL ]]/taoTestTaker/api/testTakers`
- use authorization `Basic` and pass your admin credentials;
- use the following headers:
```
Accept:application/json
```
- use the following body params (x-www-form-urlencoded):
```
userLanguage:Invalid_Lng
login:[[ LOGIN ]]
password:[[ PASSWORD ]]
```
- press `Send`.
  
#### How to test
**Bug**: response will contain text + JSON data. Example:
```
Validation for field 'http: //www.tao.lu/Ontologies/generis.rdf#userUILg' has failed.Validation for field 'userLanguage' has failed.{"success":false,"errorCode":0,"errorMsg":"Validation for field 'userLanguage' has failed.","version":"3.4.0-sprint12*"}
```

**Fixed**: response will contain only JSON data. Example:
```
{
    "success": false,
    "errorCode": 0,
    "errorMsg": "Validation for field 'userLanguage' has failed.",
    "version": "3.4.0-sprint12*"
}
```

#### Test commands (**Requires companion PRs**):
sudo -u www-data vendor/bin/phpunit taoTestTaker/test/integration/RestTestTakerTest.php --filter=testCreateTestTakerWithInvalidField

#### Dependencies
   
Companion PR :
 - [ ] [https://github.com/oat-sa/tao-core/pull/2417](https://github.com/oat-sa/tao-core/pull/2417)
 - [ ] [https://github.com/oat-sa/extension-tao-testtaker/pull/144](https://github.com/oat-sa/extension-tao-testtaker/pull/144)