### PR TITLE
Feature/tao 10377/cloud front modify links to assets qti test package before import

### DIFF
--- a/common/oatbox/filesystem/FileSystemService.php
+++ b/common/oatbox/filesystem/FileSystemService.php
@@ -186,6 +186,22 @@ class FileSystemService extends ConfigurableService
     }
 
     /**
+     * Get the full path to the file
+     *
+     * @param File $file
+     * @return string
+     * @throws \common_exception_NotFound
+     * @throws common_exception_Error
+     */
+    public function getFullPathFile($file)
+    {
+        $config = $this->getAdapterConfig($file->getFileSystemId());
+        $adapter = $this->getFlysystemAdapter($config['adapter']);
+
+        return $adapter->getPathPrefix() . $file->getMetadata()['path'];
+    }
+
+    /**
      * Returns the configuration for an adapter
      * @param string $id
      * @return string[]

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.32.1',
+    'version' => '12.33.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [

--- a/test/integration/common/filesystem/DirectoryFilesystemTest.php
+++ b/test/integration/common/filesystem/DirectoryFilesystemTest.php
@@ -76,6 +76,28 @@ class DirectoryFilesystemTest extends GenerisTestCase
         $directory->rename('testDirectory.exist');
     }
 
+    public function testGetFullPathFile()
+    {
+        $file = $this->getTempDirectory()->getFile('fixture');
+        $fileSystemId = $file->getFileSystemId();
+
+        $fileSystemService = new FileSystemService([
+            FileSystemService::OPTION_FILE_PATH => '/tmp/testing',
+            FileSystemService::OPTION_ADAPTERS => [
+                $fileSystemId => [
+                    'class' => FileSystemService::FLYSYSTEM_LOCAL_ADAPTER,
+                    'options' => ['root' => $file->getFileSystemId()]
+                ]
+            ],
+        ]);
+
+        $file = $this->getTempDirectory()->getFile('fixture');
+
+        $result = $fileSystemService->getFullPathFile($file);
+
+        $this->assertEquals($result, $file->getFileSystemId() . '/');
+    }
+
 
     /**
      * @return bool


### PR DESCRIPTION
__Related to task:__ https://oat-sa.atlassian.net/browse/TAO-10377
__Description:__ If CloudFront is configured run TAO script to modify links to assets QTI test package before import

It depends on it https://github.com/oat-sa/extension-tao-operations/pull/122

__how to test:__
1. create s3 backet and cloudFront on aws and and configure it as per doc https://github.com/oat-sa/extension-tao-operations/wiki/Create-CloudFront-Package
2. configure files replacement.conf.php and awsClient.conf in config/generis according to your aws account
3. make test import
As a result, a folder with static items data should be created in your s3 backet, static data of created items must reference your s3 backet