### PR TITLE
Fix/lti user without first name

### DIFF
--- a/core/kernel/persistence/smoothsql/class.Resource.php
+++ b/core/kernel/persistence/smoothsql/class.Resource.php
@@ -659,9 +659,11 @@ class core_kernel_persistence_smoothsql_Resource implements core_kernel_persiste
             $normalizedValues[] = $value->getUri();
         } elseif (is_array($value)) {
             foreach ($value as $val) {
-                $normalizedValues[] = $val instanceof core_kernel_classes_Resource
-                    ? $val->getUri()
-                    : $val;
+                if ($val !== null) {
+                    $normalizedValues[] = $val instanceof core_kernel_classes_Resource
+                        ? $val->getUri()
+                        : $val;
+                }
             }
         } else {
             $normalizedValues[] = ($value == null) ? '' : $value;

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.20.0',
+    'version' => '12.20.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -493,6 +493,6 @@ class Updater extends common_ext_ExtensionUpdater
             $this->setVersion('12.12.0');
         }
 
-        $this->skip('12.12.0', '12.20.0');
+        $this->skip('12.12.0', '12.20.1');
     }
 }

--- a/test/integration/ResourceTest.php
+++ b/test/integration/ResourceTest.php
@@ -318,6 +318,25 @@ class ResourceTest extends GenerisPhpUnitTestRunner
         $instance->delete(true);
     }
 
+    public function testSetPropertiesValuesWithNull()
+    {
+
+        $class = new core_kernel_classes_Class(GenerisRdf::GENERIS_BOOLEAN);
+        $instance = $class->createInstance('a label', 'a comment');
+        $this->assertIsA($instance, 'core_kernel_classes_Resource');
+
+        $instance->setPropertiesValues([
+            OntologyRdfs::RDFS_COMMENT        => [null]
+        ]);
+
+        $seeAlso = $instance->getOnePropertyValue(new core_kernel_classes_Property(OntologyRdfs::RDFS_COMMENT));
+        $this->assertNotNull($seeAlso);
+        $this->assertIsA($seeAlso, 'core_kernel_classes_Literal');
+        $this->assertEquals($seeAlso->literal, "a comment");
+
+        $instance->delete(true);
+    }
+
     public function testGetUsedLanguages()
     {
         $class = new core_kernel_classes_Class(GenerisRdf::GENERIS_BOOLEAN, __METHOD__);


### PR DESCRIPTION
The fix for 
`Fatal error: Uncaught TypeError: Argument 4 passed to core_kernel_classes_Triple::createTriple() must be of the type string, null given, called in /generis/core/kernel/persistence/smoothsql/class.Resource.php on line 642 and defined in /generis/core/kernel/classes/class.Triple.php:106 `

How to reproduce:
Start a Lti session without `first_name` or `last_name` for a TT