### PR TITLE
Remove declare statement from the manifest

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -1,7 +1,5 @@
 <?php
 
-declare(strict_types=1);
-
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License


### PR DESCRIPTION
Fix: remove `declare` statement from `manifest.php` in order to fix the compatibility with the node-based AST PHP parser