### PR TITLE
Remove __serialize method in basic Container class

### DIFF
--- a/core/kernel/classes/class.Container.php
+++ b/core/kernel/classes/class.Container.php
@@ -30,17 +30,4 @@
  */
 class core_kernel_classes_Container extends common_Object
 {
-
-
-    /**
-     * Short description of method __serialize
-     *
-     * @access public
-     * @author firstname and lastname of author, <author@example.org>
-     * @return string
-     */
-    public function __serialize()
-    {
-        return 'container';
-    }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.20.0',
+    'version' => '12.20.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -493,6 +493,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('12.12.0');
         }
 
-        $this->skip('12.12.0', '12.20.0');
+        $this->skip('12.12.0', '12.20.1');
     }
 }


### PR DESCRIPTION
This method became magic in PHP 7.4 and current implementation raises fatal issues.

If you are running tao on 7.4 version, attempt to launch delivery will fail due to such error message
```
Warning: session_start(): Failed to decode session object. Session has been destroyed in /var/www/html/tao/models/classes/mvc/Bootstrap.php on line 292
```
I tried only LTI launch, but I guess it will fail on regular too.