### PR TITLE
Version bump for NEX-1814

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '13.7.0',
+    'version' => '13.8.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [


### PR DESCRIPTION
Mixup with versions, 2 PR's had the same version bump, one merged before sprint 138 release, another soon afterwards.
The version, `13.7.0`, was the same, so no conflict.
https://github.com/oat-sa/generis/pull/840
https://github.com/oat-sa/generis/pull/839

Please approve this PR so that we have a new version to release