### PR TITLE
Add new dependency required for tests

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '13.9.1',
+    'version' => '13.9.2',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [

--- a/test/OntologyMockTrait.php
+++ b/test/OntologyMockTrait.php
@@ -21,6 +21,7 @@
 
 namespace oat\generis\test;
 
+use oat\generis\persistence\DriverConfigurationFeeder;
 use oat\oatbox\user\UserLanguageServiceInterface;
 use oat\oatbox\session\SessionService;
 use Prophecy\Argument;
@@ -83,7 +84,8 @@ trait OntologyMockTrait
             EventManager::SERVICE_ID => new EventManager(),
             LoggerService::SERVICE_ID => $this->prophesize(LoggerInterface::class)->reveal(),
             UriProvider::SERVICE_ID => new Bin2HexUriProvider([Bin2HexUriProvider::OPTION_NAMESPACE => 'http://ontology.mock/bin2hex#']),
-            SimpleCache::SERVICE_ID => new NoCache()
+            SimpleCache::SERVICE_ID => new NoCache(),
+            DriverConfigurationFeeder::SERVICE_ID => new DriverConfigurationFeeder(),
         ]);
         $session->setServiceLocator($sl);
         $onto->setServiceLocator($sl);


### PR DESCRIPTION
There are some cases that we are using `OntologyMockTrait` with persistence and now the persistence class does an extra call to ServiceLocator. This call should be mapped here too. Just discovered it today.