### PR TITLE
Fix/si 503/php file driver makedir

### DIFF
--- a/common/persistence/class.PhpFileDriver.php
+++ b/common/persistence/class.PhpFileDriver.php
@@ -200,17 +200,19 @@ class common_persistence_PhpFileDriver implements common_persistence_KvDriver, c
      */
     private function makedir(string $dirpath, int $mode)
     {
-        $result = is_dir($dirpath) || @mkdir($dirpath, $mode, true);
-        if ($result === false) {
-            if (is_dir($dirpath)) {
-                \common_Logger::w('Directory already exists. Path: \''.$dirpath.'\'');
-            } elseif (is_file($dirpath)) {
-                \common_Logger::w('Directory was not created. File with the same name already exists. Path: \''.$dirpath.'\'');
-            } else {
-                \common_Logger::w('Directory was not created. Path: \''.$dirpath.'\'');
-            }
+        if (is_dir($dirpath) || @mkdir($dirpath, $mode, true)) {
+            return true;
         }
-        return $result;
+
+        if (is_dir($dirpath)) {
+            \common_Logger::w('Directory already exists. Path: \''.$dirpath.'\'');
+        } elseif (is_file($dirpath)) {
+            \common_Logger::w('Directory was not created. File with the same name already exists. Path: \''.$dirpath.'\'');
+        } else {
+            \common_Logger::w('Directory was not created. Path: \''.$dirpath.'\'');
+        }
+
+        return false;
     }
 
     /**

--- a/common/persistence/class.PhpFileDriver.php
+++ b/common/persistence/class.PhpFileDriver.php
@@ -159,9 +159,7 @@ class common_persistence_PhpFileDriver implements common_persistence_KvDriver, c
     {
         $filePath = $this->getPath($id);
         $dirname = dirname($filePath);
-        if (!file_exists($dirname)) {
-            mkdir($dirname, self::DEFAULT_MASK, true);
-        }
+        $this->makedir($dirname, self::DEFAULT_MASK);
 
         // we first open with 'c' in case the flock fails
         // 'w' would empty the file that someone else might be working on
@@ -192,6 +190,26 @@ class common_persistence_PhpFileDriver implements common_persistence_KvDriver, c
 
             return false;
         }
+    }
+
+    /**
+     * Create directory and suppress warning message
+     * @param $dirpath
+     * @param int $mode
+     * @return bool
+     */
+    private function makedir(string $dirpath, int $mode) {
+        $result = is_dir($dirpath) || @mkdir($dirpath, $mode, true);
+        if ($result === false) {
+            if (is_dir($dirpath)) {
+                \common_Logger::w('Directory already exists. Path: \''.$dirpath.'\'');
+            } elseif (is_file($dirpath)) {
+                \common_Logger::w('Directory was not created. File with the same name already exists. Path: \''.$dirpath.'\'');
+            } else {
+                \common_Logger::w('Directory was not created. Path: \''.$dirpath.'\'');
+            }
+        }
+        return $result;
     }
 
     /**

--- a/common/persistence/class.PhpFileDriver.php
+++ b/common/persistence/class.PhpFileDriver.php
@@ -158,8 +158,7 @@ class common_persistence_PhpFileDriver implements common_persistence_KvDriver, c
     private function writeFile($id, $value, $preWriteValueProcessor = null)
     {
         $filePath = $this->getPath($id);
-        $dirname = dirname($filePath);
-        $this->makedir($dirname, self::DEFAULT_MASK);
+        $this->makeDirectory(dirname($filePath), self::DEFAULT_MASK);
 
         // we first open with 'c' in case the flock fails
         // 'w' would empty the file that someone else might be working on
@@ -194,22 +193,22 @@ class common_persistence_PhpFileDriver implements common_persistence_KvDriver, c
 
     /**
      * Create directory and suppress warning message
-     * @param $dirpath
+     * @param $path
      * @param int $mode
      * @return bool
      */
-    private function makedir(string $dirpath, int $mode)
+    private function makeDirectory(string $path, int $mode)
     {
-        if (is_dir($dirpath) || @mkdir($dirpath, $mode, true)) {
+        if (is_dir($path) || @mkdir($path, $mode, true)) {
             return true;
         }
 
-        if (is_dir($dirpath)) {
-            \common_Logger::w('Directory already exists. Path: \''.$dirpath.'\'');
-        } elseif (is_file($dirpath)) {
-            \common_Logger::w('Directory was not created. File with the same name already exists. Path: \''.$dirpath.'\'');
+        if (is_dir($path)) {
+            \common_Logger::w(sprintf('Directory already exists. Path: \'%s\'', $path));
+        } elseif (is_file($path)) {
+            \common_Logger::w(sprintf('Directory was not created. File with the same name already exists. Path: \'%s\'', $path));
         } else {
-            \common_Logger::w('Directory was not created. Path: \''.$dirpath.'\'');
+            \common_Logger::w(sprintf('Directory was not created. Path: \'%s\'', $path));
         }
 
         return false;

--- a/common/persistence/class.PhpFileDriver.php
+++ b/common/persistence/class.PhpFileDriver.php
@@ -198,7 +198,8 @@ class common_persistence_PhpFileDriver implements common_persistence_KvDriver, c
      * @param int $mode
      * @return bool
      */
-    private function makedir(string $dirpath, int $mode) {
+    private function makedir(string $dirpath, int $mode)
+    {
         $result = is_dir($dirpath) || @mkdir($dirpath, $mode, true);
         if ($result === false) {
             if (is_dir($dirpath)) {

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '13.10.0',
+    'version' => '13.10.1',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [


### PR DESCRIPTION
Errors were logged at time of upscaling number of webserver instances.
Each time when new instance crated, the following error logged:
```
{
    "severity": "ERROR",
    "tag": "tao",
    "message": "php error(2): mkdir(): File exists",
    "code_file": "/var/www/html/tao/generis/common/persistence/class.PhpFileDriver.php",
    "code_line": "163",
    "instance_id": "i-0fa1212890c53b267",
    "stack": "gbnfr03dep",
    "host_type": "taocloud/ws/delivery"
}
```

To analyze the issue it's necessary to improve logging (log dir path and reason why it was not created).