### PR TITLE
Feature/enhance cloud watch logs json formatter

### DIFF
--- a/common/oatbox/log/logger/formatter/CloudWatchJsonFormatter.php
+++ b/common/oatbox/log/logger/formatter/CloudWatchJsonFormatter.php
@@ -82,7 +82,13 @@ class CloudWatchJsonFormatter implements FormatterInterface
             'message' => $record['message'],
             'tag' => $record['context'],
         ];
-
+        
+        if (isset($record['extra']['stack']['host_type'])) {
+            $output['host_type'] = $record['extra']['stack']['host_type'];
+        }
+        if (isset($record['extra']['stack']['id'])) {
+            $output['instance_id'] = $record['extra']['stack']['id'];
+        }
         if (isset($record['extra']['trace'])) {
             $output['trace'] = $record['extra']['trace'];
         }


### PR DESCRIPTION
add 'host_type' and 'instance_id' to cloud watch json log formatter.

To test use the following logger configuration:
```
return new oat\oatbox\log\LoggerService(array(
    'logger' => array(
        'class' => 'oat\\oatbox\\log\\logger\\TaoMonolog',
        'options' => array(
            'name' => 'tao.log',
            'handlers' => array(
                array(
                    'class' => \Monolog\Handler\StreamHandler::class,
                    'options' => array(
                        __DIR__ . '/../../log/error.txt',
                        \Monolog\Logger::DEBUG
                    ),
                    'processors' => array(
                        array(
                            'class' => \oat\oatbox\log\logger\processor\UserIdProcessor::class,
                            'options' => array(
                                100
                            )
                        ),
                        array(
                            'class' => \oat\oatbox\log\logger\processor\BacktraceProcessor::class,
                            'options' => array(
                                400, // Monolog level e.q. error
                                true,
                            )
                        ),
                        array(
                            'class' => \oat\oatbox\log\logger\processor\EnvironmentProcessor::class,
                            'options' => array(
                                100
                            )
                        )
                    ),
                    'formatter' => array(
                        'class' => \oat\oatbox\log\logger\formatter\CloudWatchJsonFormatter::class,
                    ),
                ),
            ),
        )
    )
));

```

Note: change logger file path 
host_type should be taken from HOST_TYPE env variable