### PR TITLE
Feature/unittest registries

### DIFF
--- a/common/oatbox/AbstractRegistry.php
+++ b/common/oatbox/AbstractRegistry.php
@@ -31,7 +31,7 @@ use common_ext_Extension;
  *
  * @author Lionel Lecaque <lionel@taotesting.com>
  */
-abstract class AbstractRegistry extends ConfigurableService
+abstract class AbstractRegistry`` extends ConfigurableService
 {
     /**
      *

--- a/common/oatbox/AbstractRegistry.php
+++ b/common/oatbox/AbstractRegistry.php
@@ -21,21 +21,18 @@
 
 namespace oat\oatbox;
 
+use oat\oatbox\service\ConfigurableService;
+use oat\oatbox\service\ServiceManager;
+use common_ext_Extension;
+
 /**
  *
  * Registry allows any extension to store specific arrays of data into extension config file
  *
  * @author Lionel Lecaque <lionel@taotesting.com>
  */
-abstract class AbstractRegistry
+abstract class AbstractRegistry extends ConfigurableService
 {
-
-    /**
-     *
-     * @var array
-     */
-    private static $registries = [];
-    
     /**
      *
      * @author Lionel Lecaque, lionel@taotesting.com
@@ -43,21 +40,7 @@ abstract class AbstractRegistry
      */
     public static function getRegistry()
     {
-        $class = get_called_class();
-        if (! isset(self::$registries[$class])) {
-            self::$registries[$class] = new $class();
-        }
-        
-        return self::$registries[$class];
-    }
-
-    /**
-     *
-     * @author Lionel Lecaque, lionel@taotesting.com
-     */
-    protected function __construct()
-    {
-        // empty
+        return ServiceManager::getServiceManager()->get(get_called_class());
     }
 
     /**

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.30.1',
+    'version' => '12.31.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.31.0',
+    'version' => '12.32.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [


### PR DESCRIPTION
Move registries from the static variable in abstract registries to the service locator, making it possible to mock registries

required for:
https://github.com/oat-sa/extension-tao-delivery-rdf/pull/327