### PR TITLE
feat: add atomic roles

### DIFF
--- a/core/ontology/generis.rdf
+++ b/core/ontology/generis.rdf
@@ -352,6 +352,11 @@
     <rdfs:label xml:lang="en-US"><![CDATA[User Role]]></rdfs:label>
     <rdfs:comment xml:lang="en-US"><![CDATA[The user centric Role Class]]></rdfs:comment>
   </rdf:Description>
+  <rdf:Description rdf:about="http://www.tao.lu/Ontologies/generis.rdf#ItemRole">
+    <rdfs:subClassOf rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#UserRole"/>
+    <rdfs:label xml:lang="en-US"><![CDATA[Item Role]]></rdfs:label>
+    <rdfs:comment xml:lang="en-US"><![CDATA[Atomic Item User Role Class]]></rdfs:comment>
+  </rdf:Description>
 
   <rdf:Description rdf:about="http://www.tao.lu/Ontologies/generis.rdf#GenerisRole">
   	<rdf:type rdf:resource="http://www.tao.lu/Ontologies/generis.rdf#AbstractRole"/>


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-154

- Created atomic roles for item classes (ItemClassNavigator, ItemClassEditor, ItemClassCreator) which include base BackOffice for being able to login
- Migration and install script
- Non-breaking fix in RdfController for proper division of access to view and edit methods In child controllers

How to test:

- Create users with atomic roles
- Log in and check that only specified in the task abilities are matched

Dependent PRs:

- [core](https://github.com/oat-sa/tao-core/pull/2852)
- [taoItems](https://github.com/oat-sa/extension-tao-item/pull/462)