### PR TITLE
UNO-392 BREAKING CHANGE: remove non-core widget definitions

### DIFF
--- a/common/constants.php
+++ b/common/constants.php
@@ -109,23 +109,6 @@ define('PROPERTY_MASK_SUBJECT', GENERIS_NS . '#MaskSubject');
 define('PROPERTY_MASK_PREDICATE', GENERIS_NS . '#MaskPredicate');
 define('PROPERTY_MASK_OBJECT', GENERIS_NS . '#MaskObject');
 
-
-#widget
-define('CLASS_WIDGET', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetClass');
-define('PROPERTY_WIDGET', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#widget');
-define('WIDGET_RADIO', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#RadioBox');
-define('WIDGET_COMBO', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#ComboBox');
-define('WIDGET_CHECK', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#CheckBox');
-define('WIDGET_FTE', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextBox');
-define('WIDGET_TIMER', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#Timer');
-define('WIDGET_TREEVIEW', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TreeView');
-define('WIDGET_CONSTRAINT_TYPE', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#rangeConstraintTypes');
-define('PROPERTY_WIDGET_ID', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#identifier');
-define('CLASS_WIDGETRENDERER', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetRenderer');
-define('PROPERTY_WIDGETRENDERER_WIDGET', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#renderedWidget');
-define('PROPERTY_WIDGETRENDERER_MODE', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#renderMode');
-define('PROPERTY_WIDGETRENDERER_IMPLEMENTATION', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#implementation');
-
 #Rules
 define('RULES_NS', 'http://www.tao.lu/middleware/Rules.rdf');
 

--- a/common/constants.php
+++ b/common/constants.php
@@ -119,7 +119,6 @@ define('WIDGET_CHECK', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#CheckB
 define('WIDGET_FTE', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextBox');
 define('WIDGET_TIMER', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#Timer');
 define('WIDGET_TREEVIEW', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TreeView');
-define('WIDGET_LABEL', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#Label');
 define('WIDGET_CONSTRAINT_TYPE', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#rangeConstraintTypes');
 define('PROPERTY_WIDGET_ID', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#identifier');
 define('CLASS_WIDGETRENDERER', 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetRenderer');

--- a/core/WidgetRdf.php
+++ b/core/WidgetRdf.php
@@ -27,14 +27,6 @@ interface WidgetRdf
 
     public const CLASS_URI_WIDGET                        = self::NAMESPACE . '#WidgetClass';
     public const PROPERTY_WIDGET                         = self::NAMESPACE . '#widget';
-    public const PROPERTY_WIDGET_RADIO                   = self::NAMESPACE . '#RadioBox';
-    public const PROPERTY_WIDGET_COMBO                   = self::NAMESPACE . '#ComboBox';
-    public const PROPERTY_WIDGET_CHECK                   = self::NAMESPACE . '#CheckBox';
-    public const PROPERTY_WIDGET_FTE                     = self::NAMESPACE . '#TextBox';
-    public const PROPERTY_WIDGET_HIDDEN_BOX              = self::NAMESPACE . '#HiddenBox';
-    public const PROPERTY_WIDGET_TEXT_AREA               = self::NAMESPACE . '#TextArea';
-    public const PROPERTY_WIDGET_HTML_AREA               = self::NAMESPACE . '#HTMLArea';
-    public const PROPERTY_WIDGET_TREEVIEW                = self::NAMESPACE . '#TreeView';
     public const PROPERTY_WIDGET_CONSTRAINT_TYPE         = self::NAMESPACE . '#rangeConstraintTypes';
     public const PROPERTY_WIDGET_ID                      = self::NAMESPACE . '#identifier';
     public const CLASS_URI_WIDGET_RENDERER               = self::NAMESPACE . '#WidgetRenderer';

--- a/core/WidgetRdf.php
+++ b/core/WidgetRdf.php
@@ -31,10 +31,10 @@ interface WidgetRdf
     public const PROPERTY_WIDGET_COMBO                   = self::NAMESPACE . '#ComboBox';
     public const PROPERTY_WIDGET_CHECK                   = self::NAMESPACE . '#CheckBox';
     public const PROPERTY_WIDGET_FTE                     = self::NAMESPACE . '#TextBox';
-    public const PROPERTY_WIDGET_SEARCH_BOX              = self::NAMESPACE . '#SearchTextBox';
-    public const PROPERTY_WIDGET_TIMER                   = self::NAMESPACE . '#Timer';
+    public const PROPERTY_WIDGET_HIDDEN_BOX              = self::NAMESPACE . '#HiddenBox';
+    public const PROPERTY_WIDGET_TEXT_AREA               = self::NAMESPACE . '#TextArea';
+    public const PROPERTY_WIDGET_HTML_AREA               = self::NAMESPACE . '#HTMLArea';
     public const PROPERTY_WIDGET_TREEVIEW                = self::NAMESPACE . '#TreeView';
-    public const PROPERTY_WIDGET_LABEL                   = self::NAMESPACE . '#Label';
     public const PROPERTY_WIDGET_CONSTRAINT_TYPE         = self::NAMESPACE . '#rangeConstraintTypes';
     public const PROPERTY_WIDGET_ID                      = self::NAMESPACE . '#identifier';
     public const CLASS_URI_WIDGET_RENDERER               = self::NAMESPACE . '#WidgetRenderer';

--- a/core/ontology/widgetdefinitions.rdf
+++ b/core/ontology/widgetdefinitions.rdf
@@ -112,29 +112,10 @@
     <widget:textLength><![CDATA[3]]></widget:textLength>
     <widget:textLength><![CDATA[255]]></widget:textLength>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#SearchTextBox">
-    <rdf:type rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetClass"/>
-    <rdfs:label xml:lang="en-US"><![CDATA[Search Input]]></rdfs:label>
-    <rdfs:comment xml:lang="en-US"><![CDATA[One may select 0 to N values from a defined list]]></rdfs:comment>
-    <widget:rangeConstraint rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#rangeConstraint-Resource"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#Label">
-    <rdf:type rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetClass"/>
-    <rdfs:label xml:lang="en-US"><![CDATA[Text Label]]></rdfs:label>
-    <rdfs:comment xml:lang="en-US"><![CDATA[Content is read only]]></rdfs:comment>
-    <widget:rangeConstraint rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#rangeConstraint-Literal"/>
-  </rdf:Description>
   <rdf:Description rdf:about="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#HiddenBox">
     <rdf:type rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetClass"/>
     <rdfs:label xml:lang="en-US"><![CDATA[Hidden Box]]></rdfs:label>
     <rdfs:comment xml:lang="en-US"><![CDATA[Content is hidden]]></rdfs:comment>
-    <widget:rangeConstraint rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#rangeConstraint-Literal"/>
-    <widget:textHeight><![CDATA[1]]></widget:textHeight>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#ViewableHiddenBox">
-    <rdf:type rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetClass"/>
-    <rdfs:label xml:lang="en-US"><![CDATA[Hidden Box]]></rdfs:label>
-    <rdfs:comment xml:lang="en-US"><![CDATA[Content is hidden, but visibility can be toggled]]></rdfs:comment>
     <widget:rangeConstraint rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#rangeConstraint-Literal"/>
     <widget:textHeight><![CDATA[1]]></widget:textHeight>
   </rdf:Description>
@@ -204,73 +185,4 @@
   <rdf:Description rdf:about="http://www.w3.org/2000/01/rdf-schema#comment">
     <widget:widget rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#HTMLArea"/>
   </rdf:Description>
-  <rdf:Description rdf:about="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#Calendar">
-    <rdf:type rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetClass"/>
-    <rdfs:label xml:lang="en-US"><![CDATA[Calendar]]></rdfs:label>
-    <rdfs:comment xml:lang="en-US"><![CDATA[Dynamic Calendar for easy date selecting]]></rdfs:comment>
-    <widget:rangeConstraint rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#rangeConstraint-Literal"/>
-    <widget:textHeight><![CDATA[1]]></widget:textHeight>
-    <widget:textLength><![CDATA[3]]></widget:textLength>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#Authoring">
-    <rdf:type rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetClass"/>
-    <rdfs:label xml:lang="en-US"><![CDATA[Authoring]]></rdfs:label>
-    <rdfs:comment xml:lang="en-US"><![CDATA[Open a tool to edit special content]]></rdfs:comment>
-    <widget:rangeConstraint rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#rangeConstraint-Resource"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#VersionedFile">
-    <rdf:type rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetClass"/>
-    <rdfs:label xml:lang="en-US"><![CDATA[VersionedFile]]></rdfs:label>
-    <rdfs:comment xml:lang="en-US"><![CDATA[Manage your versioned file]]></rdfs:comment>
-    <widget:rangeConstraint rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#rangeConstraint-Resource"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#AsyncFile">
-    <rdf:type rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetClass"/>
-    <widget:identifier><![CDATA[AsyncFile]]></widget:identifier>
-    <rdfs:label xml:lang="en-US"><![CDATA[File]]></rdfs:label>
-    <rdfs:comment xml:lang="en-US"><![CDATA[Upload and download file]]></rdfs:comment>
-    <widget:rangeConstraint rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#rangeConstraint-Resource"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#AsyncFileXhtmlRenderer">
-    <rdf:type rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetRenderer"/>
-    <widget:renderedWidget rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#AsyncFile"/>
-  	<widget:renderMode><![CDATA[xhtml]]></widget:renderMode>
-  	<widget:implementation><![CDATA[tao_helpers_form_elements_xhtml_AsyncFile]]></widget:implementation>
-  </rdf:Description>
-
-  <rdf:Description rdf:about="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#GenerisAsyncFile">
-    <rdf:type rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetClass"/>
-    <widget:identifier><![CDATA[GenerisAsyncFile]]></widget:identifier>
-    <rdfs:label xml:lang="en-US"><![CDATA[File]]></rdfs:label>
-    <rdfs:comment xml:lang="en-US"><![CDATA[Upload and download file]]></rdfs:comment>
-    <widget:rangeConstraint rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#rangeConstraint-Resource"/>
-  </rdf:Description>
-  <rdf:Description rdf:about="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#GenerisAsyncFileXhtmlRenderer">
-    <rdf:type rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetRenderer"/>
-    <widget:renderedWidget rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#GenerisAsyncFile"/>
-  	<widget:renderMode><![CDATA[xhtml]]></widget:renderMode>
-  	<widget:implementation><![CDATA[tao_helpers_form_elements_xhtml_GenerisAsyncFile]]></widget:implementation>
-  </rdf:Description>
-
-  <rdf:Description rdf:about="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#Readonly">
-    <rdf:type rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetClass"/>
-    <rdfs:label xml:lang="en-US"><![CDATA[Readonly]]></rdfs:label>
-    <rdfs:comment xml:lang="en-US"><![CDATA[Display a constant and uneditable value]]></rdfs:comment>
-    <widget:rangeConstraint rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#rangeConstraint-Literal"/>
-  </rdf:Description>
-
-  <rdf:Description rdf:about="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#ReadonlyLiteral">
-      <rdf:type rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetClass"/>
-      <widget:identifier><![CDATA[ReadonlyLiteral]]></widget:identifier>
-      <rdfs:label xml:lang="en-US"><![CDATA[Literal Readonly]]></rdfs:label>
-      <rdfs:comment xml:lang="en-US"><![CDATA[Display a literal constant and uneditable value]]></rdfs:comment>
-      <widget:rangeConstraint rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#rangeConstraint-Literal"/>
-    </rdf:Description>
-
-    <rdf:Description rdf:about="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#ReadonlyLiteralXhtmlRenderer">
-        <rdf:type rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#WidgetRenderer"/>
-        <widget:renderedWidget rdf:resource="http://www.tao.lu/datatypes/WidgetDefinitions.rdf#ReadonlyLiteral"/>
-        <widget:renderMode><![CDATA[xhtml]]></widget:renderMode>
-        <widget:implementation><![CDATA[tao_helpers_form_elements_xhtml_ReadonlyLiteral]]></widget:implementation>
-      </rdf:Description>
 </rdf:RDF>

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '12.33.2',
+    'version' => '13.0.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [

--- a/test/integration/ClassTest.php
+++ b/test/integration/ClassTest.php
@@ -159,19 +159,19 @@ class ClassTest extends GenerisPhpUnitTestRunner
         foreach ($instances as $k => $instance) {
             $this->assertTrue($instance instanceof core_kernel_classes_Resource);
 
-            if ($instance->getUri() === WidgetRdf::PROPERTY_WIDGET_COMBO) {
+            if ($instance->getUri() === 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#ComboBox') {
                 $this->assertEquals($instance->getLabel(), 'Drop down menu');
                 $this->assertEquals($instance->getComment(), 'In drop down menu, one may select 1 to N options');
             }
-            if ($instance->getUri() === WidgetRdf::PROPERTY_WIDGET_RADIO) {
+            if ($instance->getUri() === 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#RadioBox') {
                 $this->assertEquals($instance->getLabel(), 'Radio button');
                 $this->assertEquals($instance->getComment(), 'In radio boxes, one may select exactly one option');
             }
-            if ($instance->getUri() === WidgetRdf::PROPERTY_WIDGET_CHECK) {
+            if ($instance->getUri() === 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#CheckBox') {
                 $this->assertEquals($instance->getLabel(), 'Check box');
                 $this->assertEquals($instance->getComment(), 'In check boxes, one may select 0 to N options');
             }
-            if ($instance->getUri() === WidgetRdf::PROPERTY_WIDGET_FTE) {
+            if ($instance->getUri() === 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextBox') {
                 $this->assertEquals($instance->getLabel(), 'A Text Box');
                 $this->assertEquals($instance->getComment(), 'A particular text box');
             }
@@ -185,19 +185,19 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $this->assertTrue(count($instances2)  > 0);
         foreach ($instances2 as $k => $instance) {
             $this->assertTrue($instance instanceof core_kernel_classes_Resource);
-            if ($instance->getUri() === WidgetRdf::PROPERTY_WIDGET_COMBO) {
+            if ($instance->getUri() === 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#ComboBox') {
                 $this->assertEquals($instance->getLabel(), 'Drop down menu');
                 $this->assertEquals($instance->getComment(), 'In drop down menu, one may select 1 to N options');
             }
-            if ($instance->getUri() === WidgetRdf::PROPERTY_WIDGET_RADIO) {
+            if ($instance->getUri() === 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#RadioBox') {
                 $this->assertEquals($instance->getLabel(), 'Radio button');
                 $this->assertEquals($instance->getComment(), 'In radio boxes, one may select exactly one option');
             }
-            if ($instance->getUri() === WidgetRdf::PROPERTY_WIDGET_CHECK) {
+            if ($instance->getUri() === 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#CheckBox') {
                 $this->assertEquals($instance->getLabel(), 'Check box');
                 $this->assertEquals($instance->getComment(), 'In check boxes, one may select 0 to N options');
             }
-            if ($instance->getUri() === WidgetRdf::PROPERTY_WIDGET_FTE) {
+            if ($instance->getUri() === 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextBox') {
                 $this->assertEquals($instance->getLabel(), 'A Text Box');
                 $this->assertEquals($instance->getComment(), 'A particular text box');
             }

--- a/test/integration/PropertyTest.php
+++ b/test/integration/PropertyTest.php
@@ -107,8 +107,8 @@ class PropertyTest extends GenerisPhpUnitTestRunner
     public function testGetWidget()
     {
         $widget = $this->object->getWidget();
-        $this->assertTrue($widget instanceof core_kernel_classes_Resource);
-        $this->assertEquals($widget->getUri(), WidgetRdf::PROPERTY_WIDGET_COMBO);
+        $this->assertInstanceOf(core_kernel_classes_Resource::class, $widget);
+        $this->assertEquals($widget->getUri(), 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#ComboBox');
         $this->assertEquals($widget->getLabel(), 'Drop down menu');
         $this->assertEquals($widget->getComment(), 'In drop down menu, one may select 1 to N options');
     }


### PR DESCRIPTION
- [UNO-392](https://oat-sa.atlassian.net/browse/UNO-392) BREAKING CHANGE: remove non-core widget definitions and their ID constants, the ontology model update should be made via `tao-core`

⚠️ Has to be deployed together with `tao-core` [#2609](https://github.com/oat-sa/tao-core/pull/2609).