### PR TITLE
Laminas package name instead of outdated zend framework

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
     "easyrdf/easyrdf": "^0.9.0",
     "doctrine/dbal": "2.10.1",
     "doctrine/annotations": "~1.6.0",
-    "zendframework/zend-servicemanager": "~2.5.0",
+    "laminas/laminas-servicemanager": "~2.5.0",
     "league/flysystem": "~1.0",
     "league/flysystem-memory": "~1.0",
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",


### PR DESCRIPTION
The composer says that it is abandoned. It makes sense to update because sometime in the future it will be deleted and it make break our environments.