### PR TITLE
UNO-229: Add alias property

### DIFF
--- a/core/GenerisRdf.php
+++ b/core/GenerisRdf.php
@@ -23,60 +23,61 @@ namespace oat\generis\model;
 
 interface GenerisRdf
 {
-    const GENERIS_NS = 'http://www.tao.lu/Ontologies/generis.rdf';
-    const GENERIS_BOOLEAN = 'http://www.tao.lu/Ontologies/generis.rdf#Boolean';
-    const GENERIS_TRUE = 'http://www.tao.lu/Ontologies/generis.rdf#True';
-    const GENERIS_FALSE = 'http://www.tao.lu/Ontologies/generis.rdf#False';
-    const PROPERTY_IS_LG_DEPENDENT = 'http://www.tao.lu/Ontologies/generis.rdf#is_language_dependent';
-    const CLASS_GENERIS_RESOURCE = 'http://www.tao.lu/Ontologies/generis.rdf#generis_Ressource';
-    const PROPERTY_MULTIPLE = 'http://www.tao.lu/Ontologies/generis.rdf#Multiple';
-    const CLASS_GENERIS_FILE = 'http://www.tao.lu/Ontologies/generis.rdf#File';
-    const PROPERTY_FILE_FILENAME = 'http://www.tao.lu/Ontologies/generis.rdf#FileName';
-    const PROPERTY_FILE_FILEPATH = 'http://www.tao.lu/Ontologies/generis.rdf#FilePath';
-    const PROPERTY_FILE_FILESYSTEM = 'http://www.tao.lu/Ontologies/generis.rdf#FileRepository';
-    const PROPERTY_VERSIONEDFILE_VERSION = 'http://www.tao.lu/Ontologies/generis.rdf#FileVersion';
-    const CLASS_GENERIS_VERSIONEDREPOSITORY = 'http://www.tao.lu/Ontologies/generis.rdf#VersionedRepository';
-    const PROPERTY_GENERIS_VERSIONEDREPOSITORY_URL = 'http://www.tao.lu/Ontologies/generis.rdf#VersionedRepositoryUrl';
-    const PROPERTY_GENERIS_VERSIONEDREPOSITORY_PATH = 'http://www.tao.lu/Ontologies/generis.rdf#VersionedRepositoryPath';
-    const PROPERTY_GENERIS_VERSIONEDREPOSITORY_TYPE = 'http://www.tao.lu/Ontologies/generis.rdf#VersionedRepositoryType';
-    const PROPERTY_GENERIS_VERSIONEDREPOSITORY_LOGIN = 'http://www.tao.lu/Ontologies/generis.rdf#VersionedRepositoryLogin';
-    const PROPERTY_GENERIS_VERSIONEDREPOSITORY_PASSWORD = 'http://www.tao.lu/Ontologies/generis.rdf#VersionedRepositoryPassword';
-    const PROPERTY_GENERIS_VERSIONEDREPOSITORY_ENABLED = 'http://www.tao.lu/Ontologies/generis.rdf#VersionedRepositoryEnabled';
-    const PROPERTY_GENERIS_VERSIONEDREPOSITORY_ROOTFILE = 'http://www.tao.lu/Ontologies/generis.rdf#RepositoryRootFile';
-    const PROPERTY_GENERIS_VCS_TYPE_SUBVERSION = 'http://www.tao.lu/Ontologies/generis.rdf#VCSTypeSubversion';
-    const PROPERTY_GENERIS_VCS_TYPE_SUBVERSION_WIN = 'http://www.tao.lu/Ontologies/generis.rdf#VCSTypeSubversionWindows';
-    const PROPERTY_GENERIS_VCS_TYPE_CVS = 'http://www.tao.lu/Ontologies/generis.rdf#VCSTypeCvs';
-    const INSTANCE_GENERIS_VCS_TYPE_LOCAL = 'http://www.tao.lu/Ontologies/generis.rdf#VCSLocalDirectory';
-    const CLASS_ROLE = 'http://www.tao.lu/Ontologies/generis.rdf#ClassRole';
-    const PROPERTY_ROLE_ISSYSTEM = 'http://www.tao.lu/Ontologies/generis.rdf#isSystem';
-    const PROPERTY_ROLE_INCLUDESROLE = 'http://www.tao.lu/Ontologies/generis.rdf#includesRole';
-    const INSTANCE_ROLE_GENERIS = 'http://www.tao.lu/Ontologies/generis.rdf#GenerisRole';
-    const INSTANCE_ROLE_ANONYMOUS = 'http://www.tao.lu/Ontologies/generis.rdf#AnonymousRole';
-    const CLASS_SUBCRIPTION = 'http://www.tao.lu/Ontologies/generis.rdf#Subscription';
-    const PROPERTY_SUBCRIPTION_URL = 'http://www.tao.lu/Ontologies/generis.rdf#SubscriptionUrl';
-    const PROPERTY_SUBCRIPTION_MASK = 'http://www.tao.lu/Ontologies/generis.rdf#SubscriptionMask';
-    const CLASS_MASK = 'http://www.tao.lu/Ontologies/generis.rdf#Mask';
-    const PROPERTY_MASK_SUBJECT = 'http://www.tao.lu/Ontologies/generis.rdf#MaskSubject';
-    const PROPERTY_MASK_PREDICATE = 'http://www.tao.lu/Ontologies/generis.rdf#MaskPredicate';
-    const PROPERTY_MASK_OBJECT = 'http://www.tao.lu/Ontologies/generis.rdf#MaskObject';
+    public const GENERIS_NS = 'http://www.tao.lu/Ontologies/generis.rdf';
+    public const GENERIS_BOOLEAN = 'http://www.tao.lu/Ontologies/generis.rdf#Boolean';
+    public const GENERIS_TRUE = 'http://www.tao.lu/Ontologies/generis.rdf#True';
+    public const GENERIS_FALSE = 'http://www.tao.lu/Ontologies/generis.rdf#False';
+    public const PROPERTY_ALIAS = 'http://www.tao.lu/Ontologies/generis.rdf#alias';
+    public const PROPERTY_IS_LG_DEPENDENT = 'http://www.tao.lu/Ontologies/generis.rdf#is_language_dependent';
+    public const CLASS_GENERIS_RESOURCE = 'http://www.tao.lu/Ontologies/generis.rdf#generis_Ressource';
+    public const PROPERTY_MULTIPLE = 'http://www.tao.lu/Ontologies/generis.rdf#Multiple';
+    public const CLASS_GENERIS_FILE = 'http://www.tao.lu/Ontologies/generis.rdf#File';
+    public const PROPERTY_FILE_FILENAME = 'http://www.tao.lu/Ontologies/generis.rdf#FileName';
+    public const PROPERTY_FILE_FILEPATH = 'http://www.tao.lu/Ontologies/generis.rdf#FilePath';
+    public const PROPERTY_FILE_FILESYSTEM = 'http://www.tao.lu/Ontologies/generis.rdf#FileRepository';
+    public const PROPERTY_VERSIONEDFILE_VERSION = 'http://www.tao.lu/Ontologies/generis.rdf#FileVersion';
+    public const CLASS_GENERIS_VERSIONEDREPOSITORY = 'http://www.tao.lu/Ontologies/generis.rdf#VersionedRepository';
+    public const PROPERTY_GENERIS_VERSIONEDREPOSITORY_URL = 'http://www.tao.lu/Ontologies/generis.rdf#VersionedRepositoryUrl';
+    public const PROPERTY_GENERIS_VERSIONEDREPOSITORY_PATH = 'http://www.tao.lu/Ontologies/generis.rdf#VersionedRepositoryPath';
+    public const PROPERTY_GENERIS_VERSIONEDREPOSITORY_TYPE = 'http://www.tao.lu/Ontologies/generis.rdf#VersionedRepositoryType';
+    public const PROPERTY_GENERIS_VERSIONEDREPOSITORY_LOGIN = 'http://www.tao.lu/Ontologies/generis.rdf#VersionedRepositoryLogin';
+    public const PROPERTY_GENERIS_VERSIONEDREPOSITORY_PASSWORD = 'http://www.tao.lu/Ontologies/generis.rdf#VersionedRepositoryPassword';
+    public const PROPERTY_GENERIS_VERSIONEDREPOSITORY_ENABLED = 'http://www.tao.lu/Ontologies/generis.rdf#VersionedRepositoryEnabled';
+    public const PROPERTY_GENERIS_VERSIONEDREPOSITORY_ROOTFILE = 'http://www.tao.lu/Ontologies/generis.rdf#RepositoryRootFile';
+    public const PROPERTY_GENERIS_VCS_TYPE_SUBVERSION = 'http://www.tao.lu/Ontologies/generis.rdf#VCSTypeSubversion';
+    public const PROPERTY_GENERIS_VCS_TYPE_SUBVERSION_WIN = 'http://www.tao.lu/Ontologies/generis.rdf#VCSTypeSubversionWindows';
+    public const PROPERTY_GENERIS_VCS_TYPE_CVS = 'http://www.tao.lu/Ontologies/generis.rdf#VCSTypeCvs';
+    public const INSTANCE_GENERIS_VCS_TYPE_LOCAL = 'http://www.tao.lu/Ontologies/generis.rdf#VCSLocalDirectory';
+    public const CLASS_ROLE = 'http://www.tao.lu/Ontologies/generis.rdf#ClassRole';
+    public const PROPERTY_ROLE_ISSYSTEM = 'http://www.tao.lu/Ontologies/generis.rdf#isSystem';
+    public const PROPERTY_ROLE_INCLUDESROLE = 'http://www.tao.lu/Ontologies/generis.rdf#includesRole';
+    public const INSTANCE_ROLE_GENERIS = 'http://www.tao.lu/Ontologies/generis.rdf#GenerisRole';
+    public const INSTANCE_ROLE_ANONYMOUS = 'http://www.tao.lu/Ontologies/generis.rdf#AnonymousRole';
+    public const CLASS_SUBCRIPTION = 'http://www.tao.lu/Ontologies/generis.rdf#Subscription';
+    public const PROPERTY_SUBCRIPTION_URL = 'http://www.tao.lu/Ontologies/generis.rdf#SubscriptionUrl';
+    public const PROPERTY_SUBCRIPTION_MASK = 'http://www.tao.lu/Ontologies/generis.rdf#SubscriptionMask';
+    public const CLASS_MASK = 'http://www.tao.lu/Ontologies/generis.rdf#Mask';
+    public const PROPERTY_MASK_SUBJECT = 'http://www.tao.lu/Ontologies/generis.rdf#MaskSubject';
+    public const PROPERTY_MASK_PREDICATE = 'http://www.tao.lu/Ontologies/generis.rdf#MaskPredicate';
+    public const PROPERTY_MASK_OBJECT = 'http://www.tao.lu/Ontologies/generis.rdf#MaskObject';
     //@deprecated use UserRdf::CLASS_URI
-    const CLASS_GENERIS_USER = 'http://www.tao.lu/Ontologies/generis.rdf#User';
+    public const CLASS_GENERIS_USER = 'http://www.tao.lu/Ontologies/generis.rdf#User';
     //@deprecated use UserRdf::PROPERTY_LOGIN
-    const PROPERTY_USER_LOGIN = 'http://www.tao.lu/Ontologies/generis.rdf#login';
+    public const PROPERTY_USER_LOGIN = 'http://www.tao.lu/Ontologies/generis.rdf#login';
     //@deprecated use UserRdf::PROPERTY_PASSWORD
-    const PROPERTY_USER_PASSWORD = 'http://www.tao.lu/Ontologies/generis.rdf#password';
+    public const PROPERTY_USER_PASSWORD = 'http://www.tao.lu/Ontologies/generis.rdf#password';
     //@deprecated use UserRdf::PROPERTY_UILG
-    const PROPERTY_USER_UILG = 'http://www.tao.lu/Ontologies/generis.rdf#userUILg';
+    public const PROPERTY_USER_UILG = 'http://www.tao.lu/Ontologies/generis.rdf#userUILg';
     //@deprecated use UserRdf::PROPERTY_DEFLG
-    const PROPERTY_USER_DEFLG = 'http://www.tao.lu/Ontologies/generis.rdf#userDefLg';
+    public const PROPERTY_USER_DEFLG = 'http://www.tao.lu/Ontologies/generis.rdf#userDefLg';
     //@deprecated use UserRdf::PROPERTY_MAIL
-    const PROPERTY_USER_MAIL = 'http://www.tao.lu/Ontologies/generis.rdf#userMail';
+    public const PROPERTY_USER_MAIL = 'http://www.tao.lu/Ontologies/generis.rdf#userMail';
     //@deprecated use UserRdf::PROPERTY_FIRSTNAME
-    const PROPERTY_USER_FIRSTNAME = 'http://www.tao.lu/Ontologies/generis.rdf#userFirstName';
+    public const PROPERTY_USER_FIRSTNAME = 'http://www.tao.lu/Ontologies/generis.rdf#userFirstName';
     //@deprecated use UserRdf::PROPERTY_USER_LASTNAME
-    const PROPERTY_USER_LASTNAME = 'http://www.tao.lu/Ontologies/generis.rdf#userLastName';
+    public const PROPERTY_USER_LASTNAME = 'http://www.tao.lu/Ontologies/generis.rdf#userLastName';
     //@deprecated use UserRdf::PROPERTY_ROLES
-    const PROPERTY_USER_ROLES = 'http://www.tao.lu/Ontologies/generis.rdf#userRoles';
+    public const PROPERTY_USER_ROLES = 'http://www.tao.lu/Ontologies/generis.rdf#userRoles';
     //@deprecated use UserRdf::PROPERTY_TIMEZONE
-    const PROPERTY_USER_TIMEZONE = 'http://www.tao.lu/Ontologies/generis.rdf#userTimezone';
+    public const PROPERTY_USER_TIMEZONE = 'http://www.tao.lu/Ontologies/generis.rdf#userTimezone';
 }

--- a/core/kernel/impl/class.ApiModelOO.php
+++ b/core/kernel/impl/class.ApiModelOO.php
@@ -24,6 +24,8 @@ use oat\generis\model\OntologyRdf;
 use oat\generis\model\OntologyRdfs;
 use Doctrine\DBAL\DBALException;
 use oat\generis\model\data\import\RdfImporter;
+use oat\oatbox\service\ServiceManager;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 error_reporting(E_ALL);
 
@@ -53,7 +55,7 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
      * Short description of attribute instance
      *
      * @access private
-     * @var ApiModelOO
+     * @var self
      */
     private static $instance = null;
 
@@ -74,9 +76,11 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
     {
         $modelIds = [];
         foreach ($sourceNamespaces as $namespace) {
-            if (!preg_match("/\#$/", $namespace)) {
+            if (!preg_match('/#$/', $namespace)) {
                 $namespace .= "#";
             }
+
+            $dbWrapper = core_kernel_classes_DbWrapper::singleton();
 
             $result = $dbWrapper->query('SELECT * FROM "models"  WHERE "modeluri" = ?', [
                 $namespace
@@ -119,18 +123,18 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
     {
         $returnValue = (string) '';
 
-        
-        
-        
-        
+
+
+
+
         $dbWrapper = core_kernel_classes_DbWrapper::singleton();
         $subject = $dbWrapper->quote($uriResource);
-        
+
         $baseNs = [
                         'xmlns:rdf'     => 'http://www.w3.org/1999/02/22-rdf-syntax-ns#',
                         'xmlns:rdfs'    => 'http://www.w3.org/2000/01/rdf-schema#'
                     ];
-        
+
         $query = 'SELECT "models"."modelid", "models"."modeluri" FROM "models" INNER JOIN "statements" ON "statements"."modelid" = "models"."modelid"
 											WHERE "statements"."subject" = ' . $subject;
         $query = $dbWrapper->limitStatement($query, 1);
@@ -141,19 +145,19 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
             if (!preg_match("/#$/", $modelUri)) {
                 $modelUri .= '#';
             }
-            
+
             $result->closeCursor();
         }
         $currentNs = ["xmlns:ns{$modelId}" => $modelUri];
         $currentNs = array_merge($baseNs, $currentNs);
-        
-        
+
+
         $allModels = [];
         $result = $dbWrapper->query('SELECT * FROM "models"');
         while ($row = $result->fetch(PDO::FETCH_ASSOC)) {
             $allModels[] = $row;
         }
-        
+
         $allNs = [];
         foreach ($allModels as $i => $model) {
             if (!preg_match("/#$/", $model['modeluri'])) {
@@ -162,30 +166,30 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
             $allNs["xmlns:ns{$model['modelid']}"] = $model['modeluri'];
         }
         $allNs = array_merge($baseNs, $allNs);
-                
+
         try {
             $dom = new DOMDocument();
             $dom->formatOutput = true;
             $root = $dom->createElement('rdf:RDF');
-                
+
             foreach ($currentNs as $namespaceId => $namespaceUri) {
                 $root->setAttribute($namespaceId, $namespaceUri);
             }
             $dom->appendChild($root);
-                    
+
             $description = $dom->createElement('rdf:Description');
             $description->setAttribute('rdf:about', $uriResource);
-            
+
             $result = $dbWrapper->query('SELECT * FROM "statements" WHERE "subject" = ' . $subject);
             while ($row = $result->fetch()) {
                 $predicate  = trim($row['predicate']);
                 $object     = trim($row['object']);
                 $lang       = trim($row['l_language']);
-                
+
                 $nodeName = null;
-                
+
                 foreach ($allNs as $namespaceId => $namespaceUri) {
-                    if ($namespaceId == 'xml:base') {
+                    if ($namespaceId === 'xml:base') {
                         continue;
                     }
                     if (preg_match("/^" . preg_quote($namespaceUri, '/') . "/", $predicate)) {
@@ -197,12 +201,12 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
                         break;
                     }
                 }
-                
+
                 $resourceValue = false;
                 foreach ($allNs as $namespaceId => $namespaceUri) {
                     if (
-                        preg_match("/^" . preg_quote($namespaceUri, '/') . "/", $object) ||
-                        preg_match("/^http\:\/\/(.*)\#[a-zA-Z1-9]*/", $object)
+                        preg_match('/^' . preg_quote($namespaceUri, '/') . '/', $object) ||
+                        preg_match("/^http:\/\/(.*)#[a-zA-Z1-9]*/", $object)
                     ) {
                         $resourceValue = true;
                         break;
@@ -214,12 +218,12 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
                         if (!empty($lang)) {
                             $node->setAttribute('xml:lang', $lang);
                         }
-                        
+
                         if ($resourceValue) {
                                 $node->setAttribute('rdf:resource', $object);
                         } else {
                             if (!empty($object) && !is_null($object)) {
-                                
+
                                 /**
                                  * Replace the CDATA section inside XML fields by a replacement tag:
                                  * <![CDATA[ ]]> to <CDATA></CDATA>
@@ -242,9 +246,9 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
         } catch (DomException $e) {
             print $e;
         }
-        
-        
-        
+
+
+
 
         return (string) $returnValue;
     }
@@ -258,16 +262,13 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
      */
     public function getMetaClasses()
     {
-        $returnValue = null;
-
-        
         $returnValue = new core_kernel_classes_ContainerCollection(new core_kernel_classes_Container(__METHOD__), __METHOD__);
-        
+
         $classClass = new core_kernel_classes_Class(OntologyRdfs::RDFS_CLASS);
         foreach ($classClass->getSubClasses(true) as $uri => $subClass) {
             $returnValue->add($subClass);
         }
-        
+
 
         return $returnValue;
     }
@@ -281,14 +282,10 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
      */
     public function getRootClasses()
     {
-        $returnValue = null;
-
-        
-    
         $returnValue = new core_kernel_classes_ContainerCollection(new core_kernel_classes_Container(__METHOD__), __METHOD__);
-        
+
         $dbWrapper = core_kernel_classes_DbWrapper::singleton();
-        
+
         $query =  "SELECT DISTINCT subject FROM statements WHERE (predicate = ? AND object = ?) 
         			AND subject NOT IN (SELECT subject FROM statements WHERE predicate = ?)";
         $result = $dbWrapper->query($query, [
@@ -296,12 +293,12 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
             OntologyRdfs::RDFS_CLASS,
             OntologyRdfs::RDFS_SUBCLASSOF
         ]);
-        
+
         while ($row = $result->fetch()) {
             $returnValue->add(new core_kernel_classes_Class($row['subject']));
         }
-        
-        
+
+
 
         return $returnValue;
     }
@@ -321,11 +318,10 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
     {
         $returnValue = (bool) false;
 
-        
+
         $dbWrapper  = core_kernel_classes_DbWrapper::singleton();
         $platform   = $dbWrapper->getPlatForm();
         $localNs    = common_ext_NamespaceManager::singleton()->getLocalNamespace();
-        $mask       = 'yyy[admin,administrators,authors]';  //now it's the default right mode
         $query = 'INSERT INTO statements (modelid,subject,predicate,object,l_language,author,epoch)
         			VALUES  (?, ?, ?, ?, ?, ? , ?);';
 
@@ -336,17 +332,17 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
                 $predicate,
                 $object,
                 $language,
-                \common_session_SessionManager::getSession()->getUserUri(),
+                common_session_SessionManager::getSession()->getUserUri(),
                 $platform->getNowExpression()
-                 
+
             ]);
         } catch (DBALException $e) {
             if ($e->getCode() !== '00000') {
                 throw new common_Exception("Unable to setStatement (SPO) {$subject}, {$predicate}, {$object} : " . $e->getMessage());
             }
         }
-        
-        
+
+
 
         return (bool) $returnValue;
     }
@@ -360,26 +356,22 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
      */
     public function getAllClasses()
     {
-        $returnValue = null;
-
-        
-        
         $returnValue = new core_kernel_classes_ContainerCollection(new core_kernel_classes_Container(__METHOD__), __METHOD__);
-        
+
         $dbWrapper = core_kernel_classes_DbWrapper::singleton();
-        
+
         $query =  "SELECT DISTINCT subject FROM statements WHERE (predicate = ? AND object = ?) OR predicate = ?";
         $result = $dbWrapper->query($query, [
             OntologyRdf::RDF_TYPE,
             OntologyRdfs::RDFS_CLASS,
             OntologyRdfs::RDFS_SUBCLASSOF
         ]);
-        
+
         while ($row = $result->fetch()) {
             $returnValue->add(new core_kernel_classes_Class($row['subject']));
         }
-        
-        
+
+
 
         return $returnValue;
     }
@@ -397,8 +389,8 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
     {
         $returnValue = null;
 
-        
-        
+
+
         $sqlQuery = "SELECT subject FROM statements WHERE predicate = ? AND object= ? ";
         $dbWrapper = core_kernel_classes_DbWrapper::singleton();
         $sqlResult = $dbWrapper->query($sqlQuery, [
@@ -412,7 +404,7 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
             $returnValue->add($container);
         }
 
-        
+
 
         return $returnValue;
     }
@@ -430,11 +422,8 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
      */
     public function removeStatement($subject, $predicate, $object, $language)
     {
-        $returnValue = (bool) false;
-
-        
         $dbWrapper  = core_kernel_classes_DbWrapper::singleton();
-    
+
         $query = "DELETE FROM statements WHERE subject = ?
         			AND predicate = ? AND object = ?
         			AND (l_language = ? OR l_language = '')";
@@ -445,8 +434,6 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
             $object,
             $language
         ]);
-        
-        
 
         return (bool) $returnValue;
     }
@@ -464,7 +451,6 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
     {
         $returnValue = null;
 
-        
         $sqlQuery = "SELECT object FROM statements WHERE subject = ? AND predicate = ?";
         $dbWrapper = core_kernel_classes_DbWrapper::singleton();
         $sqlResult = $dbWrapper->query($sqlQuery, [
@@ -482,7 +468,7 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
             $container->debug = __METHOD__ ;
             $returnValue->add($container);
         }
-        
+
 
         return $returnValue;
     }
@@ -498,13 +484,13 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
     {
         $returnValue = null;
 
-        
+
         if (!isset(self::$instance)) {
             $c = __CLASS__;
             self::$instance = new $c();
         }
         $returnValue = self::$instance;
-        
+
 
         return $returnValue;
     }

--- a/core/kernel/impl/class.ApiModelOO.php
+++ b/core/kernel/impl/class.ApiModelOO.php
@@ -284,11 +284,9 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
     {
         $returnValue = $this->createClassCollection(__METHOD__);
 
-        $dbWrapper = core_kernel_classes_DbWrapper::singleton();
-
-        $query =  "SELECT DISTINCT subject FROM statements WHERE (predicate = ? AND object = ?) 
-        			AND subject NOT IN (SELECT subject FROM statements WHERE predicate = ?)";
-        $result = $dbWrapper->query($query, [
+        $query =  'SELECT DISTINCT subject FROM statements WHERE (predicate = ? AND object = ?) 
+        			AND subject NOT IN (SELECT subject FROM statements WHERE predicate = ?)';
+        $result = core_kernel_classes_DbWrapper::singleton()->query($query, [
             OntologyRdf::RDF_TYPE,
             OntologyRdfs::RDFS_CLASS,
             OntologyRdfs::RDFS_SUBCLASSOF
@@ -358,10 +356,8 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
     {
         $returnValue = $this->createClassCollection(__METHOD__);
 
-        $dbWrapper = core_kernel_classes_DbWrapper::singleton();
-
-        $query =  "SELECT DISTINCT subject FROM statements WHERE (predicate = ? AND object = ?) OR predicate = ?";
-        $result = $dbWrapper->query($query, [
+        $query =  'SELECT DISTINCT subject FROM statements WHERE (predicate = ? AND object = ?) OR predicate = ?';
+        $result = core_kernel_classes_DbWrapper::singleton()->query($query, [
             OntologyRdf::RDF_TYPE,
             OntologyRdfs::RDFS_CLASS,
             OntologyRdfs::RDFS_SUBCLASSOF

--- a/core/kernel/impl/class.ApiModelOO.php
+++ b/core/kernel/impl/class.ApiModelOO.php
@@ -262,7 +262,7 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
      */
     public function getMetaClasses()
     {
-        $returnValue = new core_kernel_classes_ContainerCollection(new core_kernel_classes_Container(__METHOD__), __METHOD__);
+        $returnValue = $this->createClassCollection(__METHOD__);
 
         $classClass = new core_kernel_classes_Class(OntologyRdfs::RDFS_CLASS);
         foreach ($classClass->getSubClasses(true) as $uri => $subClass) {
@@ -282,7 +282,7 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
      */
     public function getRootClasses()
     {
-        $returnValue = new core_kernel_classes_ContainerCollection(new core_kernel_classes_Container(__METHOD__), __METHOD__);
+        $returnValue = $this->createClassCollection(__METHOD__);
 
         $dbWrapper = core_kernel_classes_DbWrapper::singleton();
 
@@ -356,7 +356,7 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
      */
     public function getAllClasses()
     {
-        $returnValue = new core_kernel_classes_ContainerCollection(new core_kernel_classes_Container(__METHOD__), __METHOD__);
+        $returnValue = $this->createClassCollection(__METHOD__);
 
         $dbWrapper = core_kernel_classes_DbWrapper::singleton();
 
@@ -397,7 +397,7 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
             $predicate,
             $object
         ]);
-        $returnValue = new core_kernel_classes_ContainerCollection(new common_Object(__METHOD__));
+        $returnValue = new core_kernel_classes_ContainerCollection(new common_Object());
         while ($row = $sqlResult->fetch()) {
             $container = new core_kernel_classes_Resource($row['subject'], __METHOD__);
             $container->debug = __METHOD__ ;
@@ -457,7 +457,7 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
             $subject,
             $predicate
         ]);
-        $returnValue = new core_kernel_classes_ContainerCollection(new common_Object(__METHOD__));
+        $returnValue = new core_kernel_classes_ContainerCollection(new common_Object());
         while ($row = $sqlResult->fetch()) {
             $value = $row['object'];
             if (!common_Utils::isUri($value)) {
@@ -512,5 +512,10 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
     public function getServiceLocator()
     {
         return ServiceManager::getServiceManager();
+    }
+
+    private function createClassCollection(string $debug = ''): core_kernel_classes_ContainerCollection
+    {
+        return new core_kernel_classes_ContainerCollection(new core_kernel_classes_Container(), $debug);
     }
 }

--- a/core/ontology/generis.rdf
+++ b/core/ontology/generis.rdf
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
-<rdf:RDF 
-	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
-	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" 
-	xml:base="http://www.tao.lu/Ontologies/generis.rdf#" 
-	xmlns:generis="http://www.tao.lu/Ontologies/generis.rdf#" 
+<rdf:RDF
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xml:base="http://www.tao.lu/Ontologies/generis.rdf#"
+	xmlns:generis="http://www.tao.lu/Ontologies/generis.rdf#"
 	xmlns:widget="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#"
 >
   <rdf:Description rdf:about="http://www.tao.lu/Ontologies/generis.rdf#generis_Ressource">
@@ -21,6 +21,14 @@
     <rdfs:label xml:lang="en-US"><![CDATA[Plugin]]></rdfs:label>
     <rdfs:comment xml:lang="en-US"><![CDATA[Plugin]]></rdfs:comment>
     <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#Model"/>
+    <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
+    <widget:widget rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextBox"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/generis.rdf#alias">
+    <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[Alias]]></rdfs:label>
+    <rdfs:comment xml:lang="en-US"><![CDATA[Alias to be used when publishing a remote delivery]]></rdfs:comment>
+    <rdfs:domain rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
     <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
     <widget:widget rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextBox"/>
   </rdf:Description>
@@ -56,7 +64,7 @@
     <rdfs:comment xml:lang="en-US"><![CDATA[False]]></rdfs:comment>
   </rdf:Description>
 
-  
+
   <rdf:Description rdf:about="http://www.tao.lu/Ontologies/generis.rdf#File">
     <rdfs:subClassOf rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#generis_Ressource"/>
     <rdfs:label xml:lang="en-US"><![CDATA[generis_File]]></rdfs:label>
@@ -76,7 +84,7 @@
     <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#File"/>
     <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
   </rdf:Description>
-  
+
   <rdf:Description rdf:about="http://www.tao.lu/Ontologies/generis.rdf#VersionedRepository">
     <rdfs:subClassOf rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#generis_Ressource"/>
     <rdfs:label xml:lang="en-US"><![CDATA[Repository]]></rdfs:label>
@@ -222,7 +230,7 @@
     <rdfs:domain rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#Mask"/>
     <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
   </rdf:Description>
-  
+
   <!-- Users Management -->
   <rdf:Description rdf:about="http://www.tao.lu/Ontologies/generis.rdf#User">
     <rdfs:subClassOf rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#generis_Ressource"/>
@@ -310,7 +318,7 @@
   	<generis:Multiple rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#True"/>
   	<widget:widget rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#CheckBox"/>
   </rdf:Description>
-  
+
   <rdf:Description rdf:about="http://www.tao.lu/Ontologies/generis.rdf#ClassRole">
     <rdfs:label xml:lang="en-US"><![CDATA[Role]]></rdfs:label>
     <rdfs:comment xml:lang="en-US"><![CDATA[Role]]></rdfs:comment>
@@ -333,18 +341,18 @@
 	<rdfs:comment xml:lang="en-US"><![CDATA[Is a system role]]></rdfs:comment>
 	<generis:Multiple rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#False"/>
   </rdf:Description>
-  
+
   <rdf:Description rdf:about="http://www.tao.lu/Ontologies/generis.rdf#AbstractRole">
   	<rdfs:subClassOf rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#ClassRole"/>
     <rdfs:label xml:lang="en-US"><![CDATA[Abstract]]></rdfs:label>
-    <rdfs:comment xml:lang="en-US"><![CDATA[The Abstract Role Class]]></rdfs:comment>	
+    <rdfs:comment xml:lang="en-US"><![CDATA[The Abstract Role Class]]></rdfs:comment>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.tao.lu/Ontologies/generis.rdf#UserRole">
     <rdfs:subClassOf rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#ClassRole"/>
     <rdfs:label xml:lang="en-US"><![CDATA[User Role]]></rdfs:label>
     <rdfs:comment xml:lang="en-US"><![CDATA[The user centric Role Class]]></rdfs:comment>
   </rdf:Description>
-  
+
   <rdf:Description rdf:about="http://www.tao.lu/Ontologies/generis.rdf#GenerisRole">
   	<rdf:type rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#AbstractRole"/>
   	<rdfs:label xml:lang="en-US"><![CDATA[Generis]]></rdfs:label>

--- a/manifest.php
+++ b/manifest.php
@@ -33,7 +33,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.20.2',
+    'version' => '12.21.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -494,5 +494,17 @@ class Updater extends common_ext_ExtensionUpdater
         }
 
         $this->skip('12.12.0', '12.20.2');
+
+        if ($this->isVersion('12.20.2')) {
+            $file = __DIR__ . DIRECTORY_SEPARATOR .
+                '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR .
+                'core' . DIRECTORY_SEPARATOR .
+                'ontology' . DIRECTORY_SEPARATOR .
+                'generis.rdf';
+            $api = core_kernel_impl_ApiModelOO::singleton();
+            $api->importXmlRdf('http://www.tao.lu/Ontologies/generis.rdf', $file);
+
+            $this->setVersion('12.21.0');
+        }
     }
 }


### PR DESCRIPTION
This PR does nothing on its own and required for [`tao`](https://github.com/oat-sa/tao-core/pull/2503).

- [UNO-229](https://oat-sa.atlassian.net/browse/UNO-229) feature: add `GenerisRdf::PROPERTY_ALIAS` and its definition, attached to `22-rdf-syntax-ns#Property` resource
- [UNO-229](https://oat-sa.atlassian.net/browse/UNO-229) fix: import required classes to `core_kernel_impl_ApiModelOO` scope and tide it up a bit