### PR TITLE
fix: no more calls of removed method

### DIFF
--- a/common/ext/class.UpdateExtensions.php
+++ b/common/ext/class.UpdateExtensions.php
@@ -73,7 +73,6 @@ class common_ext_UpdateExtensions implements Action, ServiceLocatorAwareInterfac
             } catch (Exception $e) {
                 $this->logError('Exception during update of ' . $ext->getId() . ': ' . get_class($e) . ' "' . $e->getMessage() . '"');
                 $report->setType(Report::TYPE_ERROR);
-                $report->setTitle('Update failed');
                 $report->add(new Report(Report::TYPE_ERROR, 'Exception during update of ' . $ext->getId() . '.'));
                 break;
             }

--- a/common/ext/class.UpdateExtensions.php
+++ b/common/ext/class.UpdateExtensions.php
@@ -73,6 +73,7 @@ class common_ext_UpdateExtensions implements Action, ServiceLocatorAwareInterfac
             } catch (Exception $e) {
                 $this->logError('Exception during update of ' . $ext->getId() . ': ' . get_class($e) . ' "' . $e->getMessage() . '"');
                 $report->setType(Report::TYPE_ERROR);
+                $report->setMessage('Update failed');
                 $report->add(new Report(Report::TYPE_ERROR, 'Exception during update of ' . $ext->getId() . '.'));
                 break;
             }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-114

All of a sudden found that deprecated method has been removed, but still used at code 

Removed at https://github.com/oat-sa/generis/pull/854/files#diff-ba60ab0c32e8bb70ac83f2306188d56c33a3358e221399c4b05098efade156b4L116