### PR TITLE
[UNO-329] Feature: added a TTL option to KeyValueSessionHandler

### DIFF
--- a/common/session/php/class.KeyValueSessionHandler.php
+++ b/common/session/php/class.KeyValueSessionHandler.php
@@ -29,23 +29,23 @@ use oat\oatbox\service\ConfigurableService;
  */
 class common_session_php_KeyValueSessionHandler extends ConfigurableService implements common_session_php_SessionHandler
 {
-    const OPTION_PERSISTENCE = 'persistence';
-    
-    const KEY_NAMESPACE = "generis:session:";
-    
-    /**
-     * @var common_persistence_KeyValuePersistence
-     */
-    private $sessionPersistence = null;
-    
+    public const OPTION_PERSISTENCE = 'persistence';
+    public const OPTION_SESSION_TTL = 'session_ttl';
+
+    public const KEY_NAMESPACE = 'generis:session:';
+
+    /** @var common_persistence_KeyValuePersistence */
+    private $sessionPersistence;
+
     protected function getPersistence()
     {
         if (is_null($this->sessionPersistence)) {
             $this->sessionPersistence = common_persistence_KeyValuePersistence::getPersistence($this->getOption(self::OPTION_PERSISTENCE));
         }
+
         return $this->sessionPersistence;
     }
-    
+
     /**
      * (non-PHPdoc)
      * @see common_session_storage_SessionStorage::open()
@@ -80,7 +80,7 @@ class common_session_php_KeyValueSessionHandler extends ConfigurableService impl
      */
     public function write($id, $data)
     {
-        return $this->getPersistence()->set(self::KEY_NAMESPACE . $id, $data, (int) ini_get('session.gc_maxlifetime'));
+        return $this->getPersistence()->set(self::KEY_NAMESPACE . $id, $data, $this->getSessionTtl());
     }
 
     /**
@@ -105,5 +105,10 @@ class common_session_php_KeyValueSessionHandler extends ConfigurableService impl
         // solution 2 : Check if the eprsistence is capable of autonomous garbage
         //
         return true;
+    }
+
+    private function getSessionTtl(): int
+    {
+        return $this->getOption(self::OPTION_SESSION_TTL) ?? (int)ini_get('session.gc_maxlifetime');
     }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.23.0',
+    'version' => '12.24.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -525,6 +525,8 @@ class Updater extends common_ext_ExtensionUpdater
 
             $this->setVersion('12.23.0');
         }
+
+        $this->skip('12.23.0', '12.24.0');
     }
 
     /**

--- a/test/unit/common/session/php/common_session_php_KeyValueSessionHandlerTest.php
+++ b/test/unit/common/session/php/common_session_php_KeyValueSessionHandlerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+use oat\generis\test\TestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class common_session_php_KeyValueSessionHandlerTest extends TestCase
+{
+    /** @var common_persistence_KeyValuePersistence|MockObject */
+    private $persistence;
+
+    protected function setUp(): void
+    {
+        $this->persistence = $this->createMock(common_persistence_KeyValuePersistence::class);
+    }
+
+    public function testWriteDefaultTtl(): void
+    {
+        $defaultTtl = (int)ini_get('session.gc_maxlifetime');
+
+        $this->expectSetTtl($defaultTtl);
+
+        $handler = $this->createHandler();
+
+        $handler->write('id', 'data');
+    }
+
+    public function testWriteGivenTtl(): void
+    {
+        $this->expectSetTtl(10);
+
+        $handler = $this->createHandler(10);
+
+        $handler->write('id', 'data');
+    }
+
+    private function expectSetTtl(int $expected): void
+    {
+        $this->persistence
+            ->expects($this->once())
+            ->method('set')->with(
+                $this->anything(),
+                $this->anything(),
+                $expected
+            );
+    }
+
+    private function createHandler(?int $ttl = null): common_session_php_KeyValueSessionHandler
+    {
+        $handler = $this->getMockBuilder(common_session_php_KeyValueSessionHandler::class)
+            ->setConstructorArgs(
+                [
+                    [
+                        common_session_php_KeyValueSessionHandler::OPTION_SESSION_TTL => $ttl
+                    ]
+                ]
+            )
+            ->onlyMethods(['getPersistence'])
+            ->getMock();
+
+        $handler->method('getPersistence')->willReturn($this->persistence);
+
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
+        return $handler;
+    }
+}


### PR DESCRIPTION
This improvement is implemented in order to make session TTL configurable from a client extension without touching php.ini 