### PR TITLE
Fix/act 473/import test

### DIFF
--- a/common/oatbox/filesystem/Directory.php
+++ b/common/oatbox/filesystem/Directory.php
@@ -186,10 +186,10 @@ class Directory extends FileSystemHandler implements \IteratorAggregate
         foreach ($filePaths as $renaming) {
             try {
                 if ($this->getFileSystem()->rename($renaming['source'], $renaming['destination']) === false) {
-                    throw new \common_exception_FileSystemError("Unable to rename '" . $this->getPrefix() . "' into '${path}'.");
+                    throw new \common_exception_FileSystemError("Unable to rename '" . $renaming['source'] . "' into '".$renaming['destination']."'.");
                 }
             } catch (FileExistsException $e) {
-                throw new \common_exception_FileSystemError("Unable to rename '" . $this->getPrefix() . "' into '${path}'. File already exists.");
+                throw new \common_exception_FileSystemError("Unable to rename '" . $renaming['source'] . "' into '".$renaming['destination']."'. File already exists.");
             }
         }
 

--- a/common/oatbox/filesystem/Directory.php
+++ b/common/oatbox/filesystem/Directory.php
@@ -165,14 +165,20 @@ class Directory extends FileSystemHandler implements \IteratorAggregate
         // This implementation supersedes the Flysystem's one. Indeed, while using connectors
         // such as the Amazon S3 (v3) connector, rename on directories does not work. A custom
         // implementation is then needed.
-        $contents = $this->getFileSystem()->listContents($this->getPrefix(), true);
 
+        $contents = $this->getFileSystem()->listContents($this->getPrefix(), true);
+        $fileSystemId = $this->getFileSystemId().'/';
         // Filter files only.
         $filePaths = [];
         foreach ($contents as $content) {
             if ($content['type'] === 'file') {
+                $contentPath = $content['path'];
+                if(strpos($contentPath, $fileSystemId) === 0) {
+                    $contentPath = substr($contentPath, strlen($fileSystemId));
+                }
+
                 $filePaths[] = [
-                    'source' => $content['path'],
+                    'source' => $contentPath,
                     'destination' => str_replace($this->getPrefix(), $path, $content['path'])];
             }
         }

--- a/manifest.php
+++ b/manifest.php
@@ -34,7 +34,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.16.3',
+    'version' => '12.16.4',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'models' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -493,6 +493,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('12.12.0');
         }
 
-        $this->skip('12.12.0', '12.16.3');
+        $this->skip('12.12.0', '12.16.4');
     }
 }

--- a/test/integration/common/filesystem/DirectoryFilesystemTest.php
+++ b/test/integration/common/filesystem/DirectoryFilesystemTest.php
@@ -69,7 +69,7 @@ class DirectoryFilesystemTest extends GenerisTestCase
     {
         $this->generateFile('/testDirectory.exist/fileRename.txt');
         $directory = $this->tempDirectory->getDirectory('testDirectory.exist');
-        $this->expectExceptionObject(new \common_exception_FileSystemError("Unable to rename 'testDirectory.exist' into 'testDirectory.exist'. File already exists."));
+        $this->expectException(\common_exception_FileSystemError::class);
         $directory->rename('testDirectory.exist');
     }
 

--- a/test/integration/common/filesystem/DirectoryFilesystemTest.php
+++ b/test/integration/common/filesystem/DirectoryFilesystemTest.php
@@ -1,0 +1,135 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ */
+
+namespace oat\generis\test\integration\common\filesystem;
+
+use oat\generis\scripts\tools\FileSerializerMigration\MigrationHelper;
+use oat\generis\test\GenerisTestCase;
+use oat\oatbox\filesystem\Directory;
+use oat\oatbox\filesystem\File;
+use oat\oatbox\filesystem\FileSystemService;
+
+class DirectoryFilesystemTest extends GenerisTestCase
+{
+    /**
+     * @var MigrationHelper
+     */
+    protected $fileMigrationHelper;
+
+    /**
+     * @var \core_kernel_classes_Class
+     */
+    protected $testClass;
+
+    /**
+     * @var string
+     */
+    private $tempFileSystemId;
+
+    /**
+     * @var Directory
+     */
+    private $tempDirectory;
+
+    /**
+     * @var File|Directory
+     */
+    private $testFile;
+
+    /**
+     * @var FileSystemService
+     */
+    private $fileSystemService;
+
+    public function testDirectoryRename()
+    {
+        $this->generateFile('/testDirectory/fileRename.txt');
+        $directory = $this->tempDirectory->getDirectory('testDirectory');
+        $this->assertTrue($directory->rename('testDirectory.back'));
+    }
+
+    public function testDirectoryRenameAlreadyExistException()
+    {
+        $this->generateFile('/testDirectory.exist/fileRename.txt');
+        $directory = $this->tempDirectory->getDirectory('testDirectory.exist');
+        $this->expectExceptionObject(new \common_exception_FileSystemError("Unable to rename 'testDirectory.exist' into 'testDirectory.exist'. File already exists."));
+        $directory->rename('testDirectory.exist');
+    }
+
+
+    /**
+     * @return bool
+     * @throws \League\Flysystem\FileExistsException
+     * @throws \common_Exception
+     */
+    private function generateFile($path)
+    {
+        $dir = $this->getTempDirectory();
+        $this->testFile = $dir->getFile($path);
+        $this->testFile->write($path, 'PHP Unit test file');
+        return true;
+    }
+
+    /**
+     * @return Directory
+     */
+    private function getTempDirectory()
+    {
+        if (!$this->tempDirectory) {
+            $fileSystemService = $this->getMockFileSystem();
+            $this->tempFileSystemId = uniqid('rename-test-', true);
+
+            $adapters = $fileSystemService->getOption(FileSystemService::OPTION_ADAPTERS);
+            if (class_exists('League\Flysystem\Memory\MemoryAdapter')) {
+                $adapters[$this->tempFileSystemId] = [
+                    'class' => \League\Flysystem\Memory\MemoryAdapter::class
+                ];
+            } else {
+                $adapters[$this->tempFileSystemId] = [
+                    'class' => FileSystemService::FLYSYSTEM_LOCAL_ADAPTER,
+                    'options' => ['root' => '/tmp/testing']
+                ];
+            }
+            $fileSystemService->setOption(FileSystemService::OPTION_ADAPTERS, $adapters);
+            $fileSystemService->setOption(FileSystemService::OPTION_DIRECTORIES, [$this->tempFileSystemId => $this->tempFileSystemId]);
+            $fileSystemService->setOption(FileSystemService::OPTION_FILE_PATH, '/tmp/unit-test');
+
+            $fileSystemService->setServiceLocator($this->getServiceLocatorMock([
+                FileSystemService::SERVICE_ID => $fileSystemService
+            ]));
+
+            $this->tempDirectory = $fileSystemService->getDirectory($this->tempFileSystemId);
+        }
+        return $this->tempDirectory;
+    }
+
+    /**
+     * @return FileSystemService
+     */
+    private function getMockFileSystem()
+    {
+        if ($this->fileSystemService === null) {
+            $this->fileSystemService = $this->getServiceLocatorMock([FileSystemService::SERVICE_ID => new FileSystemService()])->get(FileSystemService::SERVICE_ID);
+        }
+
+        return $this->fileSystemService;
+    }
+
+}


### PR DESCRIPTION
When importing a test with the `itemMustBeOverwritten` parameter, the method `getFullPath` gets a path variable already with a prefix for some cases. Because of that generates a wrong path.

How to test:
**1**. Using this endpoint `taoQtiTest/RestQtiTests/importDeferred` with `itemMustBeOverwritten true` import a test:
curl --location --request POST 'https://{your_url}/taoQtiTest/RestQtiTests/importDeferred' \
--header 'Accept: application/json' \
--header 'Authorization: Basic {token}' \
--header 'Content-Type: multipart/form-data; boundary=--------------------------080153921549195856122698' \
--form 'qtiPackage=@Downloads/87746c869e71ad0bba881b70a0b522e95e7a22ff63290.zip' \
--form 'itemMustBeOverwritten=true' \
--form 'itemMustExist=false' \
--form 'enableMetadataValidators=true' \
--form 'enableMetadataGuardians=true'
**2**. After success import, run import again with the same parameters.

The second try should be without any errors