### PR TITLE
Feature/log unsuccessfull loign message

### DIFF
--- a/common/oatbox/user/LoginService.php
+++ b/common/oatbox/user/LoginService.php
@@ -27,6 +27,7 @@ use common_user_auth_AuthFailedException;
 use common_user_User;
 use common_session_DefaultSession;
 use common_session_SessionManager;
+use common_Logger;
 
 /**
  * Login service
@@ -75,6 +76,7 @@ class LoginService
                 $user = $adapter->authenticate();
             } catch (common_user_auth_AuthFailedException $exception) {
                 // try next adapter or login failed
+                common_Logger::e($exception->getMessage());
                 $exceptions[] = $exception;
             }
         }

--- a/common/oatbox/user/LoginService.php
+++ b/common/oatbox/user/LoginService.php
@@ -76,7 +76,7 @@ class LoginService
                 $user = $adapter->authenticate();
             } catch (common_user_auth_AuthFailedException $exception) {
                 // try next adapter or login failed
-                common_Logger::e($exception->getMessage());
+                common_Logger::w($exception->getMessage());
                 $exceptions[] = $exception;
             }
         }

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '13.12.0',
+    'version' => '13.13.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'requires' => [],
     'install' => [


### PR DESCRIPTION
Currently any for kind of unsuccessful login the followed message added into the Tao log:
```
Unsuccessful login of user 'ckvalenciano@gmail.com'."
```

There may be multiple reasons of unsuccessful login, such as wrong login, password, multiple users with the same login, etc.
For investigation purposes proper error message should be added to the log.

Steps to test:
1. Try to log in with wrong username
2. Try to log in with wrong password
3. make sure that you see "Invalid password for user ..." and  "Unknown user ..." messages in the log

related to : https://oat-sa.atlassian.net/browse/OATSD-945