### PR TITLE
fix: remove ROOT_URL constant definition

### DIFF
--- a/common/oatbox/extension/Manifest.php
+++ b/common/oatbox/extension/Manifest.php
@@ -49,7 +49,7 @@ class Manifest implements ServiceLocatorAwareInterface
      * @var string
      */
     private $version = null;
-    
+
     /**
      * The dependencies of the Extension the manifest describes.
      * @var array
@@ -199,7 +199,7 @@ class Manifest implements ServiceLocatorAwareInterface
         }
         return $result;
     }
-    
+
     /**
      * Return the uninstall data as an array if present, or null if not
      * @return mixed
@@ -208,7 +208,7 @@ class Manifest implements ServiceLocatorAwareInterface
     {
         return isset($this->manifest['uninstall']) ? $this->manifest['uninstall'] : null;
     }
-    
+
     /**
      * Return the className of the updateHandler
      * @return string
@@ -217,7 +217,7 @@ class Manifest implements ServiceLocatorAwareInterface
     {
         return isset($this->manifest['update']) ? $this->manifest['update'] : null;
     }
-    
+
     /**
       * PHP scripts to execute in order to add some sample data to an install
       * @return array
@@ -281,10 +281,7 @@ class Manifest implements ServiceLocatorAwareInterface
         if (!is_readable($file)) {
             throw new ManifestNotFoundException(sprintf('The Extension Manifest file located at %s could not be read.', $file));
         }
-        //ROOT_URL constant may be used in the manifest file.
-        if (!defined('ROOT_URL')) {
-            define('ROOT_URL', '');
-        }
+
         $manifest = require($file);
         $returnValue = $manifest['install']['checks'] ?? [];
         foreach ($returnValue as &$component) {


### PR DESCRIPTION
❗❗❗ *Require PR: [oat-sa/tao-core#2802](https://github.com/oat-sa/tao-core/pull/2802)* ❗❗❗

**Changes:** `ROOT_URL` constant definition was removed from `Manifest` class.

**Reason:** during first installation via seed-file constant `ROOT_URL` defines as empty line. In this case the next defined constant in `config/generis.conf.php` with the right value will not work, because this constant was already initialized.

**How to reproduce _(without this fix)_:**
1. Remove `config` and `data` folders
2. Add new empty `config` folder
3. Install an instance via seed file: `php tao/scripts/taoSetup.php seed.json -vvv`
4. Take a look on the output log. Error looks like `Error Occurs : Path "tao/views/js" is not a valid asset path in Tao`

**Fix:** right now `ROOT_URL` will be defined with the correct value and this asset will look like `ROOT_URL . tao/views/js`.

**Common seed file example _(replace `{{ variable_name }}` with the necessary values)_:**
```
{
  "super-user": {
    "login": "{{ super_user_login }}",
    "lastname": "",
    "firstname": "",
    "email": "",
    "password": "{{ super_user_password }}"
  },
  "extensions": [
    "taoCe"
  ],
  "configuration": {
    "global": {
      "lang": "en-US",
      "mode": "debug",
      "instance_name": "tao",
      "namespace": "{{ host }}/sample.rdf",
      "url": "{{ host }}/",
      "session_name": "tao_tao32_0",
      "timezone": "Europe/Luxembourg",
      "import_data": false
    },
    "generis": {
      "persistences": {
        "default": {
          "driver": "pdo_pgsql",
          "host": "{{ pgsql_host }}",
          "dbname": "{{ pgsql_dbname }}",
          "user": "{{ pgsql_user }}",
          "password": "{{ pgsql_password }}"
        },
        "cache": {
          "driver": "phpfile"
        }
      }
    }
  }
}
```