### PR TITLE
Allow interface language to be overwritten in the BasicSession

### DIFF
--- a/common/session/class.BasicSession.php
+++ b/common/session/class.BasicSession.php
@@ -15,7 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2017 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
 
@@ -142,6 +142,10 @@ class common_session_BasicSession implements common_session_Session, ServiceLoca
      */
     public function getInterfaceLanguage()
     {
+        if (PHPSession::singleton()->hasAttribute('overrideInterfaceLanguage')) {
+            return PHPSession::singleton()->getAttribute('overrideInterfaceLanguage');
+        }
+
         return $this->getServiceLocator()->get(UserLanguageServiceInterface::class)->getInterfaceLanguage($this->getUser());
     }
     


### PR DESCRIPTION
## Ticket
https://oat-sa.atlassian.net/browse/TR-32

## Summary
This change allows the interface language to be overwritten on the session level so that we can change the language in the test runner according to the language set for the Delivery.

## Dependency
This PR relates to https://github.com/oat-sa/extension-tao-delivery/pull/511 and https://github.com/oat-sa/extension-tao-delivery-rdf/pull/391.

## How to test
See https://github.com/oat-sa/extension-tao-delivery/pull/511
