### PR TITLE
Add bootstrap for unit tests

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '13.2.0',
+    'version' => '13.1.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '13.1.0',
+    'version' => '13.3.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -21,8 +21,9 @@
  * @subpackage
  */
 
-$root_dir = __DIR__ . '/../';
+$extensionRoot = __DIR__ . '/../';
 
-require_once $root_dir . 'vendor/autoload.php';
+// Use TAO dependency resolver first.
+require_once $extensionRoot . './../vendor/autoload.php';
 
-common_Config::load($root_dir . 'config/sample/generis.conf.php');
+common_Config::load($extensionRoot . 'config/sample/generis.conf.php');

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ * @license    GPLv2
+ * @package    package_name
+ * @subpackage
+ */
+
+$root_dir = __DIR__ . '/../';
+
+require_once $root_dir . 'vendor/autoload.php';
+
+common_Config::load($root_dir . 'config/sample/generis.conf.php');


### PR DESCRIPTION
Add unit test bootstrap to properly set up the environment. The per extension reference will allow us to easily adjust the process if required.

See https://github.com/oat-sa/extension-tao-test/pull/350 for full story.