### PR TITLE
Fix NEX-2150 no updater needed

### DIFF
--- a/common/ext/class.Extension.php
+++ b/common/ext/class.Extension.php
@@ -21,6 +21,8 @@
  *
  */
 
+use common_ext_ManifestException as ManifestException;
+use common_ext_UpdaterNotFoundException as UpdaterNotFoundException;
 use oat\oatbox\service\ServiceManagerAwareInterface;
 use oat\oatbox\service\ServiceManagerAwareTrait;
 use oat\oatbox\service\ServiceNotFoundException;
@@ -503,9 +505,9 @@ class common_ext_Extension implements ServiceManagerAwareInterface
     {
         $updaterClass = $this->getManifest()->getUpdateHandler();
         if ($updaterClass === null) {
-            throw new \common_ext_UpdaterNotFoundException('No Updater found for ' . $this->getName());
+            throw new UpdaterNotFoundException('No Updater found for ' . $this->getName());
         } elseif (!class_exists($updaterClass)) {
-            throw new \common_ext_ManifestException('Updater ' . $updaterClass . ' not found');
+            throw new ManifestException('Updater ' . $updaterClass . ' not found');
         }
         /** @var common_ext_ExtensionUpdater $updater */
         $updater = new $updaterClass($this);

--- a/common/ext/class.Extension.php
+++ b/common/ext/class.Extension.php
@@ -124,7 +124,7 @@ class common_ext_Extension implements ServiceManagerAwareInterface
     {
         return $this->getServiceLocator()->has($this->getId() . '/' . $key);
     }
-    
+
     /**
      * sets a configuration value
      *
@@ -241,7 +241,7 @@ class common_ext_Extension implements ServiceManagerAwareInterface
         $constants = $this->getConstants();
         return isset($constants[$key]);
     }
-    
+
     /**
      * Retrieves a constant from the manifest.php file of the extension.
      *
@@ -309,7 +309,7 @@ class common_ext_Extension implements ServiceManagerAwareInterface
                 }
             }
         }
-        
+
         // validate the classes
         foreach (array_keys($returnValue) as $key) {
             $class = $returnValue[$key];
@@ -321,7 +321,7 @@ class common_ext_Extension implements ServiceManagerAwareInterface
                 unset($returnValue[$key]);
             }
         }
-        
+
         return (array) $returnValue;
     }
 
@@ -400,7 +400,7 @@ class common_ext_Extension implements ServiceManagerAwareInterface
     {
         return $this->getManifest()->getManagementRole();
     }
-    
+
     /**
      * Get an array of Class URIs (as strings) that are considered optimizable by the Extension.
      *
@@ -412,7 +412,7 @@ class common_ext_Extension implements ServiceManagerAwareInterface
     {
         return $this->getManifest()->getOptimizableClasses();
     }
-    
+
     public function getPhpNamespace()
     {
         return $this->getManifest()->getPhpNamespace();
@@ -455,7 +455,7 @@ class common_ext_Extension implements ServiceManagerAwareInterface
                     throw new common_ext_MissingExtensionException($e->getExtensionId() . ' not found but required for ' . $this->getId(), $e->getExtensionId());
                 }
             }
-            
+
             $loader = new common_ext_ExtensionLoader($this);
             $loader->load();
             //load all dependent extensions
@@ -478,7 +478,7 @@ class common_ext_Extension implements ServiceManagerAwareInterface
         }
         return $service;
     }
-    
+
     /**
      * Get the documentation header for extension config located at key path
      *
@@ -497,12 +497,13 @@ class common_ext_Extension implements ServiceManagerAwareInterface
     /**
      * @throws common_ext_ManifestException
      * @throws common_ext_ManifestNotFoundException
+     * @throws common_ext_UpdaterNotFoundException
      */
     public function getUpdater(): common_ext_ExtensionUpdater
     {
         $updaterClass = $this->getManifest()->getUpdateHandler();
         if ($updaterClass === null) {
-            throw new \common_ext_ManifestException('No Updater found for ' . $this->getName());
+            throw new \common_ext_UpdaterNotFoundException('No Updater found for ' . $this->getName());
         } elseif (!class_exists($updaterClass)) {
             throw new \common_ext_ManifestException('Updater ' . $updaterClass . ' not found');
         }

--- a/common/ext/class.UpdateExtensions.php
+++ b/common/ext/class.UpdateExtensions.php
@@ -39,7 +39,7 @@ class common_ext_UpdateExtensions implements Action, ServiceLocatorAwareInterfac
 {
     use ServiceLocatorAwareTrait;
     use LoggerAwareTrait;
-    
+
     /**
      * (non-PHPdoc)
      * @see \oat\oatbox\action\Action::__invoke()
@@ -110,10 +110,16 @@ class common_ext_UpdateExtensions implements Action, ServiceLocatorAwareInterfac
                     $currentVersion = $returnedVersion;
                 }
 
-                if ($currentVersion == $codeVersion) {
-                    $versionReport = new Report(Report::TYPE_SUCCESS, 'Successfully updated ' . $ext->getName() . ' to ' . $currentVersion);
+                if ($currentVersion === $codeVersion) {
+                    $versionReport = new Report(
+                        Report::TYPE_SUCCESS,
+                        'Successfully updated ' . $ext->getName() . ' to ' . $currentVersion
+                    );
                 } else {
-                    $versionReport = new Report(Report::TYPE_WARNING, 'Update of ' . $ext->getName() . ' exited with version ' . $currentVersion);
+                    $versionReport = new Report(
+                        Report::TYPE_WARNING,
+                        'Update of ' . $ext->getName() . ' exited with version ' . $currentVersion
+                    );
                 }
 
                 foreach ($updater->getReports() as $updaterReport) {
@@ -123,6 +129,12 @@ class common_ext_UpdateExtensions implements Action, ServiceLocatorAwareInterfac
                 $report->add($versionReport);
 
                 $this->getServiceLocator()->get(SimpleCache::SERVICE_ID)->clear();
+            } catch (common_ext_UpdaterNotFoundException $e) {
+                $this->getExtensionManager()->updateVersion($ext, $codeVersion);
+                $versionReport = Report::createSuccess(
+                    sprintf('Successfully updated %s to %s', $ext->getName(), $codeVersion)
+                );
+                $report->add($versionReport);
             } catch (common_ext_ManifestException $e) {
                 $report = new Report(Report::TYPE_WARNING, $e->getMessage());
             }
@@ -135,7 +147,7 @@ class common_ext_UpdateExtensions implements Action, ServiceLocatorAwareInterfac
     protected function getMissingExtensions()
     {
         $missingId = \helpers_ExtensionHelper::getMissingExtensionIds($this->getExtensionManager()->getInstalledExtensions());
-        
+
         $missingExt = [];
         foreach ($missingId as $extId) {
             $ext = $this->getExtensionManager()->getExtensionById($extId);

--- a/common/ext/class.UpdateExtensions.php
+++ b/common/ext/class.UpdateExtensions.php
@@ -113,12 +113,12 @@ class common_ext_UpdateExtensions implements Action, ServiceLocatorAwareInterfac
                 if ($currentVersion === $codeVersion) {
                     $versionReport = new Report(
                         Report::TYPE_SUCCESS,
-                        'Successfully updated ' . $ext->getName() . ' to ' . $currentVersion
+                        sprintf('Successfully updated %s to %s', $ext->getName(), $currentVersion)
                     );
                 } else {
                     $versionReport = new Report(
                         Report::TYPE_WARNING,
-                        'Update of ' . $ext->getName() . ' exited with version ' . $currentVersion
+                        sprintf('Update of %s exited with version %s', $ext->getName(), $currentVersion)
                     );
                 }
 

--- a/common/ext/class.UpdaterNotFoundException.php
+++ b/common/ext/class.UpdaterNotFoundException.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+class common_ext_UpdaterNotFoundException extends common_ext_ManifestException
+{
+
+}

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '13.9.1',
+    'version' => '13.10.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [


### PR DESCRIPTION
Since updater scripts are deprecated we shouldn't create new ones
But currently, they are still mandatory to have.

This fix says: if an updater script is not defined let's just set the version mentioned in the manifest.
