### PR TITLE
Feature UNO-339 add search text box definition to the widget RDF representation

### DIFF
--- a/core/WidgetRdf.php
+++ b/core/WidgetRdf.php
@@ -23,19 +23,20 @@ namespace oat\generis\model;
 
 interface WidgetRdf
 {
-    const CLASS_URI_WIDGET = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetClass';
-    const PROPERTY_WIDGET = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#widget';
-    const PROPERTY_WIDGET_RADIO = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#RadioBox';
-    const PROPERTY_WIDGET_COMBO = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#ComboBox';
-    const PROPERTY_WIDGET_CHECK = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#CheckBox';
-    const PROPERTY_WIDGET_FTE = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextBox';
-    const PROPERTY_WIDGET_TIMER = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#Timer';
-    const PROPERTY_WIDGET_TREEVIEW = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TreeView';
-    const PROPERTY_WIDGET_LABEL = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#Label';
-    const PROPERTY_WIDGET_CONSTRAINT_TYPE = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#rangeConstraintTypes';
-    const PROPERTY_WIDGET_ID = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#identifier';
-    const CLASS_URI_WIDGET_RENDERER = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetRenderer';
-    const PROPERTY_WIDGET_RENDERER_WIDGET = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#renderedWidget';
-    const PROPERTY_WIDGET_RENDERER_MODE = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#renderMode';
-    const PROPERTY_WIDGET_RENDERER_IMPLEMENTATION = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#implementation';
+    public const CLASS_URI_WIDGET                        = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetClass';
+    public const PROPERTY_WIDGET                         = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#widget';
+    public const PROPERTY_WIDGET_RADIO                   = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#RadioBox';
+    public const PROPERTY_WIDGET_COMBO                   = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#ComboBox';
+    public const PROPERTY_WIDGET_CHECK                   = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#CheckBox';
+    public const PROPERTY_WIDGET_FTE                     = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextBox';
+    public const PROPERTY_WIDGET_SEARCH_BOX              = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#SearchTextBox';
+    public const PROPERTY_WIDGET_TIMER                   = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#Timer';
+    public const PROPERTY_WIDGET_TREEVIEW                = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TreeView';
+    public const PROPERTY_WIDGET_LABEL                   = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#Label';
+    public const PROPERTY_WIDGET_CONSTRAINT_TYPE         = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#rangeConstraintTypes';
+    public const PROPERTY_WIDGET_ID                      = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#identifier';
+    public const CLASS_URI_WIDGET_RENDERER               = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetRenderer';
+    public const PROPERTY_WIDGET_RENDERER_WIDGET         = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#renderedWidget';
+    public const PROPERTY_WIDGET_RENDERER_MODE           = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#renderMode';
+    public const PROPERTY_WIDGET_RENDERER_IMPLEMENTATION = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#implementation';
 }

--- a/core/WidgetRdf.php
+++ b/core/WidgetRdf.php
@@ -23,20 +23,22 @@ namespace oat\generis\model;
 
 interface WidgetRdf
 {
-    public const CLASS_URI_WIDGET                        = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetClass';
-    public const PROPERTY_WIDGET                         = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#widget';
-    public const PROPERTY_WIDGET_RADIO                   = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#RadioBox';
-    public const PROPERTY_WIDGET_COMBO                   = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#ComboBox';
-    public const PROPERTY_WIDGET_CHECK                   = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#CheckBox';
-    public const PROPERTY_WIDGET_FTE                     = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextBox';
-    public const PROPERTY_WIDGET_SEARCH_BOX              = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#SearchTextBox';
-    public const PROPERTY_WIDGET_TIMER                   = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#Timer';
-    public const PROPERTY_WIDGET_TREEVIEW                = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TreeView';
-    public const PROPERTY_WIDGET_LABEL                   = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#Label';
-    public const PROPERTY_WIDGET_CONSTRAINT_TYPE         = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#rangeConstraintTypes';
-    public const PROPERTY_WIDGET_ID                      = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#identifier';
-    public const CLASS_URI_WIDGET_RENDERER               = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetRenderer';
-    public const PROPERTY_WIDGET_RENDERER_WIDGET         = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#renderedWidget';
-    public const PROPERTY_WIDGET_RENDERER_MODE           = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#renderMode';
-    public const PROPERTY_WIDGET_RENDERER_IMPLEMENTATION = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#implementation';
+    public const NAMESPACE = 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf';
+
+    public const CLASS_URI_WIDGET                        = self::NAMESPACE . '#WidgetClass';
+    public const PROPERTY_WIDGET                         = self::NAMESPACE . '#widget';
+    public const PROPERTY_WIDGET_RADIO                   = self::NAMESPACE . '#RadioBox';
+    public const PROPERTY_WIDGET_COMBO                   = self::NAMESPACE . '#ComboBox';
+    public const PROPERTY_WIDGET_CHECK                   = self::NAMESPACE . '#CheckBox';
+    public const PROPERTY_WIDGET_FTE                     = self::NAMESPACE . '#TextBox';
+    public const PROPERTY_WIDGET_SEARCH_BOX              = self::NAMESPACE . '#SearchTextBox';
+    public const PROPERTY_WIDGET_TIMER                   = self::NAMESPACE . '#Timer';
+    public const PROPERTY_WIDGET_TREEVIEW                = self::NAMESPACE . '#TreeView';
+    public const PROPERTY_WIDGET_LABEL                   = self::NAMESPACE . '#Label';
+    public const PROPERTY_WIDGET_CONSTRAINT_TYPE         = self::NAMESPACE . '#rangeConstraintTypes';
+    public const PROPERTY_WIDGET_ID                      = self::NAMESPACE . '#identifier';
+    public const CLASS_URI_WIDGET_RENDERER               = self::NAMESPACE . '#WidgetRenderer';
+    public const PROPERTY_WIDGET_RENDERER_WIDGET         = self::NAMESPACE . '#renderedWidget';
+    public const PROPERTY_WIDGET_RENDERER_MODE           = self::NAMESPACE . '#renderMode';
+    public const PROPERTY_WIDGET_RENDERER_IMPLEMENTATION = self::NAMESPACE . '#implementation';
 }

--- a/core/ontology/widgetdefinitions.rdf
+++ b/core/ontology/widgetdefinitions.rdf
@@ -112,6 +112,12 @@
     <widget:textLength><![CDATA[3]]></widget:textLength>
     <widget:textLength><![CDATA[255]]></widget:textLength>
   </rdf:Description>
+  <rdf:Description rdf:about="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#SearchTextBox">
+    <rdf:type rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetClass"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[Search Input]]></rdfs:label>
+    <rdfs:comment xml:lang="en-US"><![CDATA[One may select 0 to N values from a defined list]]></rdfs:comment>
+    <widget:rangeConstraint rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#rangeConstraint-Resource"/>
+  </rdf:Description>
   <rdf:Description rdf:about="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#Label">
     <rdf:type rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetClass"/>
     <rdfs:label xml:lang="en-US"><![CDATA[Text Label]]></rdfs:label>

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.26.1',
+    'version' => '12.27.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -39,6 +39,7 @@ use oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService;
 use oat\generis\model\kernel\uri\UriProvider;
 use oat\generis\model\user\AuthAdapter;
 use oat\generis\model\user\UserFactoryService;
+use oat\generis\model\WidgetRdf;
 use oat\generis\persistence\PersistenceManager;
 use oat\oatbox\action\ActionService;
 use oat\oatbox\cache\KeyValueCache;
@@ -528,9 +529,10 @@ class Updater extends common_ext_ExtensionUpdater
         $this->skip('12.23.0', '12.26.1');
 
         if ($this->isVersion('12.26.1')) {
-            $widgetDefinitionsFilePath =  __DIR__ . '/../../core/ontology/widgetdefinitions.rdf';
-            $api = core_kernel_impl_ApiModelOO::singleton();
-            $api->importXmlRdf('http://www.tao.lu/datatypes/WidgetDefinitions.rdf', $widgetDefinitionsFilePath);
+            core_kernel_impl_ApiModelOO::singleton()->importXmlRdf(
+                WidgetRdf::NAMESPACE,
+                __DIR__ . '/../../core/ontology/widgetdefinitions.rdf'
+            );
 
             $this->setVersion('12.27.0');
         }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -526,6 +526,18 @@ class Updater extends common_ext_ExtensionUpdater
         }
 
         $this->skip('12.23.0', '12.26.1');
+
+        if ($this->isVersion('12.26.1')) {
+            $file = __DIR__ . DIRECTORY_SEPARATOR .
+                '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR .
+                'core' . DIRECTORY_SEPARATOR .
+                'ontology' . DIRECTORY_SEPARATOR .
+                'widgetdefinitions.rdf';
+            $api = core_kernel_impl_ApiModelOO::singleton();
+            $api->importXmlRdf('http://www.tao.lu/datatypes/WidgetDefinitions.rdf', $file);
+
+            $this->setVersion('12.27.0');
+        }
     }
 
     /**

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -528,13 +528,9 @@ class Updater extends common_ext_ExtensionUpdater
         $this->skip('12.23.0', '12.26.1');
 
         if ($this->isVersion('12.26.1')) {
-            $file = __DIR__ . DIRECTORY_SEPARATOR .
-                '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR .
-                'core' . DIRECTORY_SEPARATOR .
-                'ontology' . DIRECTORY_SEPARATOR .
-                'widgetdefinitions.rdf';
+            $widgetDefinitionsFilePath =  __DIR__ . '/../../core/ontology/widgetdefinitions.rdf';
             $api = core_kernel_impl_ApiModelOO::singleton();
-            $api->importXmlRdf('http://www.tao.lu/datatypes/WidgetDefinitions.rdf', $file);
+            $api->importXmlRdf('http://www.tao.lu/datatypes/WidgetDefinitions.rdf', $widgetDefinitionsFilePath);
 
             $this->setVersion('12.27.0');
         }


### PR DESCRIPTION
[UNO-339](https://oat-sa.atlassian.net/browse/UNO-339) feat: introduce `http://www.tao.lu/datatypes/WidgetDefinitions.rdf#SearchTextBox` widget's RDF definition
[UNO-339](https://oat-sa.atlassian.net/browse/UNO-339) fix(dependencies): stop using a `tao` class in tests

This PR doesn't really do anything on its own, it's purpose is to introduce a new widget entry into the RDF structure.