### PR TITLE
ignore container error for interdependence with tao and generis

### DIFF
--- a/common/persistence/PersistenceManager.php
+++ b/common/persistence/PersistenceManager.php
@@ -27,7 +27,6 @@ use oat\generis\persistence\sql\SchemaCollection;
 use common_persistence_SqlPersistence;
 use oat\generis\persistence\sql\SchemaProviderInterface;
 use oat\oatbox\service\ServiceNotFoundException;
-use Throwable;
 
 /**
  * The PersistenceManager is responsible for initializing all persistences

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '13.9.0',
+    'version' => '13.10.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '13.10.0',
+    'version' => '13.9.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [


### PR DESCRIPTION
This will fix unregistered PersistenceManager dependency before generis update run migrations:

```
❯ php tao/scripts/taoUpdate.php
PHP Fatal error:  Uncaught oat\oatbox\service\ServiceNotFoundException: Service "generis/DriverConfigurationFeeder" not found in /Users/aleksej/Work/nccer/generis/common/oatbox/service/ServiceManager.php:133
```