### PR TITLE
Feature/tdr 1/phpunit8 upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
   },
   "require-dev": {
     "mikey179/vfsstream": "1.4.0",
-    "phpunit/phpunit": "^4.8",
+    "phpunit/phpunit": "^8.5",
     "php-mock/php-mock": "^2.0",
     "symfony/cache": "~4.1"
   },

--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.14.1',
+    'version' => '12.15.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'models' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -493,6 +493,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('12.12.0');
         }
 
-        $this->skip('12.12.0', '12.14.1');
+        $this->skip('12.12.0', '12.15.0');
     }
 }

--- a/test/GenerisPhpUnitTestRunner.php
+++ b/test/GenerisPhpUnitTestRunner.php
@@ -42,15 +42,15 @@ abstract class GenerisPhpUnitTestRunner extends TestCase
      * @var boolean
      */
     private static $connected = false;
-    
+
     private $config;
-    
+
     private $files = [];
 
     /**
      * @inheritdoc
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::loadGenerisConfig();
     }
@@ -68,21 +68,21 @@ abstract class GenerisPhpUnitTestRunner extends TestCase
             $tmpfname = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $name;
         }
         $this->files[] = $tmpfname;
-    
+
         if (!empty($pContent)) {
             $handle = fopen($tmpfname, "w");
             fwrite($handle, $pContent);
             fclose($handle);
         }
-    
+
         return $tmpfname;
     }
-    
+
     protected function getSampleDir()
     {
         return __DIR__ . '/samples';
     }
-    
+
     /**
      * Cleanup of files
      * @see SimpleTestCase::after()
@@ -106,12 +106,12 @@ abstract class GenerisPhpUnitTestRunner extends TestCase
             self::$connected = true;
         }
     }
-    
+
     public function restoreTestSession()
     {
         return common_session_SessionManager::startSession(new common_test_TestUserSession());
     }
-    
+
     /**
      *
      * @author Lionel Lecaque, lionel@taotesting.com
@@ -123,7 +123,7 @@ abstract class GenerisPhpUnitTestRunner extends TestCase
     {
         $this->assertInstanceOf($className, $var);
     }
-    
+
     public function installExtension($extid)
     {
         if (!common_ext_ExtensionsManager::singleton()->isInstalled($extid)) {
@@ -132,7 +132,7 @@ abstract class GenerisPhpUnitTestRunner extends TestCase
             $installer->install();
         }
     }
-    
+
     public function uninstallExtension($extid)
     {
         if (common_ext_ExtensionsManager::singleton()->isInstalled($extid)) {
@@ -141,7 +141,7 @@ abstract class GenerisPhpUnitTestRunner extends TestCase
             $installer->uninstall();
         }
     }
-    
+
     protected function disableCache()
     {
         $ext = common_ext_ExtensionsManager::singleton()->getExtensionById('generis') ;
@@ -150,7 +150,7 @@ abstract class GenerisPhpUnitTestRunner extends TestCase
         if (isset($conf['cache']) && isset($conf['cache']['driver'])) {
             $conf['cache']['driver'] = 'no_storage';
             \common_Logger::i('Set cache on NO STORAGE');
-        
+
             $ext->setConfig(_common_persistence_Manager::SERVICE_ID, $conf);
         }
     }

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -28,14 +28,6 @@ use PHPUnit\Framework\TestCase as UnitTestCase;
 abstract class TestCase extends UnitTestCase
 {
     use SqlMockTrait;
-    /**
-     * Forward compatibility function for PHPUnit 7.0
-     * @param string $exception
-     */
-    public function expectException($exception)
-    {
-        $this->setExpectedException($exception);
-    }
 
     /**
      * @param array $services
@@ -52,43 +44,5 @@ abstract class TestCase extends UnitTestCase
 
         return $serviceLocatorProphecy->reveal();
     }
-
-    /**
-     * Forward compatibility function for PHPUnit 5.4+
-     *
-     * Returns a test double for the specified class.
-     *
-     * @param string $originalClassName
-     * @return MockObject
-     * @throws \PHPUnit_Framework_Exception
-     * @since Method available since Release 5.4.0
-     */
-    protected function createMock($originalClassName)
-    {
-        return $this->getMockBuilder($originalClassName)
-            ->disableOriginalConstructor()
-            ->disableOriginalClone()
-            ->disableArgumentCloning()
-            ->getMock();
-    }
-
-    /**
-     * Forward compatibility function for PHPUnit 5.4+
-     *
-     * Returns a partial test double for the specified class.
-     *
-     * @param string $originalClassName
-     * @param array $methods
-     * @return MockObject
-     * @since Method available since Release 5.4.0
-     */
-    protected function createPartialMock($originalClassName, array $methods = [])
-    {
-        return $this->getMockBuilder($originalClassName)
-            ->disableOriginalConstructor()
-            ->disableOriginalClone()
-            ->disableArgumentCloning()
-            ->setMethods($methods)
-            ->getMock();
-    }
+    
 }

--- a/test/integration/ApiModelTest.php
+++ b/test/integration/ApiModelTest.php
@@ -34,23 +34,23 @@ class ApiModelTest extends GenerisPhpUnitTestRunner
     {
         parent::__construct();
     }
-    
+
     /**
      * Setting the Api to test
      *
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         GenerisPhpUnitTestRunner::initTest();
-        
+
         $this->object = core_kernel_impl_ApiModelOO::singleton();
     }
-    
+
     public function testGetRootClass()
     {
         $localModel = common_ext_NamespaceManager::singleton()->getLocalNamespace()->getUri();
         $this->assertFalse(empty($localModel));
-        
+
         $rootClasses = $this->object->getRootClasses();
         $this->assertInstanceOf('common_Collection', $rootClasses);
         $expectedResult =   [
@@ -59,14 +59,14 @@ class ApiModelTest extends GenerisPhpUnitTestRunner
             OntologyRdfs::RDFS_RESOURCE,
             WidgetRdf::CLASS_URI_WIDGET_RENDERER
         ];
-        
+
         $pattern = "/^" . preg_quote($localModel, '/') . "/";
         foreach ($rootClasses->getIterator() as $rootClass) {
             $this->assertInstanceOf('core_kernel_classes_Class', $rootClass);
-            
+
             $parentClasses = $rootClass->getParentClasses(true);
             $this->assertEquals(0, count($parentClasses));
-            
+
             $types = $rootClass->getTypes(true);
             $this->assertEquals(1, count($types));
             foreach ($types as $uri => $parent) {
@@ -78,7 +78,7 @@ class ApiModelTest extends GenerisPhpUnitTestRunner
             }
         }
     }
-    
+
     public function testGetMetaClasses()
     {
         $metaClasses = $this->object->getMetaClasses();
@@ -91,7 +91,7 @@ class ApiModelTest extends GenerisPhpUnitTestRunner
             }
         }
     }
-    
+
     public function testSetStatement()
     {
         $true = new core_kernel_classes_Resource(GenerisRdf::GENERIS_TRUE, __METHOD__);
@@ -101,10 +101,10 @@ class ApiModelTest extends GenerisPhpUnitTestRunner
             $this->object->setStatement($true->getUri(), $predicate, 'test', DEFAULT_LANG),
             "setStatement should be able to set a value."
         );
-        
+
         $values = $true->getPropertyValues($property);
         $this->assertTrue(count($values) > 0);
-        
+
         $tripleFound = false;
         foreach ($values as $value) {
             if (!common_Utils::isUri($value) && $value == 'test') {
@@ -112,13 +112,13 @@ class ApiModelTest extends GenerisPhpUnitTestRunner
                 break;
             }
         }
-        
+
         $this->assertTrue($tripleFound, "A property value for property " . $property->getUri() .
                                         " should be found for resource " . $true->getUri());
-        
+
         $this->object->removeStatement($true->getUri(), $predicate, 'test', DEFAULT_LANG);
     }
-    
+
     public function testRemoveStatement()
     {
         $true = new core_kernel_classes_Resource(GenerisRdf::GENERIS_TRUE, __METHOD__);
@@ -130,7 +130,7 @@ class ApiModelTest extends GenerisPhpUnitTestRunner
         $value = $true->getPropertyValuesCollection($property);
         $this->assertTrue($value->isEmpty());
     }
-    
+
     public function testGetSubject()
     {
         $set = $this->object->getSubject(OntologyRdfs::RDFS_LABEL, 'True');

--- a/test/integration/ClassTest.php
+++ b/test/integration/ClassTest.php
@@ -36,8 +36,8 @@ use oat\generis\test\GenerisPhpUnitTestRunner;
 class ClassTest extends GenerisPhpUnitTestRunner
 {
     protected $object;
-    
-    protected function setUp()
+
+    protected function setUp(): void
     {
 
         GenerisPhpUnitTestRunner::initTest();
@@ -45,25 +45,25 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $this->object = new core_kernel_classes_Class(OntologyRdfs::RDFS_RESOURCE);
         $this->object->debug = __METHOD__;
     }
-    
+
     public function testGetSubClasses()
     {
 
         $generisResource = new core_kernel_classes_Class(GenerisRdf::CLASS_GENERIS_RESOURCE);
-    
+
         $subClass0 = $generisResource->createSubClass('test0', 'test0 Comment');
         $subClass1 = $subClass0->createSubClass('test1', 'test1 Comment');
 
-    
+
         $subClass2 = $subClass0->createSubClass('test2', 'test2 Comment');
         $subClass3 = $subClass2->createSubClass('test3', 'test3 Comment');
         $subClass4 = $subClass3->createSubClass('test4', 'test4 Comment');
-        
+
         $subClassesArray = $subClass0->getSubClasses();
         foreach ($subClassesArray as $subClass) {
             $this->assertTrue($subClass->isSubClassOf($subClass0));
         }
-        
+
         $subClassesArray2 = $subClass0->getSubClasses(true);
         foreach ($subClassesArray2 as $subClass) {
             if ($subClass->getLabel() == 'test1') {
@@ -100,7 +100,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
             $this->assertInstanceOf('core_kernel_classes_Class', $parentClass);
             $this->assertTrue(in_array($parentClass->getUri(), $expectedResult));
         }
-        
+
         $directParentClass = $class->getParentClasses();
         $this->assertEquals(1, count($directParentClass));
         foreach ($directParentClass as $parentClass) {
@@ -108,9 +108,9 @@ class ClassTest extends GenerisPhpUnitTestRunner
             $this->assertEquals(GenerisRdf::CLASS_GENERIS_RESOURCE, $parentClass->getUri());
         }
     }
-    
 
-    
+
+
 
     public function testGetProperties()
     {
@@ -118,7 +118,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $properties = $list->getProperties();
         $this->assertTrue(count($properties) == 2);
         $expectedResult =  [   OntologyRdf::RDF_FIRST, OntologyRdf::RDF_REST];
-    
+
         foreach ($properties as $property) {
             $this->assertTrue($property instanceof core_kernel_classes_Property);
             $this->assertTrue(in_array($property->getUri(), $expectedResult));
@@ -133,18 +133,18 @@ class ClassTest extends GenerisPhpUnitTestRunner
                 $this->assertEquals($property->getComment(), 'The rest of the subject RDF list after the first item.');
             }
         }
-        
-        
+
+
         $class = $list->createSubClass('toto', 'toto');
         $properties2 = $class->getProperties(true);
         $this->assertFalse(empty($properties2));
-        
+
         $class->delete();
     }
 
-    
 
-    
+
+
     public function testGetInstances()
     {
         $class = new core_kernel_classes_Class(WidgetRdf::CLASS_URI_WIDGET);
@@ -152,13 +152,13 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $instances = $class->getInstances();
         $subclass = $class->createSubClass('subTest Class', 'subTest Class');
         $subclassInstance = $subclass->createInstance('test3', 'comment3');
-        
+
 
         $this->assertTrue(count($instances)  > 0);
 
         foreach ($instances as $k => $instance) {
             $this->assertTrue($instance instanceof core_kernel_classes_Resource);
-                        
+
             if ($instance->getUri() === WidgetRdf::PROPERTY_WIDGET_COMBO) {
                 $this->assertEquals($instance->getLabel(), 'Drop down menu');
                 $this->assertEquals($instance->getComment(), 'In drop down menu, one may select 1 to N options');
@@ -180,7 +180,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
                 $this->assertEquals($instance->getComment(), 'comment3');
             }
         }
-        
+
         $instances2 = $class->getInstances(true);
         $this->assertTrue(count($instances2)  > 0);
         foreach ($instances2 as $k => $instance) {
@@ -210,14 +210,14 @@ class ClassTest extends GenerisPhpUnitTestRunner
                 $this->assertEquals($instance->getComment(), 'comment');
             }
         }
-        
+
         $plop->delete();
         $subclass->delete();
         $subclassInstance->delete();
     }
-    
-    
-    
+
+
+
     public function testIsSubClassOf()
     {
         $class = new core_kernel_classes_Class(GenerisRdf::GENERIS_BOOLEAN);
@@ -228,25 +228,25 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $this->assertTrue($subClass->isSubClassOf(new core_kernel_classes_Class(GenerisRdf::CLASS_GENERIS_RESOURCE)));
         $subClass->delete();
     }
-    
 
-    
+
+
     public function testSetSubClasseOf()
     {
         $class = new core_kernel_classes_Class('http://www.tao.lu/Ontologies/generis.rdf#Boolean');
         $subClass = $class->createSubClass('test', 'test');
         $subClass1 = $subClass->createSubClass('subclass of test', 'subclass of test');
         $subClass2 = $subClass->createSubClass('subclass of test2', 'subclass of test2');
-        
+
         $this->assertTrue($subClass->isSubClassOf($class));
         $this->assertTrue($subClass1->isSubClassOf($class));
         $this->assertTrue($subClass2->isSubClassOf($class));
-        
+
         $this->assertFalse($subClass2->isSubClassOf($subClass1));
         $subClass2->setSubClassOf($subClass1);
         $this->assertTrue($subClass2->isSubClassOf($subClass1));
 
-        
+
         $subClass->delete();
         $subClass1->delete();
         $subClass2->delete();
@@ -263,7 +263,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $instance->delete();
         $instance2->delete();
     }
-    
+
     public function testCreateSubClass()
     {
         $class = new core_kernel_classes_Class('http://www.tao.lu/Ontologies/generis.rdf#Boolean');
@@ -291,13 +291,13 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $property->delete();
         $property2->delete();
     }
-        
+
         /**
          * @group SearchInstances
          */
     public function testSearchInstances()
     {
-        
+
         $instance = $this->getMockForAbstractClass(
             \core_kernel_classes_Class::class,
             [],
@@ -307,27 +307,27 @@ class ClassTest extends GenerisPhpUnitTestRunner
             true,
             ['getImplementation']
         );
-        
+
         $mockResult = new \ArrayIterator([1,2,3,4,5,6]);
-        
+
         $propertyFilter = [
             GenerisRdf::PROPERTY_IS_LG_DEPENDENT => GenerisRdf::GENERIS_TRUE
         ];
-        
+
         $options = ['like' => false, 'recursive' => false];
-       
+
         $prophetImplementation = $this->prophesize(\core_kernel_persistence_smoothsql_Class::class);
-        
+
         $prophetImplementation
                 ->searchInstances($instance, $propertyFilter, $options)
                 ->willReturn($mockResult);
-        
+
         $ImplementationMock = $prophetImplementation->reveal();
-        
+
         $instance->expects($this->once())->method('getImplementation')->willReturn($ImplementationMock);
         $this->assertSame([1,2,3,4,5,6], $instance->searchInstances($propertyFilter, $options));
     }
-    
+
     //Test search instances with a model shared between smooth and hard implentation
     public function testSearchInstancesMultipleImpl()
     {
@@ -338,7 +338,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $sub2ClazzInstance = $sub2Clazz->createInstance('test case instance');
         $sub3Clazz = $sub2Clazz->createSubClass();
         $sub3ClazzInstance = $sub3Clazz->createInstance('test case instance');
-        
+
         $options = [
             'recursive'             => true,
             'append'                => true,
@@ -346,7 +346,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
             'referencesAllTypes'            => true,
             'rmSources'             => true
         ];
-        
+
         //Test the search instances on the smooth impl
         $propertyFilter = [
             OntologyRdfs::RDFS_LABEL => 'test case instance'
@@ -364,7 +364,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $sub2Clazz->delete(true);
         $sub3Clazz->delete(true);
     }
-    
+
     //Test the function getInstancesPropertyValues of the class Class with literal properties
     public function testGetInstancesPropertyValuesWithLiteralProperties()
     {
@@ -392,7 +392,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $i2->setPropertyValue($p2, "p22 litteral");
         $i2->setPropertyValue($p3, "p31 litteral");
         $i2->getLabel();
-        
+
         // Search * P1 for P1=P11 litteral
         // Expected 2 results, but 1 possibility
         $propertyFilters =  [
@@ -401,7 +401,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $result = $subClass->getInstancesPropertyValues($p1, $propertyFilters);
         $this->assertEquals(count($result), 2);
         $this->assertTrue(in_array("p11 litteral", $result));
-        
+
         // Search * P1 for P1=P11 litteral WITH DISTINCT options
         // Expected 1 results, and 1 possibility
         $propertyFilters =  [
@@ -410,7 +410,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $result = $subClass->getInstancesPropertyValues($p1, $propertyFilters, ["distinct" => true]);
         $this->assertEquals(count($result), 1);
         $this->assertTrue(in_array("p11 litteral", $result));
-        
+
         // Search * P2 for P1=P11 litteral WITH DISTINCT options
         // Expected 2 results, and 2 possibilities
         $propertyFilters =  [
@@ -420,7 +420,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $this->assertEquals(count($result), 2);
         $this->assertTrue(in_array("p21 litteral", $result));
         $this->assertTrue(in_array("p22 litteral", $result));
-        
+
         // Search * P2 for P1=P12 litteral WITH DISTINCT options
         // Expected 0 results, and 0 possibilities
         $propertyFilters =  [
@@ -428,7 +428,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
         ];
         $result = $subClass->getInstancesPropertyValues($p2, $propertyFilters, ["distinct" => true]);
         $this->assertEquals(count($result), 0);
-        
+
         // Search * P1 for P2=P21 litteral WITH DISTINCT options
         // Expected 1 results, and 1 possibilities
         $propertyFilters =  [
@@ -437,7 +437,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $result = $subClass->getInstancesPropertyValues($p1, $propertyFilters, ["distinct" => true]);
         $this->assertEquals(count($result), 1);
         $this->assertTrue(in_array("p11 litteral", $result));
-        
+
         // Search * P1 for P2=P22 litteral WITH DISTINCT options
         // Expected 1 results, and 1 possibilities
         $propertyFilters =  [
@@ -446,7 +446,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $result = $subClass->getInstancesPropertyValues($p1, $propertyFilters, ["distinct" => true]);
         $this->assertEquals(count($result), 1);
         $this->assertTrue(in_array("p11 litteral", $result));
-        
+
         // Search * P3 for P1=P11 & P2=P21 litteral WITH DISTINCT options
         // Expected 1 results, and 1 possibilities
         $propertyFilters =  [
@@ -456,7 +456,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $result = $subClass->getInstancesPropertyValues($p3, $propertyFilters, ["distinct" => true]);
         $this->assertEquals(count($result), 1);
         $this->assertTrue(in_array("p31 litteral", $result));
-        
+
         // Search * P2 for P1=P11 & P3=P31 litteral WITH DISTINCT options
         // Expected 2 results, and 2 possibilities
         $propertyFilters =  [
@@ -467,18 +467,18 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $this->assertEquals(count($result), 2);
         $this->assertTrue(in_array("p21 litteral", $result));
         $this->assertTrue(in_array("p22 litteral", $result));
-        
+
         // Clean the model
         $i1->delete();
         $i2->delete();
-        
+
         $p1->delete();
         $p2->delete();
         $p3->delete();
-        
+
         $subClass->delete();
     }
-    
+
     //Test the function getInstancesPropertyValues of the class Class  with resource properties
     public function testGetInstancesPropertyValuesWithResourceProperties()
     {
@@ -506,7 +506,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $i2->setPropertyValue($p2, new core_kernel_classes_Class(GenerisRdf::GENERIS_FALSE));
         $i2->setPropertyValue($p3, "p31 litteral");
         $i2->getLabel();
-        
+
         // Search * P1 for P1=GenerisRdf::GENERIS_TRUE
         // Expected 2 results, but 1 possibility
         $propertyFilters =  [
@@ -525,7 +525,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $result = $subClass->getInstancesPropertyValues($p1, $propertyFilters, ["distinct" => true]);
         $this->assertEquals(count($result), 1);
         $this->assertTrue($result[0]->getUri() == GenerisRdf::GENERIS_TRUE);
-        
+
         // Search * P2 for P1=GenerisRdf::GENERIS_TRUE WITH DISTINCT options
         // Expected 2 results, and 2 possibilities
         $propertyFilters =  [
@@ -536,7 +536,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
         foreach ($result as $property) {
             $this->assertTrue($property->getUri() == GenerisRdf::GENERIS_TRUE || $property->getUri() == GenerisRdf::GENERIS_FALSE);
         }
-        
+
         // Search * P2 for P1=NotExistingProperty litteral WITH DISTINCT options
         // Expected 1 results, and 1 possibilities
         $propertyFilters =  [
@@ -544,7 +544,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
         ];
         $result = $subClass->getInstancesPropertyValues($p2, $propertyFilters, ["distinct" => true]);
         $this->assertEquals(count($result), 0);
-        
+
         // Search * P1 for P2=GenerisRdf::GENERIS_TRUE litteral WITH DISTINCT options
         // Expected 1 results, and 1 possibilities
         $propertyFilters =  [
@@ -553,7 +553,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $result = $subClass->getInstancesPropertyValues($p1, $propertyFilters, ["distinct" => true]);
         $this->assertEquals(count($result), 1);
         $this->assertTrue($result[0]->getUri() == GenerisRdf::GENERIS_TRUE);
-        
+
         // Search * P1 for P2=GenerisRdf::GENERIS_FALSE WITH DISTINCT options
         // Expected 1 results, and 1 possibilities
         $propertyFilters =  [
@@ -562,7 +562,7 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $result = $subClass->getInstancesPropertyValues($p1, $propertyFilters, ["distinct" => true]);
         $this->assertEquals(count($result), 1);
         $this->assertTrue($result[0]->getUri() == GenerisRdf::GENERIS_TRUE);
-        
+
         // Search * P3 for P1=GenerisRdf::GENERIS_TRUE & P2=GenerisRdf::GENERIS_TRUE litteral WITH DISTINCT options
         // Expected 1 results, and 1 possibilities
         $propertyFilters =  [
@@ -584,60 +584,60 @@ class ClassTest extends GenerisPhpUnitTestRunner
         foreach ($result as $property) {
             $this->assertTrue($property->getUri() == GenerisRdf::GENERIS_TRUE || $property->getUri() == GenerisRdf::GENERIS_FALSE);
         }
-        
+
         // Clean the model
         $i1->delete();
         $i2->delete();
-        
+
         $p1->delete();
         $p2->delete();
         $p3->delete();
-        
+
         $subClass->delete();
     }
-    
+
     public function testDeleteInstances()
     {
         $taoClass = new core_kernel_classes_Class(GenerisRdf::CLASS_GENERIS_RESOURCE);
         $creativeWorkClass = $taoClass->createSubClass('Creative Work');
         $authorProperty = $taoClass->createProperty('Author');
         $relatedWorksProperty = $creativeWorkClass->createProperty('Related Works');
-        
+
         $bookLotr = $creativeWorkClass->createInstance('The Lord of The Rings (book)');
         $bookLotr->setPropertyValue($authorProperty, 'J.R.R. Tolkien');
-        
+
         $movieLotr = $creativeWorkClass->createInstance('The Lord of The Rings (movie)');
         $movieLotr->setPropertyValue($authorProperty, 'Peter Jackson');
-        
+
         $movieLotr->setPropertyValue($relatedWorksProperty, $bookLotr);
         $bookLotr->setPropertyValue($relatedWorksProperty, $movieLotr);
-        
+
         $movieMinorityReport = $creativeWorkClass->createInstance('Minority Report');
         $movieMinorityReport->setPropertyValue($authorProperty, 'Steven Spielberg');
 
         $this->assertEquals(count($creativeWorkClass->getInstances()), 3);
-        
+
         // delete the LOTR movie with its references.
         $relatedWorks = $bookLotr->getPropertyValuesCollection($relatedWorksProperty);
         $this->assertEquals($relatedWorks->sequence[0]->getLabel(), 'The Lord of The Rings (movie)');
         $creativeWorkClass->deleteInstances([$movieLotr], true);
         $relatedWorks = $bookLotr->getPropertyValues($relatedWorksProperty);
         $this->assertEquals(count($relatedWorks), 0);
-        
+
         // Only 1 resource deleted ?
         $this->assertFalse($movieLotr->exists());
         $this->assertTrue($bookLotr->exists());
         $this->assertTrue($movieMinorityReport->exists());
-        
+
         // Remove the rest.
         $creativeWorkClass->deleteInstances([$bookLotr, $movieMinorityReport]);
         $this->assertEquals(count($creativeWorkClass->getInstances()), 0);
         $this->assertFalse($bookLotr->exists());
         $this->assertFalse($movieMinorityReport->exists());
-        
+
         $this->assertTrue($authorProperty->delete());
         $this->assertTrue($relatedWorksProperty->delete());
-        
+
         $creativeWorkClass->delete(true);
     }
 }

--- a/test/integration/ComplexSearchTest.php
+++ b/test/integration/ComplexSearchTest.php
@@ -25,33 +25,33 @@ use oat\oatbox\service\ServiceManager;
 
 class ComplexSearchTest extends GenerisPhpUnitTestRunner
 {
-   
+
     private $search;
-    
-    protected function setUp()
+
+    protected function setUp(): void
     {
         GenerisPhpUnitTestRunner::initTest();
 
         $this->object = new core_kernel_classes_Class(OntologyRdfs::RDFS_RESOURCE);
         $this->object->debug = __METHOD__;
-        
+
         $this->search = ServiceManager::getServiceManager()->get(\oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService::SERVICE_ID);
     }
-    
+
     public function testRandomized()
     {
         $queryBuilder = $this->search->query();
         $query = $this->search->searchType($queryBuilder, 'http://www.w3.org/2000/01/rdf-schema#Resource', true);
         $queryBuilder->setCriteria($query)->setRandom();
         $queryBuilder->setCriteria($query)->setLimit(10);
-        
+
         // Initial call
         $result = $result = $this->search->getGateway()->search($queryBuilder);
         $pickup = [];
         foreach ($result as $r) {
             $pickup[] = $r->getUri();
         }
-        
+
         for ($i = 0; $i < 10; $i++) {
             // Leave when result different from initial one.
             $result = $result = $this->search->getGateway()->search($queryBuilder);
@@ -59,12 +59,12 @@ class ComplexSearchTest extends GenerisPhpUnitTestRunner
             foreach ($result as $r) {
                 $newPickup[] = $r->getUri();
             }
-            
+
             if ($pickup !== $newPickup) {
                 break;
             }
         }
-        
+
         if ($i >= 10) {
             $this->fail('The Complex Search API randomization failed.');
         } else {

--- a/test/integration/ConfigurationTest.php
+++ b/test/integration/ConfigurationTest.php
@@ -37,7 +37,7 @@ class ConfigurationTest extends GenerisPhpUnitTestRunner
      */
     const UNSUPPORTED_PHP_MAJOR_VERSION = 9;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         GenerisPhpUnitTestRunner::initTest();
     }

--- a/test/integration/CreateInstanceTest.php
+++ b/test/integration/CreateInstanceTest.php
@@ -35,8 +35,8 @@ use oat\generis\test\GenerisPhpUnitTestRunner;
 class CreateInstanceTest extends GenerisPhpUnitTestRunner
 {
     protected $class;
-    
-    protected function setUp()
+
+    protected function setUp(): void
     {
 
         GenerisPhpUnitTestRunner::initTest();
@@ -46,7 +46,7 @@ class CreateInstanceTest extends GenerisPhpUnitTestRunner
         $this->assertTrue($this->class->hasType(new core_kernel_classes_Class(OntologyRdfs::RDFS_CLASS)));
         common_Logger::i('using class ' . $this->class->getUri() . ' for Create instance Tests');
     }
-    
+
     public function testCreateInstance()
     {
         $class = $this->class;
@@ -58,7 +58,7 @@ class CreateInstanceTest extends GenerisPhpUnitTestRunner
         $instance->delete();
         $instance2->delete();
     }
-    
+
     public function testCreateInstanceViaFactory()
     {
         $class = $this->class;
@@ -72,29 +72,29 @@ class CreateInstanceTest extends GenerisPhpUnitTestRunner
         $instance->delete();
         $instance2->delete();
     }
-    
+
     public function testCreateInstanceWithProperties()
     {
-        
+
         // simple case, without params
 
         $class          = $this->class;
         $litproperty    = new core_kernel_classes_Property(core_kernel_classes_ResourceFactory::create(new core_kernel_classes_Class(OntologyRdf::RDF_PROPERTY))->getUri());
         $property       = new core_kernel_classes_Property(core_kernel_classes_ResourceFactory::create(new core_kernel_classes_Class(OntologyRdf::RDF_PROPERTY))->getUri());
-        
+
         $instance = $class->createInstanceWithProperties([]);
         $this->assertTrue($instance->hasType($class));
-        
+
         // simple literal properties
         $instance1 = $class->createInstanceWithProperties([
             OntologyRdfs::RDFS_LABEL        => 'testlabel',
             OntologyRdfs::RDFS_COMMENT  => 'testcomment'
         ]);
-        
+
         $this->assertTrue($instance1->hasType($class));
         $this->assertEquals($instance1->getLabel(), 'testlabel');
         $this->assertEquals($instance1->getComment(), 'testcomment');
-        
+
         // multiple literal properties
         $instance2 = $class->createInstanceWithProperties([
             OntologyRdfs::RDFS_LABEL                => 'testlabel',
@@ -105,7 +105,7 @@ class CreateInstanceTest extends GenerisPhpUnitTestRunner
         $comments = $instance2->getPropertyValues($litproperty);
         sort($comments);
         $this->assertEquals($comments, ['testlit1', 'testlit2']);
-        
+
         // single ressource properties
         $propInst = core_kernel_classes_ResourceFactory::create($class);
         $instance3 = $class->createInstanceWithProperties([
@@ -117,7 +117,7 @@ class CreateInstanceTest extends GenerisPhpUnitTestRunner
         $this->assertEquals($instance3->getLabel(), 'testlabel');
         $propActual = $instance3->getUniquePropertyValue($property); // returns a ressource
         $this->assertEquals($propInst->getUri(), $propActual->getUri());
-        
+
         // multiple ressource properties
         $propInst2 = core_kernel_classes_ResourceFactory::create($class);
         $instance4 = $class->createInstanceWithProperties([
@@ -127,30 +127,30 @@ class CreateInstanceTest extends GenerisPhpUnitTestRunner
         ]);
         $this->assertTrue($instance4->hasType($class));
         $this->assertEquals($instance4->getLabel(), 'testlabel');
-        
+
         $propActual = array_values($instance4->getPropertyValues($property));// returns uris
         $propNormative = [$propInst->getUri(), $propInst2->getUri()];
         sort($propActual);
         sort($propNormative);
         $this->assertEquals($propActual, $propNormative);
-        
+
         // multiple classes
         $classres = core_kernel_classes_ResourceFactory::create(new core_kernel_classes_Class(OntologyRdfs::RDFS_CLASS), 'TestClass2');
         $class2 = new core_kernel_classes_Class($classres);
         $classres = core_kernel_classes_ResourceFactory::create(new core_kernel_classes_Class(OntologyRdfs::RDFS_CLASS), 'TestClass3');
         $class3 = new core_kernel_classes_Class($classres);
-        
+
         // 2 classes (by ressource)
         $instance5 = $class->createInstanceWithProperties([
             OntologyRdfs::RDFS_LABEL            => 'testlabel5',
             OntologyRdf::RDF_TYPE           => $classres
         ]);
 
-        
+
         $this->assertTrue($instance5->hasType($class));
         $this->assertTrue($instance5->hasType($class3));
         $this->assertEquals($instance5->getLabel(), 'testlabel5');
-        
+
         // 3 classes (by uri + class)
         $instance6 = $class->createInstanceWithProperties([
             OntologyRdfs::RDFS_LABEL            => 'testlabel6',
@@ -160,22 +160,22 @@ class CreateInstanceTest extends GenerisPhpUnitTestRunner
         $this->assertTrue($instance6->hasType($class2));
         $this->assertTrue($instance6->hasType($class3));
         $this->assertEquals($instance6->getLabel(), 'testlabel6');
-        
+
         $instance->delete();
         $instance1->delete();
         $instance2->delete();
-        
+
         $propInst->delete();
         $propInst2->delete();
         $property->delete();
         $litproperty->delete();
-        
+
         $instance5->delete();
         $instance6->delete();
         $class2->delete();
         $class3->delete();
     }
-    
+
     public function after($pMethode)
     {
         common_Logger::i('Cleaning up class ' . $this->class->getUri() . ' for Create instance Tests');

--- a/test/integration/DbWrapperTest.php
+++ b/test/integration/DbWrapperTest.php
@@ -32,7 +32,7 @@ use oat\generis\test\GenerisPhpUnitTestRunner;
 class DbWrapperTest extends GenerisPhpUnitTestRunner
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
         GenerisPhpUnitTestRunner::initTest();
         $dbWrapper = core_kernel_classes_DbWrapper::singleton();
@@ -108,23 +108,23 @@ class DbWrapperTest extends GenerisPhpUnitTestRunner
             $this->assertTrue($value['coluMn1'] == 'value' . $i);
         }
     }
-    
+
 
     public function testCreateIndex()
     {
         $dbWrapper = core_kernel_classes_DbWrapper::singleton();
         $dbWrapper->getSchemaManager();
-        
+
         $schema = new \Doctrine\DBAL\Schema\Schema();
         $table = $schema->createTable('dbtestcase2');
         $table->addColumn("id", "integer", ["notnull" => true,"autoincrement" => true]);
         $table->setPrimaryKey(["id"]);
         $table->addColumn("uri", "string", ["length" => 255, "notnull" => true]);
         $table->addColumn("content", "text", ["notnull" => false]);
-        
-        
+
+
         $sql = $dbWrapper->getPlatform()->schemaToSql($schema);
-        
+
 
         foreach ($sql as $q) {
             $dbWrapper->exec($q);
@@ -135,11 +135,11 @@ class DbWrapperTest extends GenerisPhpUnitTestRunner
         foreach ($indexes as $index) {
             $this->assertTrue(in_array($index->getName(), ['idx_content','dbtestcase2_pkey','PRIMARY']), $index->getName() . 'is missing');
         }
-        
+
         $dbWrapper->exec('DROP TABLE dbtestcase2');
     }
-    
-    protected function tearDown()
+
+    protected function tearDown(): void
     {
         $dbWrapper = core_kernel_classes_DbWrapper::singleton();
         //TODO need to connect to a dbWrapper a function dropTable that currently not exists

--- a/test/integration/ExceptionTest.php
+++ b/test/integration/ExceptionTest.php
@@ -24,12 +24,12 @@ use oat\generis\test\GenerisPhpUnitTestRunner;
 
 class ExceptionTest extends GenerisPhpUnitTestRunner
 {
-    
-    public function setUp()
+
+    public function setUp(): void
     {
         GenerisPhpUnitTestRunner::initTest();
     }
-    
+
     // Method used in the testInvalidArgumentTypeException
     private function wrongArgumentType($object)
     {
@@ -41,7 +41,7 @@ class ExceptionTest extends GenerisPhpUnitTestRunner
             throw new common_exception_InvalidArgumentType(__CLASS__, __METHOD__, 1, 'common_Object', $object);
         }
     }
-    
+
     public function testInvalidArgumentTypeException()
     {
         try {

--- a/test/integration/GenerisIteratorTest.php
+++ b/test/integration/GenerisIteratorTest.php
@@ -25,18 +25,18 @@ use oat\generis\model\GenerisRdf;
 
 class GenerisIteratorTest extends GenerisPhpUnitTestRunner
 {
-    
+
     /**
      * @var core_kernel_classes_Class
      */
     private $topClass;
-    
+
     /**
      * @var core_kernel_classes_Class
      */
     private $emptyClass;
-    
-    public function setUp()
+
+    public function setUp(): void
     {
         GenerisPhpUnitTestRunner::initTest();
         $class = new core_kernel_classes_Class(GenerisRdf::CLASS_GENERIS_RESOURCE);
@@ -45,9 +45,9 @@ class GenerisIteratorTest extends GenerisPhpUnitTestRunner
         $class1a = $this->topClass->createSubClass('test class 1a');
         $class1b = $this->topClass->createSubClass('test class 1b');
         $class1c = $this->topClass->createSubClass('test class 1c');
-        
+
         $class1c1 = $class1c->createSubClass('test class 1c1');
-         
+
         $instance1_1 = $this->topClass->createInstance('test instance 1.1');
         $instance1_2 = $this->topClass->createInstance('test instance 1.2');
         $instance1_3 = $this->topClass->createInstance('test instance 1.3');
@@ -56,8 +56,8 @@ class GenerisIteratorTest extends GenerisPhpUnitTestRunner
         $instance1c1_1 = $class1c1->createInstance('test instance 1c1.1');
         $instance1c1_2 = $class1c1->createInstance('test instance 1c1.2');
     }
-    
-    public function tearDown()
+
+    public function tearDown(): void
     {
         foreach ($this->topClass->getInstances(true) as $instance) {
             $instance->delete();
@@ -68,7 +68,7 @@ class GenerisIteratorTest extends GenerisPhpUnitTestRunner
         $this->topClass->delete();
         $this->emptyClass->delete();
     }
-    
+
     public function testClassIterator()
     {
         $expected = [$this->topClass->getUri()];
@@ -76,20 +76,20 @@ class GenerisIteratorTest extends GenerisPhpUnitTestRunner
             $expected[] = $resource->getUri();
         }
         sort($expected);
-        
+
         $iterator = new core_kernel_classes_ClassIterator($this->topClass);
-         
+
         $found1 = [];
         foreach ($iterator as $resource) {
             $this->assertIsA($resource, 'core_kernel_classes_Class');
             $found1[] = $resource->getUri();
         }
         sort($found1);
-         
+
         $this->assertEquals($expected, $found1);
 
         $iterator = new core_kernel_classes_ClassIterator($this->emptyClass);
-        
+
         $found2 = [];
         foreach ($iterator as $instance) {
             $found2[] = $instance->getUri();
@@ -98,7 +98,7 @@ class GenerisIteratorTest extends GenerisPhpUnitTestRunner
         $this->assertEquals(1, $iterator->key());
         $this->assertEquals([$this->emptyClass->getUri()], $found2);
     }
-    
+
     public function testResourceIterator()
     {
         $expected1 = [];
@@ -106,16 +106,16 @@ class GenerisIteratorTest extends GenerisPhpUnitTestRunner
             $expected1[] = $resource->getUri();
         }
         sort($expected1);
-        
+
         $iterator = new core_kernel_classes_ResourceIterator($this->topClass);
-        
+
         $found1 = [];
         foreach ($iterator as $instance) {
             $this->assertIsA($instance, 'core_kernel_classes_Resource');
             $found1[] = $instance->getUri();
         }
         sort($found1);
-        
+
         $this->assertEquals($expected1, $found1);
 
         $found2 = [];
@@ -124,22 +124,22 @@ class GenerisIteratorTest extends GenerisPhpUnitTestRunner
         }
         sort($found2);
         $this->assertEquals($expected1, $found2);
-        
+
         $iterator = new core_kernel_classes_ResourceIterator($this->emptyClass);
         $this->assertFalse($iterator->valid());
         $this->assertEquals('1#0', $iterator->key());
     }
-    
+
     public function testResourceIteratorRewind()
     {
         $iterator = new core_kernel_classes_ResourceIterator($this->topClass);
-        
+
         $first = $iterator->current();
-        
+
         $iterator->next();
         $second = $iterator->current();
         $this->assertNotEquals($first->getUri(), $second->getUri());
-        
+
         $iterator->rewind();
         $first2 = $iterator->current();
         $this->assertEquals($first->getUri(), $first2->getUri());

--- a/test/integration/ModelsRightTest.php
+++ b/test/integration/ModelsRightTest.php
@@ -25,15 +25,15 @@ use oat\generis\test\GenerisPhpUnitTestRunner;
 
 class ModelsRightTest extends GenerisPhpUnitTestRunner
 {
-    
-    public function setUp()
+
+    public function setUp(): void
     {
             GenerisPhpUnitTestRunner::initTest();
     }
-    
+
     public function testRightModels()
     {
-        
+
         $namespaces = common_ext_NamespaceManager::singleton()->getAllNamespaces();
         $localNamespace = $namespaces[LOCAL_NAMESPACE . '#'];
 
@@ -42,22 +42,22 @@ class ModelsRightTest extends GenerisPhpUnitTestRunner
         $this->assertEquals(1, count($updatableModels));
         $this->assertEquals(1, $localNamespace->getModelId());
 
-        
+
         $readableModels = core_kernel_persistence_smoothsql_SmoothModel::getReadableModelIds();
-        
+
         $this->assertTrue(count($readableModels) > 3);
         $this->assertTrue(array_search(1, $readableModels) !== false);
         $this->assertTrue(array_search(2, $readableModels) !== false);
         $this->assertTrue(array_search(3, $readableModels) !== false);
         $this->assertTrue(array_search(4, $readableModels) !== false);
 
-        
+
         // Try to delete a resource of a locked model
         $property = new core_kernel_classes_Property(OntologyRdfs::RDFS_LABEL);
             $domain = new core_kernel_classes_Property(OntologyRdfs::RDFS_DOMAIN, __METHOD__);
         $this->assertFalse($property->removePropertyValues($domain, ['pattern' => OntologyRdfs::RDFS_LABEL]));
-        
-        
+
+
         // Try to remove a property value which is lg dependent of a locked model
         $clazz = new core_kernel_classes_Class('http://www.tao.lu/middleware/Rules.rdf#And');
         $this->assertFalse($clazz->removePropertyValueByLg($property, 'EN'));

--- a/test/integration/NamespaceTest.php
+++ b/test/integration/NamespaceTest.php
@@ -33,8 +33,8 @@ use oat\generis\test\TestCase;
 
 class NamespaceTest extends TestCase
 {
-    
-    public function setUp()
+
+    public function setUp(): void
     {
     }
 
@@ -45,13 +45,13 @@ class NamespaceTest extends TestCase
     {
         $namespaceManager = common_ext_NamespaceManager::singleton();
         $this->assertInstanceOf('common_ext_NamespaceManager', $namespaceManager);
-        
+
         //$this->assertReference($namespaceManager, common_ext_NamespaceManager::singleton());
-        
+
         $tempNamesapce = new common_ext_Namespace();
         $this->assertInstanceOf('common_ext_Namespace', $tempNamesapce);
     }
-    
+
     /**
      * test the manager retrieving methods and the namespace setters/getters
      */
@@ -60,17 +60,17 @@ class NamespaceTest extends TestCase
         $namespaceManager = common_ext_NamespaceManager::singleton();
         $namespaces = $namespaceManager->getAllNamespaces();
         $this->assertTrue(count($namespaces) > 0);
-        
+
         foreach ($namespaces as $namespace) {
             $this->assertInstanceOf('common_ext_Namespace', $namespace);
         }
-        
+
         $localNs = $namespaceManager->getLocalNamespace();
         $this->assertInstanceOf('common_ext_Namespace', $localNs);
 
         $otherLocalNs = $namespaceManager->getNamespace($localNs->getModelId());
         $this->assertInstanceOf('common_ext_Namespace', $otherLocalNs);
-        
+
         $this->assertEquals((string)$otherLocalNs, (string)$localNs);
     }
 }

--- a/test/integration/PropertyTest.php
+++ b/test/integration/PropertyTest.php
@@ -33,7 +33,7 @@ use \core_kernel_classes_Property;
 
 class PropertyTest extends GenerisPhpUnitTestRunner
 {
-    
+
     /**
      *
      * @var core_kernel_classes_Property
@@ -43,7 +43,7 @@ class PropertyTest extends GenerisPhpUnitTestRunner
      *
      * @author Lionel Lecaque, lionel@taotesting.com
      */
-    public function setUp()
+    public function setUp(): void
     {
         GenerisPhpUnitTestRunner::initTest();
         $this->object = new core_kernel_classes_Property(WidgetRdf::PROPERTY_WIDGET);
@@ -61,7 +61,7 @@ class PropertyTest extends GenerisPhpUnitTestRunner
         $this->assertEquals($domain->getLabel(), 'Property');
         $this->assertEquals($domain->getComment(), 'The class of RDF properties.');
     }
-    
+
     /**
      *
      * @author Lionel Lecaque, lionel@taotesting.com
@@ -74,18 +74,18 @@ class PropertyTest extends GenerisPhpUnitTestRunner
         $this->assertEquals(1, $domain->count());
         $this->assertEquals($class, $domain->get(0));
         $widget = new core_kernel_classes_Class(WidgetRdf::CLASS_URI_WIDGET, __METHOD__);
-         
+
         $this->assertTrue($prop->setDomain($widget));
         $this->assertEquals(2, $prop->getDomain()->count());
         $this->assertGreaterThanOrEqual(0, $prop->getDomain()->indexOf($widget));
         $this->assertGreaterThanOrEqual(0, $prop->getDomain()->indexOf($class));
-        
+
         //if domain already set return true
         $this->assertTrue($prop->setDomain($class));
         $this->assertEquals(2, $prop->getDomain()->count());
         $this->assertGreaterThanOrEqual(0, $prop->getDomain()->indexOf($widget));
         $this->assertGreaterThanOrEqual(0, $prop->getDomain()->indexOf($class));
-        
+
         $prop->delete(true);
     }
     /**
@@ -123,10 +123,10 @@ class PropertyTest extends GenerisPhpUnitTestRunner
         $multipleProperty = new core_kernel_classes_Property(GenerisRdf::PROPERTY_MULTIPLE);
 
         $this->assertEquals([], $prop->getPropertyValues($multipleProperty));
-         
+
         $prop->setMultiple(true);
         $this->assertEquals([GenerisRdf::GENERIS_TRUE], $prop->getPropertyValues($multipleProperty));
-        
+
         $prop->delete(true);
     }
     /**
@@ -140,10 +140,10 @@ class PropertyTest extends GenerisPhpUnitTestRunner
         $this->assertFalse($prop->isMultiple());
         $prop->setMultiple(true);
         $this->assertTrue($prop->isMultiple());
-        
+
         $new = new core_kernel_classes_Property($prop->getUri());
         $this->assertTrue($new->isMultiple());
-        
+
         $prop->delete(true);
     }
     /**
@@ -152,24 +152,24 @@ class PropertyTest extends GenerisPhpUnitTestRunner
      */
     public function testDelete()
     {
-    
+
         $class = new core_kernel_classes_Class(GenerisRdf::GENERIS_BOOLEAN, __METHOD__);
-        
+
         $prop = $class->createProperty('test', 'test');
-    
+
         $instance = $class->createInstance('test', 'test');
         $instance->setPropertyValue($prop, GenerisRdf::GENERIS_TRUE);
         $instance->setPropertyValue($prop, '3');
-        
+
         $this->assertArrayHasKey($prop->getUri(), $class->getProperties());
         $val = $instance->getPropertyValues($prop);
         $this->assertTrue(in_array(GenerisRdf::GENERIS_TRUE, $val));
         $this->assertTrue(in_array(3, $val));
-         
+
         $this->assertTrue($prop->delete(true));
         $this->assertEquals([], $instance->getPropertyValues($prop));
         $this->assertArrayNotHasKey($prop->getUri(), $class->getProperties());
-        
+
         $this->assertTrue($instance->delete());
     }
 }

--- a/test/integration/RegistryTest.php
+++ b/test/integration/RegistryTest.php
@@ -30,10 +30,10 @@ class RegistryTest extends TestCase
      *
      * @author Lionel Lecaque, lionel@taotesting.com
      */
-    public function setUp()
+    public function setUp(): void
     {
     }
-    
+
     /**
      *
      * @author Lionel Lecaque, lionel@taotesting.com
@@ -44,7 +44,7 @@ class RegistryTest extends TestCase
         $data = BasicRegistry::getRegistry()->getMap();
         $this->assertEquals('value', $data['key']);
     }
-    
+
     /**
      * @depends testSet
      *
@@ -55,7 +55,7 @@ class RegistryTest extends TestCase
         $value = BasicRegistry::getRegistry()->get('key');
         $this->assertEquals('value', $value);
     }
-    
+
     /**
      * @depends testSet
      *
@@ -63,7 +63,7 @@ class RegistryTest extends TestCase
      */
     public function testRemove()
     {
-        
+
         $data = BasicRegistry::getRegistry()->getMap();
         $this->assertTrue(isset($data['key']));
         BasicRegistry::getRegistry()->remove('key');

--- a/test/integration/ResourceTest.php
+++ b/test/integration/ResourceTest.php
@@ -22,6 +22,8 @@
 
 namespace oat\generis\test\integration;
 
+use common_exception_DeprecatedApiMethod;
+use common_exception_Error;
 use oat\generis\model\GenerisRdf;
 use oat\generis\model\OntologyRdfs;
 use oat\generis\test\GenerisPhpUnitTestRunner;
@@ -38,13 +40,13 @@ class ResourceTest extends GenerisPhpUnitTestRunner
 {
 
     protected $object;
-    
-    public function setUp()
+
+    public function setUp(): void
     {
         GenerisPhpUnitTestRunner::initTest();
 
         $this->object = new core_kernel_classes_Resource(GenerisRdf::GENERIS_BOOLEAN);
-        
+
         //create test class
         $clazz = new core_kernel_classes_Class(GenerisRdf::CLASS_GENERIS_RESOURCE);
         $this->clazz = $clazz->createSubClass($clazz);
@@ -54,24 +56,24 @@ class ResourceTest extends GenerisPhpUnitTestRunner
     {
         $this->clazz->delete();
     }
-    
+
     /*
      *
      * TOOLS FUNCTIONS
      *
      */
-    
+
     private function createTestResource()
     {
         return $this->clazz->createInstance();
     }
-    
+
     private function createTestProperty()
     {
         return $this->clazz->createProperty('ResourceTestCaseProperty ' . common_Utils::getNewUri());
     }
-    
-    
+
+
     /*
      *
      * TEST CASE FUNCTIONS
@@ -141,7 +143,7 @@ class ResourceTest extends GenerisPhpUnitTestRunner
                 $this->assertTrue($value->literal == 'plup' || $value->literal == 'plip', $value->literal . ' must be equal to plip or plop');
             }
         }
-        
+
         // Back to normal.
         $session->setDataLanguage(DEFAULT_LANG);
 
@@ -161,7 +163,7 @@ class ResourceTest extends GenerisPhpUnitTestRunner
         $resource->setPropertyValue($property1, 'prop1');
         $resource->setPropertyValue($property2, 'prop2');
         $resource->setPropertyValue($property3, 'prop3');
-        
+
         //test that the get properties values is getting an array as parameter, if the parameter is not an array, the function will return an exception
         try {
             $resource->getPropertiesValues($property1);
@@ -169,20 +171,20 @@ class ResourceTest extends GenerisPhpUnitTestRunner
         } catch (\Exception $e) {
             $this->assertTrue(true);
         }
-        
+
         //test with one property
         $result = $resource->getPropertiesValues([$property1]);
         $this->assertTrue(in_array(new core_kernel_classes_Literal('prop1'), $result[$property1->getUri()]));
         //test with an other one
         $result = $resource->getPropertiesValues([$property2]);
         $this->assertTrue(in_array('prop2', $result[$property2->getUri()]));
-        
+
         //test with several properties
         $result = $resource->getPropertiesValues([$property1, $property2, $property3]);
         $this->assertTrue(in_array('prop1', $result[$property1->getUri()]));
         $this->assertTrue(in_array('prop2', $result[$property2->getUri()]));
         $this->assertTrue(in_array('prop3', $result[$property3->getUri()]));
-        
+
         //clean all
         $property1->delete();
         $property2->delete();
@@ -207,7 +209,7 @@ class ResourceTest extends GenerisPhpUnitTestRunner
             $property1->delete();
             $resource->delete();
         }
-        
+
         $resource = $this->createTestResource();
         $property1 = $this->createTestProperty();
         $resource->setPropertyValue($property1, 'prop1');
@@ -221,8 +223,8 @@ class ResourceTest extends GenerisPhpUnitTestRunner
             $resource->delete(true);
         }
     }
-    
-    
+
+
     /**
      *
      * @author Lionel Lecaque, lionel@taotesting.com
@@ -307,7 +309,7 @@ class ResourceTest extends GenerisPhpUnitTestRunner
             OntologyRdfs::RDFS_LABEL        => ['new label', 'another label', 'yet a last one'],
             OntologyRdfs::RDFS_COMMENT  => 'new comment'
             ]);
-            
+
         $seeAlso = $instance->getOnePropertyValue(new core_kernel_classes_Property(OntologyRdfs::RDFS_SEEALSO));
         $this->assertNotNull($seeAlso);
         $this->assertIsA($seeAlso, 'core_kernel_classes_Literal');
@@ -386,12 +388,12 @@ class ResourceTest extends GenerisPhpUnitTestRunner
 
         $instance->removePropertyValue($seeAlso, 'foo');
         $this->assertEquals(['bar'], $instance->getPropertyValues($seeAlso));
-         
-        
+
+
         $instance->delete();
         $seeAlso->delete();
     }
-    
+
     public function testRemovePropertyValueByLg()
     {
         $class = new core_kernel_classes_Class(GenerisRdf::GENERIS_BOOLEAN, __METHOD__);
@@ -412,24 +414,24 @@ class ResourceTest extends GenerisPhpUnitTestRunner
         $instance->delete();
         $seeAlso->delete();
     }
-    
+
     public function testRemovePropertyValues()
     {
         $session = GenerisPhpUnitTestRunner::getTestSession();
         $class = new core_kernel_classes_Class(GenerisRdf::GENERIS_BOOLEAN, __METHOD__);
         $instance = $class->createInstance('test', 'test');
         $instance2 = $class->createInstance('test2', 'test2');
-        
+
         $prop1 = $class->createProperty('property1', 'monologingual');
         $prop2 = $class->createProperty('property2', 'multilingual', true);
-        
+
         // We first go with monolingual property.
         $instance->setPropertyValue($prop1, 'mono');
         $propValue = $instance->getOnePropertyValue($prop1);
         $this->assertTrue($propValue->literal == 'mono');
         $this->assertTrue($instance->removePropertyValues($prop1));
         $this->assertTrue(count($instance->getPropertyValues($prop1)) == 0);
-        
+
         // And new we go multilingual.
         $instance->setPropertyValue($prop2, 'multi');
         $instance->setPropertyValueByLg($prop2, 'multiFR1', 'FR');
@@ -438,32 +440,32 @@ class ResourceTest extends GenerisPhpUnitTestRunner
         $instance->setPropertyValueByLg($prop2, 'multiSE1', 'SE');
         $instance->setPropertyValueByLg($prop2, 'multiJA', 'JA');
         $this->assertEquals(count($instance->getPropertyValues($prop2)), 1);
-        
+
         // We are by default in EN language (English). If we call removePropertyValues
         // for property values on a language dependant property, we should only remove
         // one triple with value 'multi'@EN.
         $this->assertTrue(count($instance->getPropertyValues($prop2)) == 1);
         $this->assertTrue($instance->removePropertyValues($prop2));
         $this->assertTrue(count($instance->getPropertyValues($prop2)) == 0);
-        
+
         // We now switch to Swedish language and remove the values in the language.
         $session->setDataLanguage('SE');
         $this->assertTrue(count($instance->getPropertyValues($prop2)) == 2);
         $this->assertTrue($instance->removePropertyValues($prop2));
         $this->assertTrue(count($instance->getPropertyValues($prop2)) == 0);
-        
+
         // Same as above with Japanese language.
         $session->setDataLanguage('JA');
         $this->assertTrue(count($instance->getPropertyValues($prop2)) == 1);
         $this->assertTrue($instance->removePropertyValues($prop2));
         $this->assertTrue(count($instance->getPropertyValues($prop2)) == 0);
-        
+
         // And now final check in French language.
         $session->setDataLanguage('FR');
         $this->assertTrue(count($instance->getPropertyValues($prop2)) == 2);
         $this->assertTrue($instance->removePropertyValues($prop2));
         $this->assertTrue(count($instance->getPropertyValues($prop2)) == 0);
-        
+
         $prop1->delete();
         $prop2->delete();
         $instance->delete();
@@ -475,23 +477,23 @@ class ResourceTest extends GenerisPhpUnitTestRunner
         $class = new core_kernel_classes_Class(GenerisRdf::GENERIS_BOOLEAN, __METHOD__);
         $instance = $class->createInstance('test', 'test');
         $seeAlso = $class->createProperty('seeAlso', 'multilingue', true);
-        
+
         $this->assertEquals([], $instance->getPropertyValues($seeAlso));
         $instance->editPropertyValues($seeAlso, 'foo');
         $this->assertEquals(['foo'], $instance->getPropertyValues($seeAlso));
         $instance->editPropertyValues($seeAlso, 'bar');
         $this->assertEquals(['bar'], $instance->getPropertyValues($seeAlso));
-        
+
         $instance->editPropertyValues($seeAlso, ['foo2','bar']);
         $val = $instance->getPropertyValues($seeAlso);
-    
+
         $this->assertTrue(in_array('bar', $val));
         $this->assertTrue(in_array('foo2', $val));
-         
+
         $instance->delete();
         $seeAlso->delete();
     }
-    
+
     public function testEditPropertyValueByLg()
     {
         $class = new core_kernel_classes_Class(GenerisRdf::GENERIS_BOOLEAN, __METHOD__);
@@ -523,7 +525,7 @@ class ResourceTest extends GenerisPhpUnitTestRunner
         $one = $instance->getOnePropertyValue($seeAlso);
         $this->assertEquals(null, $one);
 
-        
+
         $instance->setPropertyValue($seeAlso, 'plop');
         $one = $instance->getOnePropertyValue($seeAlso);
         $this->assertInstanceOf(\core_kernel_classes_Literal::class, $one);
@@ -541,7 +543,7 @@ class ResourceTest extends GenerisPhpUnitTestRunner
         $session->setDataLanguage('FR');
         $instance->setPropertyValue($seeAlso, 'plopFR');
         $one = $instance->getPropertyValuesByLg($seeAlso, 'FR');
-        
+
         // Back to default language.
         $session->setDataLanguage(DEFAULT_LANG);
         $seeAlso->delete();
@@ -557,25 +559,25 @@ class ResourceTest extends GenerisPhpUnitTestRunner
         $this->assertTrue(count($typeUri) == 1);
         $instance->delete();
     }
-    
+
     public function testHasType()
     {
         $class = new core_kernel_classes_Class(GenerisRdf::GENERIS_BOOLEAN, __METHOD__);
         $file = new core_kernel_classes_Class(GenerisRdf::CLASS_GENERIS_FILE);
-         
+
         $instance = $class->createInstance('test', 'test');
         $this->assertTrue($instance->hasType($class));
         $this->assertFalse($instance->hasType($file));
-         
+
         $instance->delete();
     }
-    
-    
+
+
     public function testSetType()
     {
         $class = new core_kernel_classes_Class(GenerisRdf::GENERIS_BOOLEAN, __METHOD__);
         $file = new core_kernel_classes_Class(GenerisRdf::CLASS_GENERIS_FILE);
-    
+
         $instance = $class->createInstance('test', 'test');
         $this->assertTrue($instance->hasType($class));
         $this->assertFalse($instance->hasType($file));
@@ -585,19 +587,19 @@ class ResourceTest extends GenerisPhpUnitTestRunner
 
         $instance->delete();
     }
-    
+
     public function testRemoveType()
     {
         $class = new core_kernel_classes_Class(GenerisRdf::GENERIS_BOOLEAN, __METHOD__);
         $instance = $class->createInstance('test', 'test');
-        
+
         $file = new core_kernel_classes_Class(GenerisRdf::CLASS_GENERIS_FILE);
         $instance->setType($file);
 
         $instance->removeType($class);
         $this->assertTrue($instance->hasType($file));
         $this->assertFalse($instance->hasType($class));
-        
+
         $instance->delete();
     }
 
@@ -607,8 +609,8 @@ class ResourceTest extends GenerisPhpUnitTestRunner
         $this->assertTrue($inst->getLabel() == 'generis_Ressource');
         $this->assertTrue($inst->getComment() == 'generis_Ressource');
     }
-    
-    
+
+
     public function testIsInstanceOf()
     {
         $baseClass = new core_kernel_classes_Class(OntologyRdfs::RDFS_CLASS);
@@ -616,7 +618,7 @@ class ResourceTest extends GenerisPhpUnitTestRunner
         $level1b = $baseClass->createSubClass('level1b');
         $level2a = $level1a->createSubClass('level2a');
         $level2b = $level1b->createSubClass('level2b');
-        
+
         // single type
         $instance = $level2a->createInstance('test Instance');
         $this->assertTrue($instance->isInstanceOf($level2a));
@@ -624,7 +626,7 @@ class ResourceTest extends GenerisPhpUnitTestRunner
         $this->assertTrue($instance->isInstanceOf($baseClass));
         $this->assertFalse($instance->isInstanceOf($level1b));
         $this->assertFalse($instance->isInstanceOf($level2b));
-        
+
         // multiple types
         $instance->setType($level2b);
         $this->assertTrue($instance->isInstanceOf($level2a));
@@ -640,8 +642,8 @@ class ResourceTest extends GenerisPhpUnitTestRunner
         $this->assertTrue($instance2->isInstanceOf($baseClass));
         $this->assertTrue($instance2->isInstanceOf($level1b));
         $this->assertFalse($instance2->isInstanceOf($level2b));
-        
-        
+
+
         $instance2->delete();
         $instance->delete();
         $level2b->delete();
@@ -649,34 +651,34 @@ class ResourceTest extends GenerisPhpUnitTestRunner
         $level1b->delete();
         $level1a->delete();
     }
-    
-    
+
+
     public function testIsProperty()
     {
         $prop = $this->createTestProperty();
         $this->assertTrue($prop->isProperty());
         $prop->delete();
-        
+
         $instance = $this->createTestResource();
         $this->assertFalse($instance->isProperty());
-        
-        
+
+
         $class = new core_kernel_classes_Class(GenerisRdf::GENERIS_BOOLEAN, __METHOD__);
         $this->assertFalse($class->isProperty());
         $prop->delete();
         $instance->delete();
     }
-    
+
     /**
-     * @expectedException        common_exception_Error
-     * @expectedExceptionMessage could not create resource from NULL debug:
      * @author Lionel Lecaque, lionel@taotesting.com
      */
     public function testConstructNull()
     {
+        $this->expectException(common_exception_Error::class);
+        $this->expectExceptionMessage('could not create resource from NULL debug:');
         $new = new core_kernel_classes_Resource(null);
     }
-    
+
     /**
      * @expectedException        common_exception_Error
      * @expectedExceptionMessage cannot construct the resource because the uri cannot be empty, debug:
@@ -686,13 +688,13 @@ class ResourceTest extends GenerisPhpUnitTestRunner
     {
         $new = new core_kernel_classes_Resource('');
     }
-    
+
     public function testIsClass()
     {
         $prop = $this->createTestProperty();
         $this->assertFalse($prop->isClass());
         $prop->delete();
-         
+
         $class = new core_kernel_classes_Class(OntologyRdfs::RDFS_CLASS, __METHOD__);
         $sublClass = $class->createInstance('subclass', 'subclass');
         $this->assertTrue($class->isClass());
@@ -700,42 +702,42 @@ class ResourceTest extends GenerisPhpUnitTestRunner
 
         $instance = $this->createTestResource();
         $this->assertFalse($instance->isClass());
-        
+
         $prop->delete();
         $instance->delete();
         $sublClass->delete();
     }
     /**
-     * @expectedException        common_exception_DeprecatedApiMethod
-     * @expectedExceptionMessage Use duplicated instead, because clone resource could not share same uri that original
      * @author Lionel Lecaque, lionel@taotesting.com
      */
     public function testClone()
     {
+        $this->expectException(common_exception_DeprecatedApiMethod::class);
+        $this->expectExceptionMessage('Use duplicated instead, because clone resource could not share same uri that original');
         $class = new core_kernel_classes_Class(GenerisRdf::GENERIS_BOOLEAN, __METHOD__);
         $instance = $class->createInstance('test', 'test');
         $clone = clone $instance;
-           
+
         $instance->delete();
         $clone->delete();
     }
-    
+
     public function testDuplicate()
     {
         $class = new core_kernel_classes_Class(GenerisRdf::GENERIS_BOOLEAN, __METHOD__);
         $instance = $class->createInstance('test', 'test');
         $prop = $this->createTestProperty();
         $instance->setPropertyValue($prop, 'plop');
-        
-        
+
+
         $duplicate = $instance->duplicate();
         $this->assertNotEquals($duplicate->getUri(), $instance->getUri());
         $this->assertEquals($duplicate->getLabel(), $instance->getLabel());
         $result = $instance->getPropertiesValues([$prop]);
         $this->assertTrue(in_array('plop', $result[$prop->getUri()]));
-        
 
-        
+
+
         $duplicate->delete();
         $instance->delete();
         $prop->delete();

--- a/test/integration/ResourceTest.php
+++ b/test/integration/ResourceTest.php
@@ -52,7 +52,7 @@ class ResourceTest extends GenerisPhpUnitTestRunner
         $this->clazz = $clazz->createSubClass($clazz);
     }
 
-    function tearDown()
+    function tearDown(): void
     {
         $this->clazz->delete();
     }

--- a/test/integration/UserServiceTest.php
+++ b/test/integration/UserServiceTest.php
@@ -36,7 +36,7 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
 
     private $sampleUser;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
         self::initRoles();

--- a/test/integration/UserServiceTest.php
+++ b/test/integration/UserServiceTest.php
@@ -42,14 +42,14 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
         self::initRoles();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         GenerisPhpUnitTestRunner::initTest();
         $this->service = core_kernel_users_Service::singleton();
         $this->sampleUser = $this->service->addUser(self::TESTCASE_USER_LOGIN, 'pwd' . rand());
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         $this->sampleUser->delete();
@@ -64,31 +64,31 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
         $trueInstance = new core_kernel_classes_Resource(GenerisRdf::GENERIS_TRUE);
         $falseInstance = new core_kernel_classes_Resource(GenerisRdf::GENERIS_FALSE);
         $prefix = LOCAL_NAMESPACE . '#';
-        
+
         // Do not forget that more you go deep in the Roles hierarchy, more rights you have.
         $baseRole = $roleClass->createInstance('BASE Role', 'The base role of the hierarchy (minimal rights).', $prefix . 'baseRole');
         $baseRole->setPropertyValue($isSystemProperty, $falseInstance);
-        
+
         $subRole1 = $roleClass->createInstance('SUB Role 1', 'Includes BASE role.', $prefix . 'subRole1');
         $subRole1->setPropertyValue($includesRoleProperty, $baseRole);
         $subRole1->setPropertyValue($isSystemProperty, $falseInstance);
-        
+
         $subRole2 = $roleClass->createInstance('SUB Role 2', 'Includes BASE role.', $prefix . 'subRole2');
         $subRole2->setPropertyValue($includesRoleProperty, $baseRole);
         $subRole2->setPropertyValue($isSystemProperty, $falseInstance);
-        
+
         $subRole3 = $roleClass->createInstance('SUB Role 3', 'Includes BASE role.', $prefix . 'subRole3');
         $subRole3->setPropertyValue($includesRoleProperty, $baseRole);
         $subRole3->setPropertyValue($isSystemProperty, $falseInstance);
-        
+
         $subRole11 = $roleClass->createInstance('SUB Role 11', 'Includes SUB Role 1.', $prefix . 'subRole11');
         $subRole11->setPropertyValue($includesRoleProperty, $subRole1);
         $subRole11->setPropertyValue($isSystemProperty, $falseInstance);
-        
+
         $subRole12 = $roleClass->createInstance('SUB Role 12', 'Includes SUB Role 1.', $prefix . 'subRole12');
         $subRole12->setPropertyValue($includesRoleProperty, $subRole1);
         $subRole12->setPropertyValue($isSystemProperty, $falseInstance);
-        
+
         $subRole13 = $roleClass->createInstance('SUB Role 13', 'Includes SUB Role 1, SUB Role 11, SUB Role 12.', $prefix . 'subRole13');
         $subRole13->setPropertyValue($includesRoleProperty, $subRole1);
         $subRole13->setPropertyValue($includesRoleProperty, $subRole11);
@@ -101,19 +101,19 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
         // We must have a property dedicated to Roles in the Generis User class.
         $userClass = new core_kernel_classes_Class(GenerisRdf::CLASS_GENERIS_USER);
         $this->assertTrue($userClass->exists());
-        
+
         // The userClass must have a dedicated userRoles property.
         $this->assertTrue(array_key_exists(GenerisRdf::PROPERTY_USER_ROLES, $userClass->getProperties()));
-        
+
         // The class that gather all Roles instances together must exist.
         $roleClass = new core_kernel_classes_Class(GenerisRdf::CLASS_ROLE);
         $this->assertTrue($roleClass->exists());
-        
+
         // The Role class must have the right properties (isSystem and includesRole)
         $roleClassProperties = $roleClass->getProperties();
         $this->assertTrue(array_key_exists(GenerisRdf::PROPERTY_ROLE_ISSYSTEM, $roleClassProperties));
         $this->assertTrue(array_key_exists(GenerisRdf::PROPERTY_ROLE_INCLUDESROLE, $roleClassProperties));
-        
+
         // The Generis Role must exist after installation.
         $generisRole = new core_kernel_classes_Resource(GenerisRdf::INSTANCE_ROLE_GENERIS);
         $this->assertTrue($generisRole->exists());
@@ -128,7 +128,7 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
         $login = $sysUser->getUniquePropertyValue($loginProperty);
         $this->assertIsA($login, 'core_kernel_classes_Literal');
         $this->assertEquals($login->literal, self::TESTCASE_USER_LOGIN);
-        
+
         $unknownUser = $this->service->getOneUser('unknown');
         $this->assertTrue(empty($unknownUser));
     }
@@ -136,7 +136,7 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
     public function testGetIncludedRoles()
     {
         $prefix = LOCAL_NAMESPACE . '#';
-        
+
         $subRole13 = new core_kernel_classes_Resource($prefix . 'subRole13');
         $includedRoles = $this->service->getIncludedRoles($subRole13);
         $this->assertEquals(count($includedRoles), 4);
@@ -159,19 +159,19 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
     public function testLogin()
     {
         $role = $this->service->addRole('LOGINROLE');
-        
+
         if ($this->service->loginExists('login')) {
             $this->service->getOneUser('login')->delete();
         }
         $user = $this->service->addUser('login', 'password', $role);
         $taoManagerRole = new core_kernel_classes_Resource('http://www.tao.lu/Ontologies/TAO.rdf#TaoManagerRole');
-        
+
         $this->assertTrue($this->service->login('login', 'password', $role));
         $this->assertTrue($this->service->isASessionOpened());
         $this->assertTrue($this->service->logout());
         $this->assertFalse($this->service->isASessionOpened());
         $this->assertFalse($this->service->login('toto', '', $taoManagerRole));
-        
+
         $role->delete();
         $user->delete();
     }
@@ -185,14 +185,14 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
     public function testAddUser()
     {
         $userRolesProperty = new core_kernel_classes_Property(GenerisRdf::PROPERTY_USER_ROLES);
-        
+
         // single role.
         $role1 = $this->service->addRole('ADDUSERROLE 1');
         if ($this->service->loginExists('user-fixture-1')) {
             $this->service->getOneUser('user-fixture-1')->delete();
         }
         $user = $this->service->addUser('user-fixture-1', 'password1', $role1);
-        
+
         $this->assertTrue($this->service->loginExists('user-fixture-1'));
         $userRoles = $user->getUniquePropertyValue($userRolesProperty);
         $this->assertEquals($userRoles->getUri(), $role1->getUri());
@@ -200,7 +200,7 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
         $this->assertTrue($this->service->login('user-fixture-1', 'password1', $role1));
         $this->assertTrue($this->service->logout());
         $this->assertFalse($this->service->isASessionOpened());
-        
+
         $user->delete();
         $this->assertFalse($user->exists());
         $role1->delete();
@@ -221,25 +221,25 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
     {
         $roleClass = new core_kernel_classes_Class(GenerisRdf::CLASS_ROLE);
         $includesRoleProperty = new core_kernel_classes_Property(GenerisRdf::PROPERTY_ROLE_INCLUDESROLE);
-        
+
         // Prepare roles to be included to others.
         $iRole1 = $this->service->addRole('INCLUDED ROLE 1');
-        
+
         // Role without included roles.
         $role1 = $this->service->addRole('NEWROLE 1');
         $this->assertIsA($role1, 'core_kernel_classes_Resource');
         $includesRoles = $role1->getPropertyValues($includesRoleProperty);
         $this->assertTrue(empty($includesRoles));
-        
+
         $role1->delete();
         $this->assertFalse($role1->exists());
-        
+
         // Role with included roles.
         $role2 = $this->service->addRole('NEWROLE 2', $iRole1);
         $includedRoles = $role2->getUniquePropertyValue($includesRoleProperty);
         $this->assertTrue($includedRoles->isInstanceOf($roleClass));
         $this->assertEquals($includedRoles->getUri(), $iRole1->getUri());
-        
+
         $role2->delete();
         $iRole1->delete();
         $this->assertFalse($iRole1->exists());
@@ -249,23 +249,23 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
     public function testGetUserRoles()
     {
         $prefix = LOCAL_NAMESPACE . '#';
-        
+
         $subRole2 = new core_kernel_classes_Resource($prefix . 'subRole2');
         if ($this->service->loginExists('user')) {
             $this->service->getOneUser('user')->delete();
         }
         $user = $this->service->addUser('user', 'password', $subRole2);
         $userRoles = $this->service->getUserRoles($user);
-        
+
         $this->assertEquals(count($userRoles), 2);
         $this->assertTrue(array_key_exists($prefix . 'subRole2', $userRoles));
         $this->assertTrue(array_key_exists($prefix . 'baseRole', $userRoles));
         $user->delete();
-        
+
         $subRole11 = new core_kernel_classes_Resource($prefix . 'subRole11');
         $user = $this->service->addUser('user', 'password', $subRole11);
         $userRoles = $this->service->getUserRoles($user);
-        
+
         $this->assertEquals(count($userRoles), 3);
         $this->assertTrue(array_key_exists($prefix . 'subRole11', $userRoles));
         $this->assertTrue(array_key_exists($prefix . 'subRole1', $userRoles));
@@ -290,10 +290,10 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
             $subRole12,
             $subRole13
         ];
-        
+
         $this->assertTrue($baseRole->exists());
         $this->assertTrue($subRole1->exists());
-        
+
         $user = $this->service->addUser('user', 'password', $baseRole);
         $this->assertTrue($this->service->userHasRoles($user, $baseRole));
         $this->assertFalse($this->service->userHasRoles($user, [
@@ -301,7 +301,7 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
             $subRole1
         ]));
         $user->delete();
-        
+
         $user = $this->service->addUser('user', 'password', $subRole1);
         $this->assertTrue($this->service->userHasRoles($user, $baseRole));
         $this->assertTrue($this->service->userHasRoles($user, $subRole1));
@@ -316,7 +316,7 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
             $subRole2
         ]));
         $user->delete();
-        
+
         $user = $this->service->addUser('user', 'password', $subRole13);
         $this->assertTrue($this->service->userHasRoles($user, $subRole13));
         $this->assertTrue($this->service->userHasRoles($user, $baseRole));
@@ -329,19 +329,19 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
         $prefix = LOCAL_NAMESPACE . '#';
         $role = new core_kernel_classes_Resource($prefix . 'subRole3');
         $user = $this->service->addUser('user', 'password', $role);
-        
+
         $userRoles = $this->service->getUserRoles($user);
         $this->assertEquals(count($userRoles), 2);
         $this->assertTrue(array_key_exists($prefix . 'baseRole', $userRoles));
         $this->assertTrue(array_key_exists($role->getUri(), $userRoles));
-        
+
         // subRole3 includes subRole2 for this test.
         $roleToInclude = new core_kernel_classes_Resource($prefix . 'subRole2');
         $this->service->includeRole($role, $roleToInclude);
-        
+
         $userRoles = $this->service->getUserRoles($user);
         $this->assertEquals(count($userRoles), 3);
-        
+
         $user->delete();
         $this->assertFalse($user->exists());
     }
@@ -354,27 +354,27 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
         $prefix = LOCAL_NAMESPACE . '#';
         $role = new core_kernel_classes_Resource($prefix . 'subRole11');
         $user = $this->service->addUser('user', 'password', $role);
-        
+
         $userRoles = $this->service->getUserRoles($user);
         $baseRole = new core_kernel_classes_Resource($prefix . 'baseRole');
         $subRole1 = new core_kernel_classes_Resource($prefix . 'subRole1');
-        
+
         $this->assertEquals(3, count($userRoles));
         $this->assertTrue(array_key_exists($baseRole->getUri(), $userRoles));
         $this->assertTrue(array_key_exists($subRole1->getUri(), $userRoles));
         $this->assertTrue(array_key_exists($role->getUri(), $userRoles));
-        
+
         $this->service->unincludeRole($subRole1, $baseRole);
         $userRoles = $this->service->getUserRoles($user);
         $this->assertEquals(2, count($userRoles));
         $this->assertTrue(array_key_exists($role->getUri(), $userRoles));
         $this->assertTrue(array_key_exists($subRole1->getUri(), $userRoles));
-        
+
         $this->service->includeRole($role, $baseRole);
         $userRoles = $this->service->getUserRoles($user);
         $this->assertEquals(3, count($userRoles));
         $this->assertTrue(array_key_exists($baseRole->getUri(), $userRoles));
-        
+
         $user->delete();
         $this->assertFalse($user->exists());
     }
@@ -382,16 +382,16 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
     public function testRemoveRole()
     {
         $prefix = LOCAL_NAMESPACE . '#';
-        
+
         $subRole13 = new core_kernel_classes_Resource($prefix . 'subRole13');
         $user = $this->service->addUser('user', 'password', $subRole13);
         $this->assertTrue($this->service->userHasRoles($user, $subRole13));
-        
+
         $this->assertTrue($this->service->removeRole($subRole13));
         $this->assertFalse($this->service->userHasRoles($user, $subRole13));
         $userRoles = $this->service->getUserRoles($user);
         $this->assertTrue(empty($userRoles));
-        
+
         $user->delete();
     }
 
@@ -421,19 +421,19 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
     {
         $prefix = LOCAL_NAMESPACE . '#';
         $user = $this->service->addUser('attachUser', 'attachUser');
-        
+
         $role = new core_kernel_classes_Resource($prefix . 'baseRole');
         $this->service->attachRole($user, $role);
         $userRoles = $this->service->getUserRoles($user);
         $this->assertFalse(empty($userRoles));
         $this->assertEquals(count($userRoles), 2); // also contains Generis Role.
         $this->assertTrue(array_key_exists($prefix . 'baseRole', $userRoles));
-        
+
         $this->service->unnatachRole($user, $role);
         $userRoles = $this->service->getUserRoles($user);
         $this->assertEquals(count($userRoles), 1);
         $this->assertFalse(array_key_exists($prefix . 'baseRole', $userRoles));
-        
+
         $this->assertTrue($user->delete());
     }
 
@@ -458,7 +458,7 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
     {
         $includedRole = $this->service->addRole('INCLUDED ROLE');
         $role = $this->service->addRole('CACHE ROLE', $includedRole);
-        
+
         // Nothing is in the cache, we should get an exception.
         try {
             core_kernel_users_Cache::retrieveIncludedRoles($role);
@@ -466,35 +466,35 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
         } catch (core_kernel_users_CacheException $e) {
             $this->assertTrue(true);
         }
-        
+
         $includedRoles = $this->service->getIncludedRoles($role);
         $this->assertEquals(count($includedRoles), 1);
         $this->assertTrue(array_key_exists($includedRole->getUri(), $includedRoles));
-        
+
         // try to put included roles in the cache.
         try {
             core_kernel_users_Cache::cacheIncludedRoles($role, $includedRoles);
-            
+
             // now try to retrieve it.
             $includedRolesFromCache = core_kernel_users_Cache::retrieveIncludedRoles($role);
             $this->assertTrue(is_array($includedRolesFromCache));
             $this->assertEquals(count($includedRolesFromCache), 1);
             $this->assertTrue(array_key_exists($includedRole->getUri(), $includedRolesFromCache));
-            
+
             // and remove it !
             $this->assertTrue(core_kernel_users_Cache::removeIncludedRoles($role));
             $this->assertFalse(core_kernel_users_Cache::areIncludedRolesInCache($role));
         } catch (core_kernel_users_CacheException $e) {
             $this->assertTrue(false, 'An exception occured while writing included roles in the cache memory.');
         }
-        
+
         // try to flush users cache.
         try {
             core_kernel_users_Cache::flush();
         } catch (core_kernel_users_CacheException $e) {
             $this->assertTrue(false, 'An error occured while flushing the users cache.');
         }
-        
+
         $includedRole->delete();
         $role->delete();
     }
@@ -511,7 +511,7 @@ class UserServiceTestCase extends GenerisPhpUnitTestRunner
             $prefix . 'subRole12',
             $prefix . 'subRole13'
         ];
-        
+
         foreach ($roleUris as $ru) {
             $r = new core_kernel_classes_Class($ru);
             $r->delete(true);

--- a/test/integration/common/cache/CacheTest.php
+++ b/test/integration/common/cache/CacheTest.php
@@ -22,6 +22,7 @@
 
 namespace oat\generis\test\integration\common\cache;
 
+use common_cache_NotFoundException;
 use oat\generis\test\GenerisPhpUnitTestRunner;
 use \common_cache_FileCache;
 
@@ -29,7 +30,7 @@ use \common_cache_FileCache;
 
 class CacheTest extends GenerisPhpUnitTestRunner
 {
-    
+
     /**
      * @dataProvider keyProvider
      */
@@ -41,12 +42,12 @@ class CacheTest extends GenerisPhpUnitTestRunner
         $this->assertTrue($cache->has($key));
         $this->assertEquals('data', $cache->get($key));
         $this->assertTrue($cache->remove($key));
-        $this->setExpectedException('common_cache_NotFoundException');
+        $this->expectException(common_cache_NotFoundException::class);
         $cache->get($key);
         $this->assertFalse($cache->has($key));
     }
-    
-    
+
+
     public function keyProvider()
     {
         return [

--- a/test/integration/common/persistence/PhpFilePersistenceTest.php
+++ b/test/integration/common/persistence/PhpFilePersistenceTest.php
@@ -22,6 +22,7 @@
 
 namespace oat\generis\test\integration\common\persistence;
 
+use common_exception_NotImplemented;
 use oat\generis\test\GenerisPhpUnitTestRunner;
 use \common_persistence_Persistence;
 use \common_persistence_PhpFileDriver;
@@ -66,7 +67,7 @@ class PhpFilePersistenceTest extends GenerisPhpUnitTestRunner
      */
     public function testSetException($persistence)
     {
-        $this->expectException(\common_exception_NotImplemented::class);
+        $this->expectException(common_exception_NotImplemented::class);
         $persistence->set('empty', 'empty', 6);
     }
 

--- a/test/integration/common/persistence/PhpFilePersistenceTest.php
+++ b/test/integration/common/persistence/PhpFilePersistenceTest.php
@@ -30,8 +30,8 @@ use org\bovigo\vfs\vfsStream;
 class PhpFilePersistenceTest extends GenerisPhpUnitTestRunner
 {
     private $root;
-    
-    public function setUp()
+
+    public function setUp(): void
     {
         if (!class_exists('org\bovigo\vfs\vfsStream')) {
             $this->markTestSkipped(
@@ -40,14 +40,14 @@ class PhpFilePersistenceTest extends GenerisPhpUnitTestRunner
         }
         $this->root = vfsStream::setup('data');
     }
-    
+
     public function testGetPersistence()
     {
         $driver = common_persistence_Persistence::getPersistence('cache');
         $this->assertInstanceOf('common_persistence_KeyValuePersistence', $driver);
     }
-    
-    
+
+
     public function testConnect()
     {
         $params = [
@@ -61,15 +61,15 @@ class PhpFilePersistenceTest extends GenerisPhpUnitTestRunner
     }
     /**
      * @depends testConnect
-     * @expectedException     common_exception_NotImplemented
      * @author Lionel Lecaque, lionel@taotesting.com
      * @param common_persistence_KeyValuePersistence $persistence
      */
     public function testSetException($persistence)
     {
+        $this->expectException(\common_exception_NotImplemented::class);
         $persistence->set('empty', 'empty', 6);
     }
-    
+
     /**
      * @depends testConnect
      * @author Lionel Lecaque, lionel@taotesting.com
@@ -83,7 +83,7 @@ class PhpFilePersistenceTest extends GenerisPhpUnitTestRunner
         $this->assertEquals("<?php return 'value';" . PHP_EOL, $content);
         $this->assertTrue($return);
     }
-    
+
     /**
      * @depends testConnect
      * @author Lionel Lecaque, lionel@taotesting.com
@@ -94,8 +94,8 @@ class PhpFilePersistenceTest extends GenerisPhpUnitTestRunner
         $this->assertTrue($persistence->set('fakeKeyName', 'value'));
         $this->assertEquals('value', $persistence->get('fakeKeyName'));
     }
-    
-    
+
+
     /**
      * @depends testConnect
      * @author Lionel Lecaque, lionel@taotesting.com
@@ -107,7 +107,7 @@ class PhpFilePersistenceTest extends GenerisPhpUnitTestRunner
         $this->assertTrue($persistence->set('fakeKeyName', 'value'));
         $this->assertTrue($persistence->exists('fakeKeyName'));
     }
-    
+
     /**
      * @depends testConnect
      * @author Lionel Lecaque, lionel@taotesting.com
@@ -115,7 +115,7 @@ class PhpFilePersistenceTest extends GenerisPhpUnitTestRunner
      */
     public function testDel($persistence)
     {
-       
+
         $this->assertTrue($persistence->set('fakeKeyName', 'value'));
         $this->assertTrue($persistence->exists('fakeKeyName'));
         $this->assertTrue($persistence->del('fakeKeyName'));
@@ -157,7 +157,7 @@ class PhpFilePersistenceTest extends GenerisPhpUnitTestRunner
      */
     public function testPurge($persistence)
     {
-         
+
         $this->assertTrue($persistence->set('fakeKeyName', 'value'));
         $this->assertTrue($persistence->set('fakeKeyName2', 'value'));
         $this->assertTrue($persistence->exists('fakeKeyName'));
@@ -165,7 +165,7 @@ class PhpFilePersistenceTest extends GenerisPhpUnitTestRunner
         $this->assertTrue($persistence->purge());
         $this->assertFalse($this->root->hasChildren());
     }
-    
+
     /**
      *
      * @author Lionel Lecaque, lionel@taotesting.com
@@ -178,7 +178,7 @@ class PhpFilePersistenceTest extends GenerisPhpUnitTestRunner
         ];
         $driver = new common_persistence_PhpFileDriver();
         $persistence = $driver->connect('test', $params);
-        
+
         $persistence->set('fakeKeyName', 'value');
         $this->assertEquals('value', $persistence->get('fakeKeyName'));
     }

--- a/test/integration/common/persistence/sql/UpdateMultipleTestAbstract.php
+++ b/test/integration/common/persistence/sql/UpdateMultipleTestAbstract.php
@@ -11,7 +11,7 @@ abstract class UpdateMultipleTestAbstract extends TestCase
     /** @var common_persistence_sql_dbal_Driver|common_persistence_sql_pdo_sqlite_Driver */
     protected $driver;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $this->setUpDriver();
@@ -63,7 +63,7 @@ abstract class UpdateMultipleTestAbstract extends TestCase
         return $this->driver->lastInsertId();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         $this->setUpDriver();

--- a/test/integration/common/persistence/sql/UpdateMultipleTestAbstract.php
+++ b/test/integration/common/persistence/sql/UpdateMultipleTestAbstract.php
@@ -60,7 +60,7 @@ abstract class UpdateMultipleTestAbstract extends TestCase
             ':value_6' => 'value_6_3',
         ]);
 
-        return $this->driver->lastInsertId();
+        $this->driver->lastInsertId();
     }
 
     public function tearDown(): void

--- a/test/integration/common/persistence/sql/dbal/DriverTest.php
+++ b/test/integration/common/persistence/sql/dbal/DriverTest.php
@@ -95,12 +95,10 @@ class DriverTest extends TestCase
         $this->assertInstanceOf(common_persistence_sql_Platform::class, $platform);
     }
 
-    /**
-     * @expectedException  \Doctrine\DBAL\DBALException
-     * @expectedExceptionMessage Testing
-     */
     public function testMaxAttemptsToConnect()
     {
+        $this->expectException(DBALException::class);
+        $this->expectExceptionMessage('Testing');
         $driver = new TestDbalDriver();
 
         $connectionMock = $this->prophesize(Connection::class);

--- a/test/integration/core/kernel/classes/ResourceIteratorTest.php
+++ b/test/integration/core/kernel/classes/ResourceIteratorTest.php
@@ -34,7 +34,7 @@ class ResourceIteratorTest extends TaoPhpUnitTestRunner
 
     protected static $sampleClass = 'http://www.tao.lu/Ontologies/TAO.rdf#ResourceIteratorTest';
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->removeResources();
     }

--- a/test/integration/helpers/FileSerializerMigrationHelperTest.php
+++ b/test/integration/helpers/FileSerializerMigrationHelperTest.php
@@ -91,7 +91,7 @@ class FileSerializerMigrationHelperTest extends GenerisTestCase
     /**
      * Initialize test
      */
-    public function setUp()
+    public function setUp(): void
     {
         common_Config::load();
         $this->fileMigrationHelper = new MigrationHelper();
@@ -199,7 +199,7 @@ class FileSerializerMigrationHelperTest extends GenerisTestCase
         return $this->tempDirectory;
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $dir = $this->getTempDirectory();
         $this->testFile = $dir->getFile(self::SAMPLE_FILE);

--- a/test/integration/helpers/FileTest.php
+++ b/test/integration/helpers/FileTest.php
@@ -27,12 +27,12 @@ class FileTest extends TestCase
 {
     private $rootDir;
 
-    public function tearDown()
+    public function tearDown(): void
     {
         \tao_helpers_File::delTree($this->rootDir);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->rootDir = uniqid(sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'test-file-inside-directory', true) . DIRECTORY_SEPARATOR;
         mkdir($this->rootDir);

--- a/test/integration/model/persistence/file/FileModelTest.php
+++ b/test/integration/model/persistence/file/FileModelTest.php
@@ -32,7 +32,7 @@ class FileModelTest extends GenerisPhpUnitTestRunner
      *
      * @see PHPUnit_Framework_TestCase::setUp()
      */
-    public function setUp()
+    public function setUp(): void
     {
     }
 
@@ -81,13 +81,13 @@ class FileModelTest extends GenerisPhpUnitTestRunner
 
     /**
      * @depends testConstruct
-     * @expectedException common_exception_NoImplementation
      *
      * @author Lionel Lecaque, lionel@taotesting.com
      * @param array $model
      */
     public function testGetRdfsInterface($model)
     {
+        $this->expectException(\common_exception_NoImplementation::class);
         $model->getRdfsInterface();
     }
 

--- a/test/integration/model/persistence/file/FileRdfTest.php
+++ b/test/integration/model/persistence/file/FileRdfTest.php
@@ -21,6 +21,7 @@
 
 namespace oat\generis\test\integration\model\kernel\persistence\file;
 
+use common_Exception;
 use oat\generis\test\GenerisPhpUnitTestRunner;
 use oat\generis\model\kernel\persistence\file\FileRdf;
 
@@ -30,72 +31,70 @@ class FileRdfTest extends GenerisPhpUnitTestRunner
      *
      * @see PHPUnit_Framework_TestCase::setUp()
      */
-    public function setUp()
+    public function setUp(): void
     {
         GenerisPhpUnitTestRunner::initTest();
     }
-    
+
     /**
-     * @expectedException common_Exception
-     * @expectedExceptionMessage Not implemented
      *
      * @author Lionel Lecaque, lionel@taotesting.com
      */
     public function testGet()
     {
+        $this->expectException(common_Exception::class);
+        $this->expectExceptionMessage('Not implemented');
         $rdf = new FileRdf('test');
         $rdf->get(null, null);
     }
-    
+
     /**
-     * @expectedException common_Exception
-     * @expectedExceptionMessage Not implemented
-     *
      * @author Lionel Lecaque, lionel@taotesting.com
      */
     public function testAdd()
     {
+        $this->expectException(common_Exception::class);
+        $this->expectExceptionMessage('Not implemented');
         $triple = new \core_kernel_classes_Triple();
         $triple->modelid = 22;
         $triple->subject = 'subjectUri';
         $triple->predicate = 'predicateUri';
         $triple->object = 'objectUri';
-        
+
         $rdf = new FileRdf('test');
         $rdf->add($triple);
     }
-    
+
     /**
-     * @expectedException common_Exception
-     * @expectedExceptionMessage Not implemented
-     *
      * @author Lionel Lecaque, lionel@taotesting.com
      */
     public function testRemove()
     {
+        $this->expectException(common_Exception::class);
+        $this->expectExceptionMessage('Not implemented');
         $triple = new \core_kernel_classes_Triple();
         $triple->modelid = 22;
         $triple->subject = 'subjectUri';
         $triple->predicate = 'predicateUri';
         $triple->object = 'objectUri';
-        
+
         $rdf = new FileRdf('test');
         $rdf->remove($triple);
     }
-    
+
 
     /**
-     * @expectedException common_Exception
-     * @expectedExceptionMessage Not implemented
      *
      * @author Lionel Lecaque, lionel@taotesting.com
      */
     public function testSearch()
     {
+        $this->expectException(common_Exception::class);
+        $this->expectExceptionMessage('Not implemented');
         $rdf = new FileRdf('test');
         $rdf->search(null, null);
     }
-    
+
     /**
      *
      * @author Lionel Lecaque, lionel@taotesting.com

--- a/test/integration/model/persistence/smoothsql/SmoothModelTest.php
+++ b/test/integration/model/persistence/smoothsql/SmoothModelTest.php
@@ -31,7 +31,7 @@ class SmoothModelTest extends GenerisPhpUnitTestRunner
      *
      * @see PHPUnit_Framework_TestCase::setUp()
      */
-    public function setUp()
+    public function setUp(): void
     {
         GenerisPhpUnitTestRunner::initTest();
     }

--- a/test/integration/rules/OperationFactoryTest.php
+++ b/test/integration/rules/OperationFactoryTest.php
@@ -28,11 +28,11 @@ class OperationFactoryTestCase extends GenerisPhpUnitTestRunner
 {
 
 
-    public function setUp()
+    public function setUp(): void
     {
         GenerisPhpUnitTestRunner::initTest();
     }
-    
+
     public function testCreateOperation()
     {
         $constant5 = core_kernel_rules_TermFactory::createConst('5');
@@ -43,23 +43,23 @@ class OperationFactoryTestCase extends GenerisPhpUnitTestRunner
             new core_kernel_classes_Resource(RulesRdf::INSTANCE_OPERATOR_ADD)
         );
         $this->assertIsA($operation, 'core_kernel_rules_Operation');
-        
+
         $firstOperand = new core_kernel_classes_Property(RulesRdf::PROPERTY_OPERATION_FIRST_OP);
         $secondOperand = new core_kernel_classes_Property(RulesRdf::PROPERTY_OPERATION_SECOND_OP);
         $operatorProperty = new core_kernel_classes_Property(RulesRdf::PROPERTY_OPERATION_OPERATOR);
-        
+
         $operator = $operation->getUniquePropertyValue($operatorProperty);
         $this->assertIsA($operator, 'core_kernel_classes_Resource');
         $this->assertEquals($operator->getUri(), RulesRdf::INSTANCE_OPERATOR_ADD);
-        
+
         $term1 = $operation->getUniquePropertyValue($firstOperand);
         $this->assertIsA($term1, 'core_kernel_classes_Resource');
         $this->assertEquals($term1->getUri(), $constant5->getUri());
-        
+
         $term2 = $operation->getUniquePropertyValue($secondOperand);
         $this->assertIsA($term2, 'core_kernel_classes_Resource');
         $this->assertEquals($term2->getUri(), $constant12->getUri());
-        
+
         $constant5->delete();
         $constant12->delete();
         $operation->delete();

--- a/test/integration/rules/OperationTest.php
+++ b/test/integration/rules/OperationTest.php
@@ -28,16 +28,16 @@ class OperationTest extends GenerisPhpUnitTestRunner
 {
 
 
-    public function setUp()
+    public function setUp(): void
     {
         GenerisPhpUnitTestRunner::initTest();
     }
-    
+
     public function testEvaluate()
     {
         $constant5 = core_kernel_rules_TermFactory::createConst('5');
         $constant12 = core_kernel_rules_TermFactory::createConst('12');
-        
+
         //5 + 12
         $operation = core_kernel_rules_OperationFactory::createOperation(
             $constant5,
@@ -47,7 +47,7 @@ class OperationTest extends GenerisPhpUnitTestRunner
         $result = $operation->evaluate();
         $this->assertIsA($result, 'core_kernel_classes_Literal');
         $this->assertEquals($result->literal, '17');
-        
+
         //5 - 12
         $operation = core_kernel_rules_OperationFactory::createOperation(
             $constant5,
@@ -57,7 +57,7 @@ class OperationTest extends GenerisPhpUnitTestRunner
         $result = $operation->evaluate();
         $this->assertIsA($result, 'core_kernel_classes_Literal');
         $this->assertEquals($result->literal, '-7');
-        
+
         //5 * 12
         $operation = core_kernel_rules_OperationFactory::createOperation(
             $constant5,
@@ -67,7 +67,7 @@ class OperationTest extends GenerisPhpUnitTestRunner
         $result = $operation->evaluate();
         $this->assertIsA($result, 'core_kernel_classes_Literal');
         $this->assertEquals($result->literal, '60');
-        
+
         //60 / 12
         $constant60 = core_kernel_rules_TermFactory::createConst('60');
         $operation = core_kernel_rules_OperationFactory::createOperation(
@@ -78,7 +78,7 @@ class OperationTest extends GenerisPhpUnitTestRunner
         $result = $operation->evaluate();
         $this->assertIsA($result, 'core_kernel_classes_Literal');
         $this->assertEquals($result->literal, '5');
-        
+
         // 60 concat 12
         $operation = core_kernel_rules_OperationFactory::createOperation(
             $constant60,
@@ -88,14 +88,14 @@ class OperationTest extends GenerisPhpUnitTestRunner
         $result = $operation->evaluate();
         $this->assertIsA($result, 'core_kernel_classes_Literal');
         $this->assertEquals($result->literal, '60 12');
-        
+
         // raise excption bad operator
         $operation = core_kernel_rules_OperationFactory::createOperation(
             $constant60,
             $constant12,
             new core_kernel_classes_Resource(RulesRdf::INSTANCE_OPERATOR_UNION)
         );
-        
+
         try {
             $operation->evaluate();
             $this->fail('should raise exception : problem evaluating operation, operator do not match with operands');
@@ -103,8 +103,8 @@ class OperationTest extends GenerisPhpUnitTestRunner
             $this->assertEquals($e->getMessage(), 'problem evaluating operation, operator do not match with operands');
         }
 
-        
-        
+
+
         $constant60->delete();
         $constant5->delete();
         $constant12->delete();

--- a/test/integration/rules/TermFactoryTest.php
+++ b/test/integration/rules/TermFactoryTest.php
@@ -30,11 +30,11 @@ class TermFactoryTest extends GenerisPhpUnitTestRunner
 {
 
 
-    public function setUp()
+    public function setUp(): void
     {
         GenerisPhpUnitTestRunner::initTest();
     }
-    
+
     public function testCreateConst()
     {
         $constantResource = core_kernel_rules_TermFactory::createConst('test1');
@@ -42,45 +42,45 @@ class TermFactoryTest extends GenerisPhpUnitTestRunner
         $typeUri = array_keys($constantResource->getTypes());
         $this->assertEquals($typeUri[0], RulesRdf::CLASS_TERM_CONST);
         $this->assertTrue(count($typeUri) == 1);
-            
+
         $termValueProperty = new core_kernel_classes_Property(RulesRdf::PROPERTY_TERM_VALUE);
         $logicalOperatorProperty = new core_kernel_classes_Property(RulesRdf::PROPERTY_HASLOGICALOPERATOR);
         $terminalExpressionProperty = new core_kernel_classes_Property(RulesRdf::PROPERTY_TERMINAL_EXPRESSION);
-        
+
         $term = $constantResource->getUniquePropertyValue($termValueProperty);
         $this->assertIsA($term, 'core_kernel_classes_Literal');
         $this->assertEquals($term, 'test1');
-        
+
         $operator = $constantResource->getUniquePropertyValue($logicalOperatorProperty);
         $this->assertIsA($operator, 'core_kernel_classes_Resource');
         $this->assertEquals($operator->getUri(), RulesRdf::INSTANCE_EXISTS_OPERATOR_URI);
-    
+
         $terminalExpression = $constantResource->getUniquePropertyValue($terminalExpressionProperty);
         $this->assertIsA($terminalExpression, 'core_kernel_classes_Resource');
         $this->assertEquals($terminalExpression->getUri(), $constantResource->getUri());
 
         $constantResource->delete();
     }
-    
+
     public function testCreateSPX()
     {
         $booleanClass = new core_kernel_classes_Class(GenerisRdf::GENERIS_BOOLEAN);
         $maybe = core_kernel_classes_ResourceFactory::create($booleanClass, 'testCase testCreateSPX', __METHOD__);
-        
+
         $SPXResource = core_kernel_rules_TermFactory::createSPX($maybe, new core_kernel_classes_Property(OntologyRdfs::RDFS_COMMENT));
         $this->assertIsA($SPXResource, 'core_kernel_rules_Term');
-        
+
         $subjectProperty = new core_kernel_classes_Property(RulesRdf::PROPERTY_TERM_SPX_SUBJET);
         $predicateProperty = new core_kernel_classes_Property(RulesRdf::PROPERTY_TERM_SPX_PREDICATE);
-        
+
         $subject = $SPXResource->getUniquePropertyValue($subjectProperty);
         $this->assertIsA($subject, 'core_kernel_classes_Resource');
         $this->assertEquals($subject->getUri(), $maybe->getUri());
-        
+
         $predicate = $SPXResource->getUniquePropertyValue($predicateProperty);
         $this->assertIsA($predicate, 'core_kernel_classes_Resource');
         $this->assertEquals($predicate->getUri(), OntologyRdfs::RDFS_COMMENT);
-        
+
         $SPXResource->delete();
         $maybe->delete();
     }

--- a/test/integration/rules/TermTest.php
+++ b/test/integration/rules/TermTest.php
@@ -29,15 +29,15 @@ class TermTest extends GenerisPhpUnitTestRunner
 {
 
 
-    public function setUp()
+    public function setUp(): void
     {
         GenerisPhpUnitTestRunner::initTest();
     }
-    
+
     public function testEvaluate()
     {
-        
-        
+
+
         //bad term
         $badTermResource = core_kernel_classes_ResourceFactory::create(
             new core_kernel_classes_Class(RulesRdf::CLASS_TERM),
@@ -51,23 +51,23 @@ class TermTest extends GenerisPhpUnitTestRunner
         } catch (common_Exception $e) {
             $this->assertEquals($e->getMessage(), 'Forbidden Type of Term');
         }
-        
+
         // eval const
         $constantResource = core_kernel_rules_TermFactory::createConst('test1');
         $term = $constantResource->evaluate();
         $this->assertIsA($term, 'core_kernel_classes_Literal');
         $this->assertEquals($term, 'test1');
         $constantResource->delete();
-        
+
         //eval SPX
         $booleanClass = new core_kernel_classes_Class(GenerisRdf::GENERIS_BOOLEAN);
-        
+
         $maybe = core_kernel_classes_ResourceFactory::create($booleanClass, 'testCase testCreateSPX', __METHOD__);
         $SPXResource = core_kernel_rules_TermFactory::createSPX($maybe, new core_kernel_classes_Property(OntologyRdfs::RDFS_COMMENT));
         $spxResult = $SPXResource->evaluate();
         $this->assertIsA($spxResult, 'core_kernel_classes_Literal');
         $this->assertEquals($spxResult, __METHOD__);
-        
+
         // eval operation
         $constant5 = core_kernel_rules_TermFactory::createConst('5');
         $constant12 = core_kernel_rules_TermFactory::createConst('12');
@@ -79,8 +79,8 @@ class TermTest extends GenerisPhpUnitTestRunner
         $operationTerm = new core_kernel_rules_Term($operation->getUri());
         $result = $operationTerm->evaluate();
         $this->assertEquals($result->literal, '17');
-        
-        
+
+
         $fakeTerm = new core_kernel_rules_Term($maybe->getUri());
         try {
             $fakeTerm->evaluate();
@@ -88,7 +88,7 @@ class TermTest extends GenerisPhpUnitTestRunner
         } catch (common_Exception $e) {
             $this->assertEquals($e->getMessage(), 'problem evaluating Term');
         }
-        
+
         $badTermResource->delete();
         $constant5->delete();
         $constant12->delete();

--- a/test/unit/CollectionTest.php
+++ b/test/unit/CollectionTest.php
@@ -39,7 +39,7 @@ class CollectionTest extends TestCase
      * Setting the collection to test
      *
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->object = new common_Collection(new common_Object(__METHOD__));
         $this->toto =  new core_kernel_classes_Literal('toto', __METHOD__);
@@ -47,7 +47,7 @@ class CollectionTest extends TestCase
         $this->object->sequence[0] = $this->toto;
         $this->object->sequence[1] = $this->tata;
     }
-    
+
     /**
      * Test common_Collection->add
      *
@@ -58,7 +58,7 @@ class CollectionTest extends TestCase
         $this->object->add($titi);
         $this->assertEquals($this->object->sequence[2], $titi);
     }
-    
+
     /**
      * Test common_Collection->count
      *
@@ -67,7 +67,7 @@ class CollectionTest extends TestCase
     {
         $this->assertTrue($this->object->count() == 2);
     }
-    
+
     /**
      * Test common_Collection->indexOf
      *
@@ -78,7 +78,7 @@ class CollectionTest extends TestCase
         $this->assertTrue($this->object->indexOf($this->tata) == 1);
         $this->assertFalse($this->object->indexOf(new common_Object(__METHOD__)) == 2);
     }
-    
+
     /**
      * Test common_Collection->get
      *
@@ -88,7 +88,7 @@ class CollectionTest extends TestCase
         $this->assertEquals($this->object->get(0), $this->object->sequence[0]);
         $this->assertEquals($this->object->get(0)->literal, 'toto');
     }
-    
+
     /**
      * Test common_Collection->isEmtpy
      *
@@ -100,7 +100,7 @@ class CollectionTest extends TestCase
         $emtpy->add(new common_Object(__METHOD__));
         $this->assertFalse($emtpy->isEmpty());
     }
-    
+
     /**
      * Test common_Collection->remove
      *
@@ -110,7 +110,7 @@ class CollectionTest extends TestCase
         $this->object->remove($this->toto);
         $this->assertFalse($this->object->indexOf($this->toto) == 0);
     }
-    
+
      /**
       * Test common_Collection->union
       */
@@ -126,7 +126,7 @@ class CollectionTest extends TestCase
         $this->assertTrue($results->get($results->indexOf($this->tata))->literal == 'tata');
         $this->assertTrue($results->get(2)->literal == 'plop');
     }
-    
+
      /**
       * Test common_Collection->intersect
       */

--- a/test/unit/FileHelperTest.php
+++ b/test/unit/FileHelperTest.php
@@ -26,7 +26,7 @@ use oat\generis\test\TestCase;
 class FileHelperTest extends TestCase
 {
 
-    protected function setUp()
+    protected function setUp(): void
     {
     }
 

--- a/test/unit/ManifestTest.php
+++ b/test/unit/ManifestTest.php
@@ -25,20 +25,20 @@ use oat\generis\test\TestCase;
 
 class ManifestTest extends TestCase
 {
-    
+
     const SAMPLES_PATH = '/../../test/samples/manifests/';
     const MANIFEST_PATH_DOES_NOT_EXIST = 'idonotexist.php';
     const MANIFEST_PATH_LIGHTWEIGHT = 'lightweightManifest.php';
     const MANIFEST_PATH_COMPLEX = 'complexManifest.php';
-    
-    public function setUp()
+
+    public function setUp(): void
     {
     }
-    
+
     public function testManifestLoading()
     {
         $currentPath = dirname(__FILE__);
-        
+
         // try to load a manifest that does not exists.
         try {
             $manifestPath = $currentPath . self::SAMPLES_PATH . self::MANIFEST_PATH_DOES_NOT_EXIST;
@@ -47,7 +47,7 @@ class ManifestTest extends TestCase
         } catch (Exception $e) {
             $this->assertInstanceOf('common_ext_ManifestNotFoundException', $e);
         }
-        
+
         // Load a simple lightweight manifest that exists and is well formed.
         $manifestPath = $currentPath . self::SAMPLES_PATH . self::MANIFEST_PATH_LIGHTWEIGHT;
         try {
@@ -60,7 +60,7 @@ class ManifestTest extends TestCase
         } catch (common_ext_ManifestException $e) {
             $this->assertTrue(false, "Trying to load a manifest that exists and well formed should not raise an exception.");
         }
-        
+
         // Load a more complex manifest that exists and is well formed.
         $manifestPath = $currentPath . self::SAMPLES_PATH . self::MANIFEST_PATH_COMPLEX;
         try {
@@ -84,7 +84,7 @@ class ManifestTest extends TestCase
         } catch (common_ext_ManifestException $e) {
             $this->assertTrue(false, $e->getMessage());
         }
-        
+
         // Load a malformed manifest.
         // @TODO try to load a malformed manifest.
     }

--- a/test/unit/common/configuration/ComponentFactoryTest.php
+++ b/test/unit/common/configuration/ComponentFactoryTest.php
@@ -40,7 +40,7 @@ class ComponentFactoryTest extends TestCase
     /** @var common_configuration_ComponentFactory */
     private $subject;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/test/unit/common/configuration/FileSystemComponentTest.php
+++ b/test/unit/common/configuration/FileSystemComponentTest.php
@@ -35,7 +35,7 @@ class FileSystemComponentTest extends TestCase
     /** @var common_configuration_FileSystemComponent */
     private $subject;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -73,7 +73,7 @@ class FileSystemComponentTest extends TestCase
     }
 
     /**
-     * @depends skipIfVfsStreamNotAvailable()
+     * @depends testSkipIfVfsStreamNotAvailable
      */
     public function testIsReadable()
     {
@@ -85,7 +85,7 @@ class FileSystemComponentTest extends TestCase
     }
 
     /**
-     * @depends skipIfVfsStreamNotAvailable()
+     * @depends testSkipIfVfsStreamNotAvailable
      */
     public function testIsWritable()
     {
@@ -97,7 +97,7 @@ class FileSystemComponentTest extends TestCase
     }
 
     /**
-     * @depends skipIfVfsStreamNotAvailable()
+     * @depends testSkipIfVfsStreamNotAvailable
      */
     public function testIsExecutable()
     {
@@ -113,7 +113,7 @@ class FileSystemComponentTest extends TestCase
     }
 
     /**
-     * @depends skipIfVfsStreamNotAvailable()
+     * @depends testSkipIfVfsStreamNotAvailable
      */
     public function testCheckDirectoryPermissionsSuccess()
     {
@@ -131,7 +131,7 @@ class FileSystemComponentTest extends TestCase
     }
 
     /**
-     * @depends skipIfVfsStreamNotAvailable()
+     * @depends testSkipIfVfsStreamNotAvailable
      */
     public function testCheckFilePermissionsSuccess()
     {
@@ -151,7 +151,7 @@ class FileSystemComponentTest extends TestCase
     }
 
     /**
-     * @depends skipIfVfsStreamNotAvailable()
+     * @depends testSkipIfVfsStreamNotAvailable
      */
     public function testCheckDirectoryContentFailure()
     {
@@ -172,7 +172,7 @@ class FileSystemComponentTest extends TestCase
     }
 
     /**
-     * @depends skipIfVfsStreamNotAvailable()
+     * @depends testSkipIfVfsStreamNotAvailable
      */
     public function testCheckDirectoryContentSuccess()
     {
@@ -190,7 +190,10 @@ class FileSystemComponentTest extends TestCase
         );
     }
 
-    public function skipIfVfsStreamNotAvailable()
+    /**
+     * @doesNotPerformAssertions
+     */
+    public function testSkipIfVfsStreamNotAvailable()
     {
         if (!class_exists('org\bovigo\vfs\vfsStream')) {
             $this->markTestSkipped('VfsStream is not available.');

--- a/test/unit/common/persistence/AdvKeyValuePersistenceTest.php
+++ b/test/unit/common/persistence/AdvKeyValuePersistenceTest.php
@@ -29,7 +29,7 @@ class AdvKeyValuePersistenceTest extends TestCase
      */
     protected $largeValuePersistence;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->largeValuePersistence = new \common_persistence_AdvKeyValuePersistence(
             [
@@ -39,7 +39,7 @@ class AdvKeyValuePersistenceTest extends TestCase
         );
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->largeValuePersistence);
     }

--- a/test/unit/common/persistence/InMemoryAdvKvDriverTest.php
+++ b/test/unit/common/persistence/InMemoryAdvKvDriverTest.php
@@ -29,7 +29,7 @@ class InMemoryAdvKvDriverTest extends TestCase
      */
     private $driver;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->driver = new \common_persistence_InMemoryAdvKvDriver();
     }

--- a/test/unit/common/persistence/KeyValuePersistenceTest.php
+++ b/test/unit/common/persistence/KeyValuePersistenceTest.php
@@ -30,7 +30,7 @@ class KeyValuePersistenceTest extends TestCase
     /** @var \common_persistence_Driver */
     protected $driver;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->driver = new \common_persistence_InMemoryKvDriver();
 
@@ -64,7 +64,7 @@ class KeyValuePersistenceTest extends TestCase
             );
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         unset($this->largeValuePersistence);
     }
@@ -126,11 +126,11 @@ class KeyValuePersistenceTest extends TestCase
 
         $this->testDelExistsLarge();
     }
-    
+
     public function testSetValueLengthEqualsMax()
     {
         $str = str_repeat('a', 100);
-        
+
         $this->largeValuePersistence->set('equalsMax', $str);
         $this->assertEquals($str, $this->largeValuePersistence->get('equalsMax'));
         $this->assertTrue($this->largeValuePersistence->del('equalsMax'));

--- a/test/unit/common/persistence/PersistenceManagerTest.php
+++ b/test/unit/common/persistence/PersistenceManagerTest.php
@@ -33,7 +33,7 @@ class PersistenceManagerTest extends TestCase
      */
     private $pm;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->pm = new PersistenceManager([
             PersistenceManager::OPTION_PERSISTENCES => [

--- a/test/unit/common/persistence/PhpFilePersistenceTtlModeTest.php
+++ b/test/unit/common/persistence/PhpFilePersistenceTtlModeTest.php
@@ -41,7 +41,7 @@ class PhpFilePersistenceTtlModeTest extends TestCase
 
     private $root;
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!class_exists('org\bovigo\vfs\vfsStream')) {
             $this->markTestSkipped(

--- a/test/unit/helpers/ExtensionHelperTest.php
+++ b/test/unit/helpers/ExtensionHelperTest.php
@@ -21,6 +21,7 @@
 
 namespace oat\generis\test\unit\helpers;
 
+use common_exception_Error;
 use oat\generis\test\TestCase;
 
 class ExtensionHelperTest extends TestCase
@@ -34,23 +35,18 @@ class ExtensionHelperTest extends TestCase
         $this->assertEquals([$ext1,$ext2,$ext3], array_values($sorted));
     }
 
-    /**
-     * @expectedException common_exception_Error
-     */
     public function testCyclicDependencies()
     {
-        $ext1 = $this->mockExtension('ext0', ['ext1']);
+        $this->expectException(common_exception_Error::class);
         $ext1 = $this->mockExtension('ext1', ['ext2']);
         $ext2 = $this->mockExtension('ext2', ['ext3']);
         $ext3 = $this->mockExtension('ext3', ['ext1']);
         $sorted = \helpers_ExtensionHelper::sortByDependencies([$ext2,$ext3,$ext1]);
     }
 
-    /**
-     * @expectedException common_exception_Error
-     */
     public function testMissingDependencies()
     {
+        $this->expectException(common_exception_Error::class);
         $ext1 = $this->mockExtension('ext1', []);
         $ext2 = $this->mockExtension('ext2', ['ext4']);
         $ext3 = $this->mockExtension('ext3', ['ext2','ext4']);

--- a/test/unit/model/ResourceFormatterTest.php
+++ b/test/unit/model/ResourceFormatterTest.php
@@ -20,6 +20,7 @@
 
 namespace oat\generis\test\unit\model;
 
+use common_exception_NoContent;
 use \core_kernel_classes_ResourceFormatter;
 use oat\generis\model\GenerisRdf;
 use oat\generis\test\TestCase;
@@ -151,39 +152,39 @@ class ResourceFormatterTest extends TestCase
         $result = $formatter->getResourceDescription($this->createResourceDescription(false));
 
         $this->assertInstanceOf('stdClass', $result);
-        $this->assertAttributeEquals('#fakeUri', 'uri', $result);
-        $this->assertAttributeInternalType('array', 'properties', $result);
-        $this->assertAttributeCount(2, 'properties', $result);
+        $this->assertSame('#fakeUri', $result->uri);
+        $this->assertIsArray($result->properties);
+        $this->assertCount(2, $result->properties);
 
         $this->assertInstanceOf('stdClass', $result->properties[0]);
-        $this->assertAttributeEquals('#propertyUri', 'predicateUri', $result->properties[0]);
-        $this->assertAttributeInternalType('array', 'values', $result->properties[0]);
-        $this->assertAttributeCount(2, 'values', $result->properties[0]);
+        $this->assertSame('#propertyUri', $result->properties[0]->predicateUri);
+        $this->assertIsArray($result->properties[0]->values);
+        $this->assertCount(2, $result->properties[0]->values);
 
         $this->assertInstanceOf('stdClass', $result->properties[0]->values[0]);
-        $this->assertAttributeEquals('literal', 'valueType', $result->properties[0]->values[0]);
-        $this->assertAttributeEquals('value1', 'value', $result->properties[0]->values[0]);
+        $this->assertSame('literal', $result->properties[0]->values[0]->valueType);
+        $this->assertSame('value1', $result->properties[0]->values[0]->value);
 
         $this->assertInstanceOf('stdClass', $result->properties[0]->values[1]);
-        $this->assertAttributeEquals('literal', 'valueType', $result->properties[0]->values[1]);
-        $this->assertAttributeEquals('value2', 'value', $result->properties[0]->values[1]);
+        $this->assertSame('literal', $result->properties[0]->values[1]->valueType);
+        $this->assertSame('value2', $result->properties[0]->values[1]->value);
 
         $this->assertInstanceOf('stdClass', $result->properties[1]);
-        $this->assertAttributeEquals('#propertyUri2', 'predicateUri', $result->properties[1]);
-        $this->assertAttributeInternalType('array', 'values', $result->properties[1]);
-        $this->assertAttributeCount(1, 'values', $result->properties[1]);
+        $this->assertSame('#propertyUri2', $result->properties[1]->predicateUri);
+        $this->assertIsArray($result->properties[1]->values);
+        $this->assertCount(1, $result->properties[1]->values);
 
         $this->assertInstanceOf('stdClass', $result->properties[1]->values[0]);
-        $this->assertAttributeEquals('resource', 'valueType', $result->properties[1]->values[0]);
-        $this->assertAttributeEquals(GenerisRdf::GENERIS_BOOLEAN, 'value', $result->properties[1]->values[0]);
+        $this->assertSame('resource', $result->properties[1]->values[0]->valueType);
+        $this->assertSame(GenerisRdf::GENERIS_BOOLEAN, $result->properties[1]->values[0]->value);
     }
 
     /**
-     * @expectedException common_exception_NoContent
      * @author Lionel Lecaque, lionel@taotesting.com
      */
     public function testGetResourceDesciptionNoContentTripple()
     {
+        $this->expectException(common_exception_NoContent::class);
         $resourceDescProphecy = $this->createResourceProphecy('#fakeUri');
         $resourceDescProphecy->getRdfTriples()->willReturn([]);
         $formatter = new core_kernel_classes_ResourceFormatter();
@@ -222,28 +223,28 @@ class ResourceFormatterTest extends TestCase
         $result = $formatter->getResourceDescription($resourceDescProphecy->reveal(), false);
 
         $this->assertInstanceOf('stdClass', $result);
-        $this->assertAttributeEquals('#fakeUri', 'uri', $result);
-        $this->assertAttributeInternalType('array', 'properties', $result);
-        $this->assertAttributeCount(3, 'properties', $result);
+        $this->assertSame('#fakeUri', $result->uri);
+        $this->assertIsArray($result->properties);
+        $this->assertCount(3, $result->properties);
 
         $this->assertInstanceOf('stdClass', $result->properties[0]);
-        $this->assertAttributeEquals('#predicate0', 'predicateUri', $result->properties[0]);
-        $this->assertAttributeInternalType('array', 'values', $result->properties[0]);
-        $this->assertAttributeCount(1, 'values', $result->properties[0]);
+        $this->assertSame('#predicate0', $result->properties[0]->predicateUri);
+        $this->assertIsArray($result->properties[0]->values);
+        $this->assertCount(1,$result->properties[0]->values);
 
         $this->assertInstanceOf('stdClass', $result->properties[0]->values[0]);
-        $this->assertAttributeEquals('resource', 'valueType', $result->properties[0]->values[0]);
-        $this->assertAttributeEquals(GenerisRdf::GENERIS_BOOLEAN, 'value', $result->properties[0]->values[0]);
+        $this->assertSame('resource', $result->properties[0]->values[0]->valueType);
+        $this->assertSame(GenerisRdf::GENERIS_BOOLEAN, $result->properties[0]->values[0]->value);
 
         for ($i = 1; $i < 3; $i++) {
             $this->assertInstanceOf('stdClass', $result->properties[$i]);
-            $this->assertAttributeEquals('#predicate' . $i, 'predicateUri', $result->properties[$i]);
-            $this->assertAttributeInternalType('array', 'values', $result->properties[$i]);
-            $this->assertAttributeCount(1, 'values', $result->properties[$i]);
+            $this->assertSame('#predicate' . $i, $result->properties[$i]->predicateUri);
+            $this->assertIsArray($result->properties[$i]->values);
+            $this->assertCount(1,$result->properties[$i]->values);
 
             $this->assertInstanceOf('stdClass', $result->properties[$i]->values[0]);
-            $this->assertAttributeEquals('literal', 'valueType', $result->properties[$i]->values[0]);
-            $this->assertAttributeEquals('object' . $i, 'value', $result->properties[$i]->values[0]);
+            $this->assertSame('literal', $result->properties[$i]->values[0]->valueType);
+            $this->assertSame('object' . $i, $result->properties[$i]->values[0]->value);
         }
     }
 }

--- a/test/unit/model/data/permission/FreeAccessTest.php
+++ b/test/unit/model/data/permission/FreeAccessTest.php
@@ -32,11 +32,11 @@ class FreeAccessTest extends TestCase
      */
     private $user;
 
-    public function setUp()
+    public function setUp(): void
     {
         $user = $this->prophesize('oat\oatbox\user\User');
         $user->getIdentifier()->willReturn('tastIdentifier\\_of_//User');
-        
+
         $this->user = $user->reveal();
     }
 
@@ -45,7 +45,7 @@ class FreeAccessTest extends TestCase
         $model = new FreeAccess();
         $this->assertInstanceOf('oat\generis\model\data\permission\PermissionInterface', $model);
     }
-    
+
     public function testGetPermissions()
     {
         $model = new FreeAccess();
@@ -58,12 +58,12 @@ class FreeAccessTest extends TestCase
         $model = new FreeAccess();
         $this->assertEquals([], $model->getSupportedRights());
     }
-    
+
     public function testPhpSerialize()
     {
         $phpCode = \common_Utils::toPHPVariableString(new FreeAccess());
         $restoredModel = eval('return ' . $phpCode . ';');
-        
+
         $this->assertInstanceOf('oat\generis\model\data\permission\PermissionInterface', $restoredModel);
         $this->assertEquals([], $restoredModel->getSupportedRights());
         $this->assertEquals(['res1' => [FreeAccess::RIGHT_UNSUPPORTED]], $restoredModel->getPermissions($this->user, ['res1']));

--- a/test/unit/model/data/permission/IntersectionTest.php
+++ b/test/unit/model/data/permission/IntersectionTest.php
@@ -32,44 +32,44 @@ class IntersectionTest extends TestCase
      */
     private $user;
 
-    public function setUp()
+    public function setUp(): void
     {
         $user = $this->prophesize('oat\oatbox\user\User');
         $user->getIdentifier()->willReturn('tastIdentifier\\_of_//User');
-        
+
         $this->user = $user->reveal();
     }
 
-   
+
     private function createIntersection()
     {
         $permissionModel1 = $this->prophesize('oat\generis\model\data\permission\PermissionInterface');
         $permissionModel1->getSupportedRights()->willReturn(['rightA', 'rightB', 'rightC', 'right']);
-        
+
         $permissionModel2 = $this->prophesize('oat\generis\model\data\permission\PermissionInterface');
         $permissionModel2->getSupportedRights()->willReturn(['rightB', 'rightC', 'rightD', 'rightAB']);
-        
+
         $permissionModel3 = $this->prophesize('oat\generis\model\data\permission\PermissionInterface');
         $permissionModel3->getSupportedRights()->willReturn(['rightC', 'rightD', 'rightE', 'rightABC']);
-        
+
         // res1
         $permissionModel1->getPermissions($this->user, ['res1'])->willReturn(['res1' => ['rightA']]);
         $permissionModel2->getPermissions($this->user, ['res1'])->willReturn(['res1' => ['rightB']]);
         $permissionModel3->getPermissions($this->user, ['res1'])->willReturn(['res1' => ['rightC']]);
-        
+
         // res2
         $permissionModel1->getPermissions($this->user, ['res1', 'res2'])->willReturn(['res1' => ['rightA', 'rightC'], 'res2' => []]);
         $permissionModel2->getPermissions($this->user, ['res1', 'res2'])->willReturn(['res1' => ['rightC'], 'res2' => []]);
         $permissionModel3->getPermissions($this->user, ['res1', 'res2'])->willReturn(['res1' => ['rightC', 'rightD'], 'res2' => []]);
-        
+
         return Intersection::spawn([$permissionModel1->reveal(), $permissionModel2->reveal(), $permissionModel3->reveal()]);
     }
-    
+
     public function testConstruct()
     {
         $this->assertInstanceOf('oat\generis\model\data\permission\PermissionInterface', $this->createIntersection());
     }
-    
+
     public function testGetPermissions()
     {
         $model = $this->createIntersection();
@@ -82,12 +82,12 @@ class IntersectionTest extends TestCase
         $model = $this->createIntersection();
         $this->assertEquals(['rightC'], $model->getSupportedRights());
     }
-    
+
     public function testOnResourceCreated()
     {
         $permissionModel = $this->prophesize('oat\generis\model\data\permission\PermissionInterface');
         $permissionModel2 = $this->prophesize('oat\generis\model\data\permission\PermissionInterface');
-        
+
         $model = Intersection::spawn([$permissionModel->reveal(),$permissionModel2->reveal()]);
         $resourceprophecy = $this->prophesize('core_kernel_classes_Resource');
         $resource = $resourceprophecy->reveal();
@@ -95,7 +95,10 @@ class IntersectionTest extends TestCase
         $permissionModel->onResourceCreated($resource)->shouldHaveBeenCalled();
         $permissionModel2->onResourceCreated($resource)->shouldHaveBeenCalled();
     }
-    
+
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testPhpSerialize()
     {
         // no idea how to test

--- a/test/unit/model/data/permission/NoAccessTest.php
+++ b/test/unit/model/data/permission/NoAccessTest.php
@@ -32,11 +32,11 @@ class NoAccessTest extends TestCase
      */
     private $user;
 
-    public function setUp()
+    public function setUp(): void
     {
         $user = $this->prophesize('oat\oatbox\user\User');
         $user->getIdentifier()->willReturn('tastIdentifier\\_of_//User');
-        
+
         $this->user = $user->reveal();
     }
 
@@ -45,7 +45,7 @@ class NoAccessTest extends TestCase
         $model = new NoAccess();
         $this->assertInstanceOf('oat\generis\model\data\permission\PermissionInterface', $model);
     }
-    
+
     public function testGetPermissions()
     {
         $model = new NoAccess();

--- a/test/unit/model/persistence/smoothsql/SmoothModelIteratorTest.php
+++ b/test/unit/model/persistence/smoothsql/SmoothModelIteratorTest.php
@@ -28,43 +28,43 @@ use oat\generis\test\TestCase;
 class SmoothModelIteratorTest extends TestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
     }
 
-   
+
     private function createIterator()
     {
 
         $persistenceProphecy = $this->prophesize('common_persistence_SqlPersistence');
-        
+
         $statementProphecy = $this->prophesize('PDOStatement');
         $statementValue = [
-            "modelid" => 1,
-            "subject" => '#subject',
-            "predicate" => '#predicate',
-            "object" => 'obb',
-            "id" => 898,
+            "modelid"    => 1,
+            "subject"    => '#subject',
+            "predicate"  => '#predicate',
+            "object"     => 'obb',
+            "id"         => 898,
             "l_language" => 'en-US',
-            "author" => 'testauthor'
+            "author"     => 'testauthor'
         ];
         $statementValue2 = [
-            "modelid" => 1,
-            "subject" => '#subject2',
-            "predicate" => '#predicate2',
-            "object" => 'ob2',
-            "id" => 899,
+            "modelid"    => 1,
+            "subject"    => '#subject2',
+            "predicate"  => '#predicate2',
+            "object"     => 'ob2',
+            "id"         => 899,
             "l_language" => 'en-US',
-            "author" => 'testauthor'
+            "author"     => 'testauthor'
         ];
         $return = new ReturnPromise([
             $statementValue,
             $statementValue2,
             false
         ]);
-        
+
         $statementProphecy->fetch()->will($return);
-        
+
         $plop = $statementProphecy->reveal();
 
         $query = 'SELECT * FROM statements ORDER BY id';
@@ -73,38 +73,38 @@ class SmoothModelIteratorTest extends TestCase
         $platformProphecy = $this->prophesize('common_persistence_sql_Platform');
         $platformProphecy->limitStatement($query, 100, 0)->willReturn($finalQuery);
         $platform = $platformProphecy->reveal();
-        
+
         $persistenceProphecy->getPlatForm()->willReturn($platform);
         $persistenceProphecy
-        ->query($finalQuery, Argument::type('array'))
-        ->willReturn($plop);
-         
+            ->query($finalQuery, Argument::type('array'))
+            ->willReturn($plop);
+
         $iterator = new \core_kernel_persistence_smoothsql_SmoothIterator($persistenceProphecy->reveal());
         return $iterator;
     }
-    
+
     public function testConstruct()
     {
         $this->assertInstanceOf('core_kernel_persistence_smoothsql_SmoothIterator', $this->createIterator());
     }
-    
+
     /**
      * @author Lionel Lecaque, lionel@taotesting.com
      */
     public function testCurrent()
     {
-                
+
         $iterator = $this->createIterator();
         $this->assertTrue($iterator->valid());
-        
+
         $current = $iterator->current();
         $this->assertInstanceOf('core_kernel_classes_Triple', $current);
-        $this->assertAttributeEquals(1, 'modelid', $current);
-        $this->assertAttributeEquals('#subject', 'subject', $current);
-        $this->assertAttributeEquals('#predicate', 'predicate', $current);
-        $this->assertAttributeEquals('obb', 'object', $current);
-        $this->assertAttributeEquals(898, 'id', $current);
-        $this->assertAttributeEquals('en-US', 'lg', $current);
+        $this->assertSame(1, $current->modelid);
+        $this->assertSame('#subject', $current->subject);
+        $this->assertSame('#predicate', $current->predicate);
+        $this->assertSame('obb', $current->object);
+        $this->assertSame(898, $current->id);
+        $this->assertSame('en-US', $current->lg);
     }
 
     /**
@@ -117,11 +117,11 @@ class SmoothModelIteratorTest extends TestCase
         $this->assertTrue($iterator->valid());
         $current = $iterator->current();
         $this->assertInstanceOf('core_kernel_classes_Triple', $current);
-        $this->assertAttributeEquals(1, 'modelid', $current);
-        $this->assertAttributeEquals('#subject2', 'subject', $current);
-        $this->assertAttributeEquals('#predicate2', 'predicate', $current);
-        $this->assertAttributeEquals('ob2', 'object', $current);
-        $this->assertAttributeEquals(899, 'id', $current);
-        $this->assertAttributeEquals('en-US', 'lg', $current);
+        $this->assertSame(1, $current->modelid);
+        $this->assertSame('#subject2', $current->subject);
+        $this->assertSame('#predicate2', $current->predicate);
+        $this->assertSame('ob2', $current->object);
+        $this->assertSame(899, $current->id);
+        $this->assertSame('en-US', $current->lg);
     }
 }

--- a/test/unit/model/persistence/smoothsql/SmoothRdfTest.php
+++ b/test/unit/model/persistence/smoothsql/SmoothRdfTest.php
@@ -21,6 +21,7 @@
 
 namespace oat\generis\test\unit\model\persistence\smoothsql;
 
+use common_Exception;
 use \core_kernel_persistence_smoothsql_SmoothRdf;
 use Prophecy\Prophet;
 use oat\generis\test\TestCase;
@@ -28,41 +29,39 @@ use oat\generis\test\TestCase;
 class SmoothRdfTest extends TestCase
 {
     /**
-     * @expectedException common_Exception
-     * @expectedExceptionMessage Not implemented
-     *
      * @author Lionel Lecaque, lionel@taotesting.com
      */
     public function testGet()
     {
+        $this->expectException(common_Exception::class);
+        $this->expectExceptionMessage('Not implemented');
         $prophet = new Prophet();
         $persistence = $prophet->prophesize('\common_persistence_SqlPersistence');
-        
+
         $model = $prophet->prophesize('\core_kernel_persistence_smoothsql_SmoothModel');
         $model->getPersistence()->willReturn($persistence->reveal());
-        
+
         $rdf = new core_kernel_persistence_smoothsql_SmoothRdf($model->reveal());
         $rdf->get(null, null);
     }
 
     /**
-     * @expectedException common_Exception
-     * @expectedExceptionMessage Not implemented
-     *
      * @author Lionel Lecaque, lionel@taotesting.com
      */
     public function testSearch()
     {
+        $this->expectException(common_Exception::class);
+        $this->expectExceptionMessage('Not implemented');
         $prophet = new Prophet();
         $persistence = $prophet->prophesize('\common_persistence_SqlPersistence');
-        
+
         $model = $prophet->prophesize('\core_kernel_persistence_smoothsql_SmoothModel');
         $model->getPersistence()->willReturn($persistence->reveal());
-        
+
         $rdf = new core_kernel_persistence_smoothsql_SmoothRdf($model->reveal());
         $rdf->search(null, null);
     }
-    
+
     /**
      *
      * @author Lionel Lecaque, lionel@taotesting.com
@@ -71,17 +70,17 @@ class SmoothRdfTest extends TestCase
     {
         $platform = $this->prophesize('\common_persistence_sql_Platform');
         $platform->getNowExpression()->willReturn('now');
-        
+
         $persistence = $this->prophesize('\common_persistence_SqlPersistence');
         $persistence->getPlatForm()->willReturn($platform->reveal());
         $query = "INSERT INTO statements ( modelId, subject, predicate, object, l_language, epoch, author) VALUES ( ? , ? , ? , ? , ? , ?, ?);";
-        
+
         $triple = new \core_kernel_classes_Triple();
         $triple->modelid = 22;
         $triple->subject = 'subjectUri';
         $triple->predicate = 'predicateUri';
         $triple->object = 'objectUri';
-        
+
         $persistence->exec($query, [
             22,
             'subjectUri',
@@ -91,13 +90,13 @@ class SmoothRdfTest extends TestCase
             'now',
             ''
         ])->willReturn(true);
-        
+
         $model = $this->prophesize('\core_kernel_persistence_smoothsql_SmoothModel');
         $model->getReadableModels()->willReturn([22]);
         $model->getPersistence()->willReturn($persistence->reveal());
-        
+
         $rdf = new core_kernel_persistence_smoothsql_SmoothRdf($model->reveal());
-        
+
         $this->assertTrue($rdf->add($triple));
     }
 
@@ -139,7 +138,7 @@ class SmoothRdfTest extends TestCase
 
         $this->assertTrue($rdf->add($triple));
     }
-    
+
     /**
      *
      * @author Lionel Lecaque, lionel@taotesting.com
@@ -149,26 +148,26 @@ class SmoothRdfTest extends TestCase
         $prophet = new Prophet();
         $persistence = $prophet->prophesize('\common_persistence_SqlPersistence');
         $query = "DELETE FROM statements WHERE subject = ? AND predicate = ? AND object = ? AND l_language = ?;";
-        
+
         $triple = new \core_kernel_classes_Triple();
         $triple->modelid = 22;
         $triple->subject = 'subjectUri';
         $triple->predicate = 'predicateUri';
         $triple->object = 'objectUri';
-        
+
         $persistence->exec($query, [
             'subjectUri',
             'predicateUri',
             'objectUri',
             ''
         ])->willReturn(true);
-        
+
         $model = $prophet->prophesize('\core_kernel_persistence_smoothsql_SmoothModel');
         $model->getPersistence()->willReturn($persistence->reveal());
-        
-        
+
+
         $rdf = new core_kernel_persistence_smoothsql_SmoothRdf($model->reveal());
-        
+
         $this->assertTrue($rdf->remove($triple));
     }
 }

--- a/test/unit/oatbox/config/ConfigSetsTest.php
+++ b/test/unit/oatbox/config/ConfigSetsTest.php
@@ -21,6 +21,7 @@
 
 namespace oat\generis\test\unit\config;
 
+use common_exception_InconsistentData;
 use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\config\ConfigSets;
 use oat\generis\test\TestCase;
@@ -41,7 +42,7 @@ class ConfigSetsTest extends TestCase
     /**
      * Configure registry instance
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->configurable = new ConfigurableTestSample([
             'handlers' => [
@@ -74,11 +75,9 @@ class ConfigSetsTest extends TestCase
         $this->assertEquals('baz', $this->configurable->hashGet('foo', 'bar'));
     }
 
-    /**
-     * @expectedException \common_exception_InconsistentData
-     */
     public function testHashSetException()
     {
+        $this->expectException(common_exception_InconsistentData::class);
         $this->configurable->hashSet('key', 'bar', 'baz');
     }
 

--- a/test/unit/oatbox/extension/script/OptionContainerTest.php
+++ b/test/unit/oatbox/extension/script/OptionContainerTest.php
@@ -26,21 +26,21 @@ use oat\generis\test\TestCase;
 
 class OptionContainerTest extends TestCase
 {
-    
+
     /**
      * @dataProvider instantiateProvider
      */
     public function testInstantiate(array $options, array $values, array $expectedOptions)
     {
         $optionContainer = new OptionContainer($options, $values);
-        
+        $this->assertIsArray($expectedOptions);
         // Check flags.
         foreach ($expectedOptions as $optionName => $optionValue) {
             $this->assertTrue($optionContainer->has($optionName));
             $this->assertSame($optionValue, $optionContainer->get($optionName));
         }
     }
-    
+
     public function instantiateProvider()
     {
         return [

--- a/test/unit/oatbox/log/LoggerServiceTest.php
+++ b/test/unit/oatbox/log/LoggerServiceTest.php
@@ -27,13 +27,13 @@ use oat\generis\test\TestCase;
 
 class LoggerServiceTest extends TestCase
 {
-    
+
     const RUNS = 1000;
-    
-    protected function setUp()
+
+    protected function setUp(): void
     {
     }
-    
+
     public function testFileAppender()
     {
         $dfile = tempnam(sys_get_temp_dir(), "logtest");
@@ -118,7 +118,7 @@ class LoggerServiceTest extends TestCase
         unlink($efile);
         unlink($cfile);
     }
-    
+
     public function testLogTags()
     {
         $dfile = tempnam(sys_get_temp_dir(), "logtest");
@@ -139,7 +139,7 @@ class LoggerServiceTest extends TestCase
 
         $logger->logDebug('message');
         $this->assertEntriesInFile($dfile, 0);
-        
+
         $logger->logDebug('message', ['WRONGTAG']);
         $this->assertEntriesInFile($dfile, 0);
 
@@ -156,7 +156,7 @@ class LoggerServiceTest extends TestCase
 
         unlink($dfile);
     }
-    
+
     public function assertEntriesInFile($pFile, $pCount)
     {
         if (file_exists($pFile)) {

--- a/test/unit/oatbox/log/TestLoggerTest.php
+++ b/test/unit/oatbox/log/TestLoggerTest.php
@@ -20,6 +20,7 @@
 
 namespace oat\generis\test\unit\oatbox\log;
 
+use common_exception_InconsistentData;
 use Psr\Log\LogLevel;
 use oat\generis\test\TestCase;
 
@@ -65,20 +66,16 @@ class TestLoggerTest extends TestCase
         $this->assertEquals(1, count($logger->get(LogLevel::ERROR)));
     }
 
-    /**
-     * @expectedException common_exception_InconsistentData
-     */
     public function testGetBadLevel()
     {
+        $this->expectException(common_exception_InconsistentData::class);
         $logger = new TestLogger();
         $logger->get('BAD_LEVEL');
     }
 
-    /**
-     * @expectedException common_exception_InconsistentData
-     */
     public function testHasBadLevel()
     {
+        $this->expectException(common_exception_InconsistentData::class);
         $logger = new TestLogger();
         $logger->has('BAD_LEVEL', 'testMessage');
     }

--- a/test/unit/oatbox/service/EnvironmentVariableTest.php
+++ b/test/unit/oatbox/service/EnvironmentVariableTest.php
@@ -32,7 +32,7 @@ class EnvironmentVariableTest extends TestCase
     /** @var EnvironmentVariable */
     private $subject;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->subject = new EnvironmentVariable(self::VAR_NAME);
     }
@@ -48,7 +48,8 @@ class EnvironmentVariableTest extends TestCase
 
     public function testConstructorWithNonStringKeyThrowsException()
     {
-        $this->setExpectedException(InvalidArgumentException::class, 'Environment variable name must be a string.');
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Environment variable name must be a string.');
         new EnvironmentVariable([]);
     }
 

--- a/test/unit/oatbox/user/UserLanguageServiceTest.php
+++ b/test/unit/oatbox/user/UserLanguageServiceTest.php
@@ -33,7 +33,7 @@ use oat\generis\test\TestCase;
 class UserLanguageServiceTest extends TestCase
 {
 
-    public function setUp()
+    public function setUp(): void
     {
         if (!defined('DEFAULT_LANG')) {
             define('DEFAULT_LANG', 'en-US');


### PR DESCRIPTION
related to: https://oat-sa.atlassian.net/browse/TDR-1
Upgrade to phpunit8
Main changes:
1 - Removed deprecations and methods for backward\forward compatibility  from generis TestCase
2 - setup,teardown etc. added :void
3 - expectException,exceptExceptionMessage etc. instead of setExpectedException, @expectedException,@expectedExceptionMessage
4 - assertInternalType('type') -> assertIsArray/assertIsString etc.
5 - some depricated assertions such as 'assertContains',assertAttributeEquals,assertAttributeCount,assertArraySubset etc.
6 - added @doesNotPerformAssertions to tests that do nothing and $this->assertIsTrue(true) to tests that performs no assertions but testing some logic.
7 - changed `getMock` to `createMock`. In some places this change cause errors and were modified with additional options (onlyMethods,addMethods,getMockForAbstractClass)