### PR TITLE
Fix TR-1438: eliminate models table usage

### DIFF
--- a/common/ext/class.Namespace.php
+++ b/common/ext/class.Namespace.php
@@ -88,26 +88,4 @@ class common_ext_Namespace
     {
         return $this->getUri();
     }
-
-    /**
-     * Remove a namespace from the ontology. All triples bound to the model will
-     * be removed.
-     *
-     * @author Jerome Bogaerts, <jerome.bogaerts@tudor.lu>
-     *
-     * @return boolean
-     * @throws core_kernel_persistence_Exception
-     */
-    public function remove()
-    {
-        $db = core_kernel_classes_DbWrapper::singleton();
-
-        // TODO refactor this to use triple store abstraction.
-        if (false === $db->exec("DELETE FROM statements WHERE modelid = ?", [$this->getModelId()])) {
-            return false;
-        }
-
-        // TODO refactor this to use triple store abstraction.
-        return $db->exec("DELETE FROM models WHERE modelid = ?", [$this->getModelId()]);
-    }
 }

--- a/common/legacy/class.LegacyAutoLoader.php
+++ b/common/legacy/class.LegacyAutoLoader.php
@@ -19,8 +19,6 @@
  *
  */
 
-use oat\oatbox\extension\Manifest;
-
 /**
  * the generis autoloader
  *
@@ -46,14 +44,14 @@ class common_legacy_LegacyAutoLoader
 
     private $legacyPrefixes = [];
 
-    private $root;
+    private $generisPath;
 
     /**
      * protect the cunstructer, singleton pattern
      */
     private function __construct()
     {
-        $this->root = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR;
+        $this->generisPath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR;
     }
 
     /**
@@ -99,32 +97,32 @@ class common_legacy_LegacyAutoLoader
 
         // Search for class.X.php
         $filePath = '/' . $path . 'class.' . $tokens[$size - 1] . '.php';
-        if (file_exists($this->root . $filePath)) {
-            require_once $this->root . $filePath;
+        if (file_exists($this->generisPath . $filePath)) {
+            require_once $this->generisPath . $filePath;
             return;
         }
 
         // Search for interface.X.php
         $filePathInterface = '/' . $path . 'interface.' . $tokens[$size - 1] . '.php';
-        if (file_exists($this->root . $filePathInterface)) {
-            require_once $this->root . $filePathInterface;
+        if (file_exists($this->generisPath . $filePathInterface)) {
+            require_once $this->generisPath . $filePathInterface;
             return;
         }
 
         // Search for trait.X.php
         $filePathTrait = '/' . $path . 'trait.' . $tokens[$size - 1] . '.php';
-        if (file_exists($this->root . $filePathTrait)) {
-            require_once $this->root . $filePathTrait;
+        if (file_exists($this->generisPath . $filePathTrait)) {
+            require_once $this->generisPath . $filePathTrait;
             return;
         }
 
-        if (file_exists($this->root . '..' . DIRECTORY_SEPARATOR . $filePath)) {
-            require_once $this->root . '..' . DIRECTORY_SEPARATOR . $filePath;
+        if (file_exists($this->generisPath . '..' . DIRECTORY_SEPARATOR . $filePath)) {
+            require_once $this->generisPath . '..' . DIRECTORY_SEPARATOR . $filePath;
             return;
         }
 
-        if (file_exists($this->root . '..' . DIRECTORY_SEPARATOR . $filePathInterface)) {
-            require_once $this->root . '..' . DIRECTORY_SEPARATOR . $filePathInterface;
+        if (file_exists($this->generisPath . '..' . DIRECTORY_SEPARATOR . $filePathInterface)) {
+            require_once $this->generisPath . '..' . DIRECTORY_SEPARATOR . $filePathInterface;
             return;
         }
 

--- a/core/kernel/api/class.ModelExporter.php
+++ b/core/kernel/api/class.ModelExporter.php
@@ -1,4 +1,7 @@
 <?php
+
+use oat\generis\model\data\ModelManager;
+
 /**
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -21,7 +24,7 @@
 
 class core_kernel_api_ModelExporter
 {
-    
+
     /**
      * Export the entire ontology
      *
@@ -33,7 +36,7 @@ class core_kernel_api_ModelExporter
         $result = $dbWrapper->query('SELECT DISTINCT "subject", "predicate", "object", "l_language" FROM "statements"');
         return self::statement2rdf($result);
     }
-    
+
     /**
      * Export models by id
      *
@@ -45,24 +48,21 @@ class core_kernel_api_ModelExporter
         $dbWrapper = core_kernel_classes_DbWrapper::singleton();
         $result = $dbWrapper->query('SELECT DISTINCT "subject", "predicate", "object", "l_language" FROM "statements" 
             WHERE "modelid" IN (\'' . implode('\',\'', $modelIds) . '\')');
-            
+
         common_Logger::i('Found ' . $result->rowCount() . ' entries for models ' . implode(',', $modelIds));
         return self::statement2rdf($result);
     }
-    
+
     /**
-     * Export a model by URI
-     *
-     * @param array $modelUri
      * @return string
      */
-    public static function exportModelByUri($modelUri)
+    public static function exportModelByUri()
     {
-        $dbWrapper = core_kernel_classes_DbWrapper::singleton();
-        $result = $dbWrapper->query('SELECT modelid FROM "models"  WHERE "modeluri" = ?', [$modelUri])->fetch(PDO::FETCH_ASSOC);
-        self::exportModels($result['modelid']);
+        return self::exportModels(
+            self::getOntology()->getReadableModels()
+        );
     }
-    
+
     /**
      * @ignore
      */
@@ -78,8 +78,13 @@ class core_kernel_api_ModelExporter
                 $graph->addLiteral($r['subject'], $r['predicate'], $r['object']);
             }
         }
-        
+
         $format = EasyRdf_Format::getFormat('rdfxml');
         return $graph->serialise($format);
+    }
+
+    private static function getOntology(): core_kernel_persistence_smoothsql_SmoothModel
+    {
+        return ModelManager::getModel();
     }
 }

--- a/core/kernel/api/interface.ApiModel.php
+++ b/core/kernel/api/interface.ApiModel.php
@@ -37,17 +37,6 @@ interface core_kernel_api_ApiModel extends core_kernel_api_Api
 
 
     /**
-     * build xml rdf containing rdf:Description of all meta-data the conected
-     * may get
-     *
-     * @access public
-     * @author Bertrand Chevrier, <bertrand.chevrier@tudor.lu>
-     * @param  array sourceNamespaces
-     * @return string
-     */
-    public function exportXmlRdf($sourceNamespaces = []);
-
-    /**
      * import xml rdf files into the knowledge base
      *
      * @access public

--- a/core/kernel/impl/class.ApiModelOO.php
+++ b/core/kernel/impl/class.ApiModelOO.php
@@ -159,7 +159,7 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
         }
 
         $allNs = [];
-        foreach ($allModels as $i => $model) {
+        foreach ($allModels as $model) {
             if (!preg_match("/#$/", $model['modeluri'])) {
                 $model['modeluri'] .= '#';
             }
@@ -203,7 +203,7 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
                 }
 
                 $resourceValue = false;
-                foreach ($allNs as $namespaceId => $namespaceUri) {
+                foreach ($allNs as $namespaceUri) {
                     if (
                         preg_match('/^' . preg_quote($namespaceUri, '/') . '/', $object) ||
                         preg_match("/^http:\/\/(.*)#[a-zA-Z1-9]*/", $object)

--- a/core/kernel/impl/class.ApiModelOO.php
+++ b/core/kernel/impl/class.ApiModelOO.php
@@ -440,8 +440,6 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
      */
     public function getObject($subject, $predicate)
     {
-        $returnValue = null;
-
         $sqlQuery = "SELECT object FROM statements WHERE subject = ? AND predicate = ?";
         $dbWrapper = core_kernel_classes_DbWrapper::singleton();
         $sqlResult = $dbWrapper->query($sqlQuery, [

--- a/core/kernel/impl/class.ApiModelOO.php
+++ b/core/kernel/impl/class.ApiModelOO.php
@@ -382,10 +382,6 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
      */
     public function getSubject($predicate, $object)
     {
-        $returnValue = null;
-
-
-
         $sqlQuery = "SELECT subject FROM statements WHERE predicate = ? AND object= ? ";
         $dbWrapper = core_kernel_classes_DbWrapper::singleton();
         $sqlResult = $dbWrapper->query($sqlQuery, [

--- a/core/kernel/impl/class.ApiModelOO.php
+++ b/core/kernel/impl/class.ApiModelOO.php
@@ -264,7 +264,7 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
         $returnValue = $this->createClassCollection(__METHOD__);
 
         $classClass = new core_kernel_classes_Class(OntologyRdfs::RDFS_CLASS);
-        foreach ($classClass->getSubClasses(true) as $uri => $subClass) {
+        foreach ($classClass->getSubClasses(true) as $subClass) {
             $returnValue->add($subClass);
         }
 

--- a/core/kernel/impl/class.ApiModelOO.php
+++ b/core/kernel/impl/class.ApiModelOO.php
@@ -229,8 +229,7 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
                                  * <![CDATA[ ]]> to <CDATA></CDATA>
                                  * @todo check if this behavior is the right
                                  */
-                                $object = str_replace('<![CDATA[', '<CDATA>', $object);
-                                $object = str_replace(']]>', '</CDATA>', $object);
+                                $object = str_replace(['<![CDATA[', ']]>'], ['<CDATA>', '</CDATA>'], $object);
 
                                 $node->appendChild($dom->createCDATASection($object));
                             }

--- a/core/kernel/impl/class.ApiModelOO.php
+++ b/core/kernel/impl/class.ApiModelOO.php
@@ -104,37 +104,15 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
                         'xmlns:rdfs'    => 'http://www.w3.org/2000/01/rdf-schema#'
                     ];
 
-        $query = 'SELECT "models"."modelid", "models"."modeluri" FROM "models" INNER JOIN "statements" ON "statements"."modelid" = "models"."modelid"
-											WHERE "statements"."subject" = ' . $subject;
-        $query = $dbWrapper->limitStatement($query, 1);
-        $result = $dbWrapper->query($query);
-        if ($row = $result->fetch()) {
-            $modelId  = $row['modelid'];
-            $modelUri =  $row['modeluri'];
-            if (!preg_match("/#$/", $modelUri)) {
-                $modelUri .= '#';
-            }
+        $modelId  = core_kernel_persistence_smoothsql_SmoothModel::DEFAULT_WRITABLE_MODEL;
+        $modelUri = LOCAL_NAMESPACE . '#';
 
-            $result->closeCursor();
-        }
         $currentNs = ["xmlns:ns{$modelId}" => $modelUri];
         $currentNs = array_merge($baseNs, $currentNs);
 
 
-        $allModels = [];
-        $result = $dbWrapper->query('SELECT * FROM "models"');
-        while ($row = $result->fetch(PDO::FETCH_ASSOC)) {
-            $allModels[] = $row;
-        }
-
-        $allNs = [];
-        foreach ($allModels as $model) {
-            if (!preg_match("/#$/", $model['modeluri'])) {
-                $model['modeluri'] .= '#';
-            }
-            $allNs["xmlns:ns{$model['modelid']}"] = $model['modeluri'];
-        }
-        $allNs = array_merge($baseNs, $allNs);
+        $allNs = $currentNs;
+        $allNs['xmlns:ns' . core_kernel_persistence_smoothsql_SmoothModel::DEFAULT_READ_ONLY_MODEL] = $modelUri;
 
         try {
             $dom = new DOMDocument();

--- a/core/kernel/impl/class.ApiModelOO.php
+++ b/core/kernel/impl/class.ApiModelOO.php
@@ -477,17 +477,12 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
      */
     public static function singleton()
     {
-        $returnValue = null;
-
-
         if (!isset(self::$instance)) {
             $c = __CLASS__;
             self::$instance = new $c();
         }
-        $returnValue = self::$instance;
 
-
-        return $returnValue;
+        return self::$instance;
     }
 
     /**

--- a/core/kernel/impl/class.ApiModelOO.php
+++ b/core/kernel/impl/class.ApiModelOO.php
@@ -63,37 +63,6 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
 
 
     /**
-     * build xml rdf containing rdf:Description of all meta-data the conected
-     * may get
-     *
-     * @deprecated
-     * @access public
-     * @author firstname and lastname of author, <author@example.org>
-     * @param  array sourceNamespaces
-     * @return string
-     */
-    public function exportXmlRdf($sourceNamespaces = [])
-    {
-        $modelIds = [];
-        foreach ($sourceNamespaces as $namespace) {
-            if (!preg_match('/#$/', $namespace)) {
-                $namespace .= "#";
-            }
-
-            $dbWrapper = core_kernel_classes_DbWrapper::singleton();
-
-            $result = $dbWrapper->query('SELECT * FROM "models"  WHERE "modeluri" = ?', [
-                $namespace
-            ]);
-            if ($row = $result->fetch(PDO::FETCH_ASSOC)) {
-                $modelIds[] = $row['modelid'];
-                $result->closeCursor();
-            }
-        }
-        return $xml = core_kernel_api_ModelExporter::exportXmlRdf($modelIds);
-    }
-
-    /**
      * import xml rdf files into the knowledge base
      *
      * @access public
@@ -394,8 +363,6 @@ class core_kernel_impl_ApiModelOO extends core_kernel_impl_Api implements core_k
             $container->debug = __METHOD__ ;
             $returnValue->add($container);
         }
-
-
 
         return $returnValue;
     }

--- a/test/integration/RdfExportTest.php
+++ b/test/integration/RdfExportTest.php
@@ -20,6 +20,7 @@
  *               2012-2014 (update and modification) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 
+use oat\generis\model\data\ModelManager;
 use oat\generis\test\GenerisPhpUnitTestRunner;
 
 class RdfExportTest extends GenerisPhpUnitTestRunner
@@ -29,18 +30,15 @@ class RdfExportTest extends GenerisPhpUnitTestRunner
         $dbWrapper = core_kernel_classes_DbWrapper::singleton();
         $result = $dbWrapper->query('SELECT count(*) as count FROM (SELECT DISTINCT subject, predicate, object, l_language FROM statements) as supercount')->fetch();
         $triples = $result['count'];
-        
 
-        $result = $dbWrapper->query('SELECT modelid FROM "models"');
-        $modelIds = [];
-        while ($row = $result->fetch(PDO::FETCH_ASSOC)) {
-            $modelIds[] = $row['modelid'];
-        }
-        $xml = core_kernel_api_ModelExporter::exportModels($modelIds);
-        
+
+        $xml = core_kernel_api_ModelExporter::exportModels(
+            ModelManager::getModel()->getReadableModels()
+        );
+
         $doc = new DOMDocument();
         $doc->loadXML($xml);
-        
+
         $count = 0;
         $descriptions = $doc->getElementsByTagNameNS('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'Description');
         foreach ($descriptions as $description) {
@@ -50,7 +48,7 @@ class RdfExportTest extends GenerisPhpUnitTestRunner
                 }
             }
         }
-        
-        $this->assertEquals($triples, $count);
+
+        static::assertEquals($triples, $count);
     }
 }


### PR DESCRIPTION
# [TR-1438](https://oat-sa.atlassian.net/browse/TR-1438)

- chore: merge multiple `str_replace()` calls within `core_kernel_impl_ApiModelOO::getResourceDescriptionXML()` method
- chore: remove unused variables from `core_kernel_api_ApiModel::singleton()` method
- chore: remove unused variables from `core_kernel_api_ApiModel::getSubject()` method
- chore: remove unused variables from `core_kernel_api_ApiModel::getResourceDescriptionXML()` method
- chore: remove unused variables from `core_kernel_api_ApiModel::getMetaClasses()` method
- chore: remove unused variables from `core_kernel_api_ApiModel::getObject()` method
- chore!: remove a deprecated `core_kernel_api_ApiModel::exportXmlRdf()` method contract and its implementation
- fix: eliminate a long-gone `models` table usage by `core_kernel_impl_ApiModelOO`
- fix: eliminate a long-gone `models` table usage by `core_kernel_api_ModelExporter`
- chore!: remove a deprecated `common_ext_Namespace::remove()` method
- fix: eliminate a long-gone `models` table usage by `oat\generis\test\GenerisPhpUnitTestRunner\RdfExportTest`
- fix(autoloader): support root-package installation by the `LegacyAutoLoader`

## How to test

1. Publish a local Delivery Assembly
2. Run `php index.php "oat\taoDeliveryRdf\model\export\ExportAssemblyClass" <delivery_id> <writable_directory>` to export a Delivery (the script itself is still broken, but doesn't cause an error now)

ℹ️ This unblocks [TR-1478](https://oat-sa.atlassian.net/browse/TR-1478)
ℹ️ This is a follow up of #737