### PR TITLE
Feature/fluentd handler configure with fqcn

### DIFF
--- a/common/oatbox/log/logger/handler/FluentdHandler.php
+++ b/common/oatbox/log/logger/handler/FluentdHandler.php
@@ -38,14 +38,21 @@ class FluentdHandler extends AbstractProcessingHandler
     /**
      * Initialize Handler
      *
-     * @param FluentLogger $logger
+     * @param FluentLogger|string $logger
      * @param int          $level
      * @param bool         $bubble
+     * @param array        $options
      */
-    public function __construct(FluentLogger $logger = null, $level = Logger::DEBUG, $bubble = true)
+    public function __construct($logger = null, $level = Logger::DEBUG, $bubble = true, $options = [])
     {
         parent::__construct($level, $bubble);
 
+        if (!is_a($logger, FluentLogger::class, true)) {
+            throw new \TypeError('Logger must be an instance of FluentLogger type');
+        }
+        if (is_string($logger)) {
+            $logger = new $logger(...$options);
+        }
         $this->logger = $logger;
     }
 

--- a/test/unit/common/oatbox/log/logger/handler/FluentdHandlerTest.php
+++ b/test/unit/common/oatbox/log/logger/handler/FluentdHandlerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\generis\test\unit\common\oatbox\log\logger\handler;
+
+use oat\oatbox\log\logger\handler\FluentdHandler;
+use oat\generis\test\TestCase;
+use Fluent\Logger\FluentLogger;
+
+class FluentdHandlerTest extends TestCase
+{
+    public function testConstruct()
+    {
+        $logMessage = ['level' => 100, 'extra' => [], 'context' => [], 'message' => 'foo', 'channel' => 'tao'];
+        $logger = $this->getMockBuilder(FluentLogger::class)
+            ->getMock();
+        $logger->expects($this->once())
+            ->method('post');
+        $handler = new FluentdHandler($logger);
+        $handler->handle($logMessage);
+
+        new FluentdHandler(FluentLogger::class, 100, true, ["127.0.0.1", 24224]);
+    }
+
+    public function testConstructThrowsTypeException()
+    {
+        $this->expectException(\TypeError::class);
+        new FluentdHandler(FluentLogger::class.'foo');
+    }
+
+}


### PR DESCRIPTION
`FluentdHandler` expects to receive an instance of `FluentLogger` as the first parameter of constructor what make it impossible to use used in seed.json

To verify it you may use the following configuration of `generis/log` service:

```
"log": {
        "type": "configurableService",
        "class": "oat\\oatbox\\log\\LoggerService",
        "options": {
          "logger": {
            "class": "oat\\oatbox\\log\\logger\\TaoMonolog",
            "options": {
              "name" : "tao.log",
              "handlers": [
                {
                  "class": "oat\\oatbox\\log\\logger\\handler\\FluentdHandler",
                  "options": [
                    "Fluent\\Logger\\FluentLogger",
                    100,
                    true,
                    [
                      "127.0.0.1",
                      24224
                    ]
                  ]
                }
              ]
            },
            "processors": [
              {
                "class": "oat\\oatbox\\log\\logger\\processor\\UserIdProcessor",
                "options": [100]
              }
            ],
            "formatter": {
              "class": "oat\\oatbox\\log\\logger\\formatter\\CloudWatchJsonFormatter"
            }
          }
        }
      },
```

tcp listener:

```
<?php
$socket = stream_socket_server("tcp://127.0.0.1:24224");
while ($conn = stream_socket_accept($socket)) {
    $message = fread($conn, 1024);
    echo $message;
    fclose($conn);
}
fclose($socket);
```