### PR TITLE
Fix/cache sessions

### DIFF
--- a/core/kernel/users/class.Cache.php
+++ b/core/kernel/users/class.Cache.php
@@ -103,9 +103,10 @@ class core_kernel_users_Cache
         }
         
         $serial = self::buildIncludedRolesSerial($role);
-        $cache = ServiceManager::getServiceManager()->get('generis/cache');
+        /** @var SimpleCache $cache */
+        $cache = ServiceManager::getServiceManager()->get(SimpleCache::SERVICE_ID);
         try {
-            $cache->put($toCache, $serial);
+            $cache->set($serial, $toCache);
             $returnValue = true;
         } catch (common_Exception $e) {
             $roleUri = $role->getUri();

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '13.9.0',
+    'version' => '13.9.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [


### PR DESCRIPTION
Because of https://github.com/oat-sa/generis/pull/791/files#diff-41527d5edb3851cc22277782cd23b829R68 when update the `config/generis/SimpleCache.conf.php` and set `persistence = redis` I see the next error message `Includes roles related to Role with URI '${roleUri}' is not in the Cache memory.`