### PR TITLE
Feature/cgf 205/task queue logging

### DIFF
--- a/common/log/class.SingleFileAppender.php
+++ b/common/log/class.SingleFileAppender.php
@@ -96,9 +96,9 @@ class common_log_SingleFileAppender extends common_log_BaseAppender
     /**
      *
      * @access public
+     * @author Joel Bout, <joel.bout@tudor.lu>
      * @param array $configuration
      * @return boolean
-     * @author Joel Bout, <joel.bout@tudor.lu>
      */
     public function init($configuration)
     {
@@ -122,35 +122,28 @@ class common_log_SingleFileAppender extends common_log_BaseAppender
             $this->reduceRatio = 1 - abs($configuration['rotation-ratio']);
         }
 
-        return !empty($this->filename) ? parent::init($configuration) : false;
+        return ! empty($this->filename) ? parent::init($configuration) : false;
     }
 
     /**
      * Initialises the logfile, and checks whenever the file require pruning
      *
      * @access protected
-     * @return mixed
      * @author Joel Bout, <joel.bout@tudor.lu>
+     * @return mixed
      */
     protected function initFile()
     {
         if ($this->maxFileSize > 0 && file_exists($this->filename) && filesize($this->filename) >= $this->maxFileSize) {
             // need to reduce the file size
-            //@TODO consider using file object SPL file iterator
             $file = file($this->filename);
             $file = array_splice($file, ceil(count($file) * $this->reduceRatio));
             $this->filehandle = @fopen($this->filename, 'w');
-            if ($this->filehandle !== false) {
-                flock($this->filehandle, LOCK_EX);
-            }
             foreach ($file as $line) {
                 @fwrite($this->filehandle, $line);
             }
         } else {
             $this->filehandle = @fopen($this->filename, 'a');
-            if ($this->filehandle !== false) {
-                flock($this->filehandle, LOCK_EX);
-            }
         }
     }
 
@@ -158,14 +151,15 @@ class common_log_SingleFileAppender extends common_log_BaseAppender
      * Prepares and saves log entries to file
      *
      * @access public
+     * @author Joel Bout, <joel.bout@tudor.lu>
      * @param common_log_Item $item
      * @return mixed
-     * @author Joel Bout, <joel.bout@tudor.lu>
      */
     public function doLog(common_log_Item $item)
     {
-        $this->initFile();
-
+        if (is_null($this->filehandle)) {
+            $this->initFile();
+        }
         if ($this->filehandle !== false) {
             $map = [
                 '%d' => gmdate('Y-m-d H:i:s', $item->getDateTime()),
@@ -183,7 +177,6 @@ class common_log_SingleFileAppender extends common_log_BaseAppender
             }
             $str = strtr($this->format, $map) . PHP_EOL;
             @fwrite($this->filehandle, $str);
-            @fclose($this->filehandle);
         }
     }
 
@@ -191,12 +184,12 @@ class common_log_SingleFileAppender extends common_log_BaseAppender
      * Closes file descriptor when logger object was destroyed
      *
      * @access public
-     * @return mixed
      * @author Joel Bout, <joel.bout@tudor.lu>
+     * @return mixed
      */
     public function __destruct()
     {
-        if (!is_null($this->filehandle) && $this->filehandle !== false) {
+        if (! is_null($this->filehandle) && $this->filehandle !== false) {
             @fclose($this->filehandle);
         }
     }

--- a/common/oatbox/log/StreamHandler.php
+++ b/common/oatbox/log/StreamHandler.php
@@ -92,7 +92,7 @@ class StreamHandler extends MonologStreamHandler
 
         $errorLevels = Logger::getLevels();
         if (!isset($errorLevels[$logLevelParameter])) {
-            throw new \Exception(sprintf('There is not exist such log level. Please, use one of: %s', implode(', ', array_flip($errorLevels))));
+            throw new \Exception(sprintf('Such log level doesn't exist. Please, use one of: %s', implode(', ', array_flip($errorLevels))));
         }
 
         return $errorLevels[$logLevelParameter];

--- a/common/oatbox/log/StreamHandler.php
+++ b/common/oatbox/log/StreamHandler.php
@@ -34,8 +34,8 @@ use Monolog\Logger;
  * for example:
  * php index.php 'oat\taoTaskQueue\scripts\tools\RunWorker' --log-file /var/www/html/data/tao/log/tao-nccer.log
  *
- * if the --log-level parameter is specified, the path to the file for logging is taken from this parameter,
- * if this parameter is not specified, the path to the file is taken from the system configuration
+ * if the --log-level parameter is specified, the minimum logging level is taken from this parameter,
+ * if this parameter is not specified, the minimum logging level is taken from the system configuration
  * can take values DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT or EMERGENCY
  * for example:
  * php index.php 'oat\taoTaskQueue\scripts\tools\RunWorker' --log-level DEBUG

--- a/common/oatbox/log/StreamHandler.php
+++ b/common/oatbox/log/StreamHandler.php
@@ -80,10 +80,10 @@ class StreamHandler extends MonologStreamHandler
     }
 
     /**
-     * @return string|null
+     * @return int|null
      * @throws \Exception
      */
-    private function getLogLevelParameter(): ?string
+    private function getLogLevelParameter(): ?int
     {
         $logLevelParameter = $this->getScriptParameter(self::PARAM_LOG_LEVEL);
         if (!$logLevelParameter) {

--- a/common/oatbox/log/StreamHandler.php
+++ b/common/oatbox/log/StreamHandler.php
@@ -19,6 +19,8 @@
  *
  */
 
+declare(strict_types=1);
+
 namespace oat\oatbox\log;
 
 use Monolog\Handler\StreamHandler as MonologStreamHandler;
@@ -44,6 +46,9 @@ use Monolog\Logger;
  */
 class StreamHandler extends MonologStreamHandler
 {
+    public const PARAM_LOG_FILE = '--log-file';
+    public const PARAM_LOG_LEVEL = '--log-level';
+
     /**
      * @param resource|string $defaultStream (Unless this parameter is specified on the command line as --log-file, otherwise it is ignored) resource where data will be output
      * @param int $defaultLevel (Unless this parameter is specified on the command line as --log-level, otherwise it is ignored) The minimum logging level at which this handler will be triggered
@@ -56,7 +61,7 @@ class StreamHandler extends MonologStreamHandler
      */
     public function __construct($defaultStream, int $defaultLevel = Logger::DEBUG, bool $bubble = true, $filePermission = null, bool $useLocking = false)
     {
-        $stream = $this->getScriptParameter('--log-file') ?: $defaultStream;
+        $stream = $this->getScriptParameter(self::PARAM_LOG_FILE) ?: $defaultStream;
         $logLevel = $this->getLogLevelParameter() ?: $defaultLevel;
         parent::__construct($stream, $logLevel, $bubble, $filePermission, $useLocking);
     }
@@ -71,8 +76,7 @@ class StreamHandler extends MonologStreamHandler
             return null;
         }
 
-        $indexValueParameter = array_search($parameter, $_SERVER['argv']) + 1;
-        return $_SERVER['argv'][$indexValueParameter];
+        return $_SERVER['argv'][array_search($parameter, $_SERVER['argv']) + 1];
     }
 
     /**
@@ -81,14 +85,14 @@ class StreamHandler extends MonologStreamHandler
      */
     private function getLogLevelParameter(): ?string
     {
-        $logLevelParameter = $this->getScriptParameter('--log-level');
+        $logLevelParameter = $this->getScriptParameter(self::PARAM_LOG_LEVEL);
         if (!$logLevelParameter) {
             return null;
         }
 
         $errorLevels = Logger::getLevels();
         if (!isset($errorLevels[$logLevelParameter])) {
-            throw new \Exception('There is no such level of logging. Use DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT or EMERGENCY');
+            throw new \Exception(sprintf('There is no such level of logging. Use %s', implode(', ', array_flip($errorLevels))));
         }
 
         return $errorLevels[$logLevelParameter];

--- a/common/oatbox/log/StreamHandler.php
+++ b/common/oatbox/log/StreamHandler.php
@@ -92,7 +92,7 @@ class StreamHandler extends MonologStreamHandler
 
         $errorLevels = Logger::getLevels();
         if (!isset($errorLevels[$logLevelParameter])) {
-            throw new \Exception(sprintf('There is no such level of logging. Use %s', implode(', ', array_flip($errorLevels))));
+            throw new \Exception(sprintf('There is not exist such log level. Please, use one of: %s', implode(', ', array_flip($errorLevels))));
         }
 
         return $errorLevels[$logLevelParameter];

--- a/common/oatbox/log/StreamHandler.php
+++ b/common/oatbox/log/StreamHandler.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+namespace oat\oatbox\log;
+
+use Monolog\Handler\StreamHandler as MonologStreamHandler;
+use Monolog\Logger;
+
+/**
+ * Stores to any stream resource
+ *
+ * Provides the ability to use command line parameters --log-file-path and --log-level:
+ *
+ * if the --log-file-path parameter is specified, the path to the file for logging is taken from this parameter,
+ * if this parameter is not specified, the path to the file is taken from the system configuration
+ * for example:
+ * php index.php 'oat\taoTaskQueue\scripts\tools\RunWorker' --log-file-path /var/www/html/data/tao/log/tao-nccer.log
+ *
+ * if the --log-level parameter is specified, the path to the file for logging is taken from this parameter,
+ * if this parameter is not specified, the path to the file is taken from the system configuration
+ * for example:
+ * php index.php 'oat\taoTaskQueue\scripts\tools\RunWorker' --log-level 100
+ *
+ * @author Andrey Niahrou, <andrei.niahrou@taotesting.com>
+ */
+class StreamHandler extends MonologStreamHandler
+{
+    /**
+     * @param resource|string $defaultStream  (Unless this parameter is specified on the command line as --log-file-path, otherwise it is ignored) resource where data will be output
+     * @param int             $defaultLevel   (Unless this parameter is specified on the command line as --log-level, otherwise it is ignored) The minimum logging level at which this handler will be triggered
+     * @param bool            $bubble         Whether the messages that are handled can bubble up the stack or not
+     * @param int|null        $filePermission Optional file permissions (default (0644) are only for owner read/write)
+     * @param bool            $useLocking     Try to lock log file before doing any writes
+     *
+     * @throws \Exception                If a missing directory is not buildable
+     * @throws \InvalidArgumentException If stream is not a resource or string
+     */
+    public function __construct($defaultStream, int $defaultLevel = Logger::DEBUG, bool $bubble = true, $filePermission = null, bool $useLocking = false)
+    {
+        $stream = $this->getScriptParameter('--log-file-path') ?: $defaultStream;
+        $logLevel = $this->getScriptParameter('--log-level') ?: $defaultLevel;
+        parent::__construct($stream, $logLevel, $bubble, $filePermission, $useLocking);
+    }
+
+    /**
+     * @param string $parameter
+     * @return string|null
+     */
+    private function getScriptParameter(string $parameter): ?string
+    {
+        if (in_array($parameter, $_SERVER['argv'])) {
+            $indexValueParameter = array_search($parameter, $_SERVER['argv']) + 1;
+            return $_SERVER['argv'][$indexValueParameter];
+        }
+        return null;
+    }
+}

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,6 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '13.15.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'install' => [
         'rdf' => [

--- a/manifest.php
+++ b/manifest.php
@@ -32,7 +32,7 @@ return [
     'label' => 'Generis Core',
     'description' => 'Core extension, provide the low level framework and an API to manage ontologies',
     'license' => 'GPL-2.0',
-    'version' => '13.14.1',
+    'version' => '13.15.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'install' => [
         'rdf' => [


### PR DESCRIPTION
**Related to task:**  https://oat-sa.atlassian.net/browse/CGF-205
**Description:** Task queue logging

**How test**
change your LoggerService config to

```
<?php

return new oat\oatbox\log\LoggerService(array(
    'logger' => array(
        'class' => 'oat\\oatbox\\log\\logger\\TaoMonolog',
        'options' => array(
            'name' => 'tao',
            'handlers' => array(
                array(
                    'class' => 'oat\\oatbox\\log\\StreamHandler',
                    'options' => array(
                        '/var/www/html/data/tao/log/tao-nccer.log',
                        100
                    )
                )
            )
        )
    )
));
```

1. run the worker with the command:

`sudo php index.php 'oat\taoTaskQueue\scripts\tools\RunWorker' --log-file /var/www/html/data/tao/log/tao-worker.log --log-level WARNING`

2. run the web version of the project

**Expected result**
1. a file `/var/www/html/data/tao/log/tao-worker.log` should be created in which the worker's logs will be written
only those logs that correspond to the --log-level statuses will be written to this file
in our case these are only errors WARNING

2. a file `/var/www/html/data/tao/log/tao-nccer.log` contains the logs of the main project (not contain workers logs)
log level corresponds to DEBUG level Detailed debug information

