### PR TITLE
Fix/legacy auto loader load from root folder

### DIFF
--- a/common/legacy/class.LegacyAutoLoader.php
+++ b/common/legacy/class.LegacyAutoLoader.php
@@ -19,6 +19,8 @@
  *
  */
 
+use oat\oatbox\extension\Manifest;
+
 /**
  * the generis autoloader
  *
@@ -129,6 +131,33 @@ class common_legacy_LegacyAutoLoader
                     return;
                 }
             }
+
+
+            $this->tryLoadFromRootFolder($pClassName);
+        }
+    }
+
+    private function tryLoadFromRootFolder($pClassName)
+    {
+        $tokens = explode("_", $pClassName);
+        if (!file_exists($this->root.'manifest.php')) {
+            return;
+        }
+        $manifest = new Manifest($this->root.'manifest.php');
+        if ($manifest->getName() !== $tokens[0]) {
+            return;
+        }
+        $path = implode('/', array_slice($tokens, 1, -1)) . '/';
+        $classFilePath = $this->root . $path . 'class.' . end($tokens) . '.php';
+        $interfaceFilePath = $this->root . $path . 'interface.' . end($tokens) . '.php';
+
+        if (file_exists($classFilePath)) {
+            require_once $classFilePath;
+            return;
+        }
+        if (file_exists($interfaceFilePath)) {
+            require_once $interfaceFilePath;
+            return;
         }
     }
     


### PR DESCRIPTION
Steps to reproduce:
1. clone tao-core repo: `git clone git@github.com:oat-sa/tao-core.git`
2. run composer update to install of dependencies of the package
3. require phpunit: `composer require "phpunit/phpunit:^8.5"` 
4. run unit tests: `vendor/bin/phpunit test/unit --bootstrap generis/test/bootstrap.php`

Expected results: tests are run
Actual results: tests run with `failed to open stream: No such file or director` error message

6. change generis dependency in composer.json: `"oat-sa/generis" : "dev-fix/LegacyAutoLoader_load_from_root_folder as 14.0.0",` and do `composer update`
7. run unit tests again