### PR TITLE
Fix/unit tests root path

### DIFF
--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -21,15 +21,26 @@
  * @subpackage
  */
 
-$extensionRoot = __DIR__ . '/../';
+$extensionRoot = realpath(__DIR__ . '/../');
 
-// Use TAO dependency resolver first.
-if (is_dir($extensionRoot . '../vendor')) {
-    require_once $extensionRoot . '../vendor/autoload.php';
-} elseif (is_dir($extensionRoot . 'vendor')){
-    require_once $extensionRoot . 'vendor/autoload.php';
+function generisInstalledAsExtension(string $extensionRoot)
+{
+    return is_dir($extensionRoot . '/../vendor') && is_dir($extensionRoot . '/../generis');
+}
+
+function generisInstalledAsRootPackage(string $extensionRoot)
+{
+    return is_dir($extensionRoot . '/vendor');
+}
+
+if (generisInstalledAsExtension($extensionRoot)) {
+    define('ROOT_PATH', realpath(__DIR__.'/../../'));
+    require_once $extensionRoot . '/../vendor/autoload.php';
+} elseif (generisInstalledAsRootPackage($extensionRoot)) {
+    define('ROOT_PATH', realpath(__DIR__.'/../'));
+    require_once $extensionRoot . '/vendor/autoload.php';
 } else {
     throw new \Exception('Vendor directory not found');
 }
 
-\common_Config::load($extensionRoot . 'test/config/generis.conf.php');
+\common_Config::load($extensionRoot . '/test/config/generis.conf.php');

--- a/test/config/generis.conf.php
+++ b/test/config/generis.conf.php
@@ -38,8 +38,6 @@ define('LOCAL_NAMESPACE', '');
 define('GENERIS_INSTANCE_NAME', '');
 define('GENERIS_SESSION_NAME', 'test');
 
-# paths
-define('ROOT_PATH', '');
 // trailing slash is important!
 define('ROOT_URL', 'http://demo.taotesting.com/');
 


### PR DESCRIPTION
At time of launch of unit tests the `ROOT_PATH` constant is empty string what causes failures: http://qa.kitchen.it.taocloud.org/blue/organizations/jenkins/ci-pipeline-cg-extension-pr%2Ftao-core/detail/PR-2812/2/pipeline

The `ROOT_PATH` constant should be defined in accordance with the way how generis installed.