### PR TITLE
Tdr 22/try autowiring in event manager

### DIFF
--- a/common/oatbox/event/EventManager.php
+++ b/common/oatbox/event/EventManager.php
@@ -50,7 +50,9 @@ class EventManager extends ConfigurableService
         foreach ($this->getListeners($eventObject) as $callback) {
             if (is_array($callback) && count($callback) == 2) {
                 list($key, $function) = $callback;
-                if (is_string($key) && !class_exists($key) && $this->getServiceManager()->has($key)) {
+                if (
+                    (is_string($key) && $this->getServiceManager()->has($key))
+                    || (class_exists($key) && is_subclass_of($key, ConfigurableService::class))) {
                     $service = $this->getServiceManager()->get($key);
                     $callback = [$service, $function];
                 }

--- a/common/oatbox/event/EventManager.php
+++ b/common/oatbox/event/EventManager.php
@@ -22,6 +22,7 @@
 namespace oat\oatbox\event;
 
 use oat\oatbox\service\ConfigurableService;
+use oat\oatbox\service\ServiceNotFoundException;
 
 /**
  * The simple placeholder ServiceManager
@@ -50,11 +51,13 @@ class EventManager extends ConfigurableService
         foreach ($this->getListeners($eventObject) as $callback) {
             if (is_array($callback) && count($callback) == 2) {
                 list($key, $function) = $callback;
-                if (
-                    (is_string($key) && $this->getServiceManager()->has($key))
-                    || (class_exists($key) && is_subclass_of($key, ConfigurableService::class))) {
-                    $service = $this->getServiceManager()->get($key);
-                    $callback = [$service, $function];
+                if (is_string($key)) {
+                    try {
+                        $service = $this->getServiceManager()->get($key);
+                        $callback = [$service, $function];
+                    } catch (ServiceNotFoundException $e) {
+                        //do nothing
+                    }
                 }
             }
             call_user_func($callback, $eventObject);

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.17.0',
+    'version' => '12.18.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -493,6 +493,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('12.12.0');
         }
 
-        $this->skip('12.12.0', '12.17.0');
+        $this->skip('12.12.0', '12.18.0');
     }
 }


### PR DESCRIPTION
Service manager tries to to autowiring by class name.
The same feature should be awailable in eventManager in order to be able to register event listener by configurable service class name:
```
$this->registerEvent(
        CreatedEvent::class,
        [Service::class, 'catchCreatedEvent']
);
```