### PR TITLE
Added basic session context support

### DIFF
--- a/common/oatbox/session/SessionContext.php
+++ b/common/oatbox/session/SessionContext.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace oat\oatbox\session;
 
 /**
- * Represents an additional context that can be attached to a sesson
+ * Represents an additional context that can be attached to a session
  */
 interface SessionContext
 {

--- a/common/oatbox/session/SessionContext.php
+++ b/common/oatbox/session/SessionContext.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\oatbox\session;
+
+/**
+ * Represents an additional context that can be attached to a sesson
+ */
+interface SessionContext
+{
+}

--- a/common/session/class.AnonymousSession.php
+++ b/common/session/class.AnonymousSession.php
@@ -33,26 +33,12 @@ use oat\oatbox\user\UserLanguageServiceInterface;
  * @package generis
 
  */
-class common_session_AnonymousSession implements common_session_StatelessSession, ServiceLocatorAwareInterface
+class common_session_AnonymousSession extends common_session_BasicSession implements common_session_StatelessSession
 {
-    use ServiceLocatorAwareTrait;
-
-    /**
-     * (non-PHPdoc)
-     * @see common_session_Session::getUser()
-     */
-    public function getUser()
-    {
-        return new AnonymousUser();
-    }
     
-    /**
-     * (non-PHPdoc)
-     * @see common_session_Session::getUserUri()
-     */
-    public function getUserUri()
+    public function __construct()
     {
-        return null;
+        parent::__construct(new AnonymousUser());
     }
 
     /**
@@ -120,10 +106,4 @@ class common_session_AnonymousSession implements common_session_StatelessSession
     {
         // nothing to do here
     }
-
-    public function getContexts(string $class = null): array
-    {
-        return [];
-    }
-
 }

--- a/common/session/class.AnonymousSession.php
+++ b/common/session/class.AnonymousSession.php
@@ -120,4 +120,10 @@ class common_session_AnonymousSession implements common_session_StatelessSession
     {
         // nothing to do here
     }
+
+    public function getContexts($class = null): array
+    {
+        return [];
+    }
+
 }

--- a/common/session/class.AnonymousSession.php
+++ b/common/session/class.AnonymousSession.php
@@ -121,7 +121,7 @@ class common_session_AnonymousSession implements common_session_StatelessSession
         // nothing to do here
     }
 
-    public function getContexts($class = null): array
+    public function getContexts(string $class = null): array
     {
         return [];
     }

--- a/common/session/class.AnonymousSession.php
+++ b/common/session/class.AnonymousSession.php
@@ -21,9 +21,8 @@
 
 use oat\generis\model\GenerisRdf;
 use oat\oatbox\user\AnonymousUser;
-use Zend\ServiceManager\ServiceLocatorAwareInterface;
-use Zend\ServiceManager\ServiceLocatorAwareTrait;
 use oat\oatbox\user\UserLanguageServiceInterface;
+use oat\oatbox\session\SessionContext;
 
 /**
  * Represents a userless Session.
@@ -35,10 +34,12 @@ use oat\oatbox\user\UserLanguageServiceInterface;
  */
 class common_session_AnonymousSession extends common_session_BasicSession implements common_session_StatelessSession
 {
-    
-    public function __construct()
+    /**
+     * @param SessionContext[] $contexts
+     */
+    public function __construct($contexts = [])
     {
-        parent::__construct(new AnonymousUser());
+        parent::__construct(new AnonymousUser(), $contexts);
     }
 
     /**

--- a/common/session/class.BasicSession.php
+++ b/common/session/class.BasicSession.php
@@ -175,7 +175,7 @@ class common_session_BasicSession implements common_session_Session, ServiceLoca
         return $this;
     }
 
-    public function getContexts($class = null): array
+    public function getContexts(string $class = null): array
     {
         $contexts = $this->contexts;
         if ($class != null) {

--- a/common/session/class.BasicSession.php
+++ b/common/session/class.BasicSession.php
@@ -49,11 +49,18 @@ class common_session_BasicSession implements common_session_Session, ServiceLoca
      */
     private $user;
 
-    private $contexts = [];
+    /**
+     * @var SessionContext[]
+     */
+    private $contexts;
 
-    public function __construct(User $user)
+    /**
+     * @param SessionContext[] $context
+     */
+    public function __construct(User $user, array $contexts = [])
     {
         $this->user = $user;
+        $this->contexts = $contexts;
     }
     
     public function getUser()
@@ -167,12 +174,6 @@ class common_session_BasicSession implements common_session_Session, ServiceLoca
             $this->user->setServiceLocator($serviceLocator);
         }
         return $this->setOriginalServiceLocator($serviceLocator);
-    }
-
-    public function withContext(SessionContext $context): self
-    {
-        $this->contexts[] = $context;
-        return $this;
     }
 
     public function getContexts(string $class = null): array

--- a/common/session/class.BasicSession.php
+++ b/common/session/class.BasicSession.php
@@ -36,6 +36,7 @@ use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\ServiceManager\ServiceLocatorAwareTrait;
 use oat\oatbox\user\UserLanguageServiceInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use oat\oatbox\session\SessionContext;
 
 class common_session_BasicSession implements common_session_Session, ServiceLocatorAwareInterface
 {
@@ -47,6 +48,8 @@ class common_session_BasicSession implements common_session_Session, ServiceLoca
      * @var common_user_User
      */
     private $user;
+
+    private $contexts = [];
 
     public function __construct(User $user)
     {
@@ -165,4 +168,20 @@ class common_session_BasicSession implements common_session_Session, ServiceLoca
         }
         return $this->setOriginalServiceLocator($serviceLocator);
     }
+
+    public function withContext(SessionContext $context): array
+    {
+        $this->contexts[] = $context;
+        return $this;
+    }
+
+    public function getContexts($class = null): array
+    {
+        $contexts = $this->contexts;
+        if ($class != null) {
+            $contexts = array_filter($contexts, function($element) use ($class) {return $element instanceof $class;});
+        }
+        return $contexts;
+    }
+
 }

--- a/common/session/class.BasicSession.php
+++ b/common/session/class.BasicSession.php
@@ -169,7 +169,7 @@ class common_session_BasicSession implements common_session_Session, ServiceLoca
         return $this->setOriginalServiceLocator($serviceLocator);
     }
 
-    public function withContext(SessionContext $context): array
+    public function withContext(SessionContext $context): self
     {
         $this->contexts[] = $context;
         return $this;

--- a/common/session/interface.Session.php
+++ b/common/session/interface.Session.php
@@ -1,4 +1,6 @@
 <?php
+use oat\oatbox\session\SessionContext;
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -105,4 +107,11 @@ interface common_session_Session
      * refreshes the information stored in the current session
      */
     public function refresh();
+
+    /**
+     * Returns additional contexts of the current session
+     * @param string $class Class to filter the contexts by, or all if none provided
+     * @return SessionContext[]
+     */
+    public function getContexts($class = null): array;
 }

--- a/common/session/interface.Session.php
+++ b/common/session/interface.Session.php
@@ -113,5 +113,5 @@ interface common_session_Session
      * @param string $class Class to filter the contexts by, or all if none provided
      * @return SessionContext[]
      */
-    public function getContexts($class = null): array;
+    public function getContexts(string $class = null): array;
 }

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.16.4',
+    'version' => '12.17.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -493,6 +493,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('12.12.0');
         }
 
-        $this->skip('12.12.0', '12.16.4');
+        $this->skip('12.12.0', '12.17.0');
     }
 }

--- a/test/unit/common/session/BasicSessionTest.php
+++ b/test/unit/common/session/BasicSessionTest.php
@@ -16,8 +16,6 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
- *
- *
  */
 
 declare(strict_types=1);

--- a/test/unit/common/session/BasicSessionTest.php
+++ b/test/unit/common/session/BasicSessionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ *
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\generis\test\unit\common\persistence;
+
+use oat\generis\test\TestCase;
+use oat\oatbox\user\User;
+use oat\oatbox\session\SessionContext;
+
+class BasicSessionTest extends TestCase
+{
+    public function testGetContext() : void
+    {
+        $user = $this->prophesize(User::class)->reveal();
+        $context1 = $this->prophesize(SessionContext::class)->reveal();
+        $context2 = $this->prophesize(SessionContext::class)->reveal();
+
+        $session = new \common_session_BasicSession($user);
+        $session->withContext($context1);
+        $this->assertEquals([$context1], $session->getContexts());
+
+        $session->withContext($context2);
+        $this->assertEquals([$context1, $context2], $session->getContexts());
+    }
+
+}

--- a/test/unit/common/session/BasicSessionTest.php
+++ b/test/unit/common/session/BasicSessionTest.php
@@ -36,11 +36,10 @@ class BasicSessionTest extends TestCase
         $context1 = $this->prophesize(SessionContext::class)->reveal();
         $context2 = $this->prophesize(SessionContext::class)->reveal();
 
-        $session = new \common_session_BasicSession($user);
-        $session->withContext($context1);
+        $session = new \common_session_BasicSession($user, [$context1]);
         $this->assertEquals([$context1], $session->getContexts());
 
-        $session->withContext($context2);
+        $session = new \common_session_BasicSession($user, [$context1, $context2]);
         $this->assertEquals([$context1, $context2], $session->getContexts());
     }
 


### PR DESCRIPTION
Currently in order to add context information to a session we have to extend the session itself (see taoLti). This feature would allow us to add different kind of contexts to the basic session