### PR TITLE
Update EasyRdf library to the latest release

### DIFF
--- a/common/legacy/ClassAliases.php
+++ b/common/legacy/ClassAliases.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * This file used for migrating extensions to the new version of EasyRdf library.
+ * After updating all extension this part of code can be removed.
+ */
+
+use EasyRdf\Format;
+use EasyRdf\Graph;
+
+class_alias(Graph::class, 'EasyRdf_Graph');
+class_alias(Format::class, 'EasyRdf_Format');

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
   "require": {
     "php": "^7.1",
     "clearfw/clearfw": "~1.2.0",
-    "easyrdf/easyrdf": "^0.9.0",
+    "easyrdf/easyrdf": "^1.1",
     "doctrine/dbal": "2.10.1",
     "doctrine/annotations": "~1.6.0",
     "laminas/laminas-servicemanager": "~2.5.0",

--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,8 @@
     "psr/container": "^1.1.1",
     "psr/simple-cache" : "^1.0.1",
     "ramsey/uuid": "^3.8",
-    "composer-runtime-api": "^2.0"
+    "composer-runtime-api": "^2.0",
+    "ext-pdo": "*"
   },
   "require-dev": {
     "mikey179/vfsstream": "1.4.0",

--- a/composer.json
+++ b/composer.json
@@ -97,6 +97,7 @@
     },
     "files": [
       "common/legacy/class.LegacyAutoLoader.php",
+      "common/legacy/ClassAliases.php",
       "common/constants.php"
     ]
   },

--- a/core/kernel/api/class.ModelExporter.php
+++ b/core/kernel/api/class.ModelExporter.php
@@ -1,5 +1,7 @@
 <?php
 
+use EasyRdf\Format;
+use EasyRdf\Graph;
 use oat\generis\model\data\ModelManager;
 
 /**
@@ -64,11 +66,12 @@ class core_kernel_api_ModelExporter
     }
 
     /**
+     * @throws \EasyRdf\Exception
      * @ignore
      */
     private static function statement2rdf(PDOStatement $statement)
     {
-        $graph = new EasyRdf_Graph();
+        $graph = new Graph();
         while ($r = $statement->fetch()) {
             if (isset($r['l_language']) && !empty($r['l_language'])) {
                 $graph->addLiteral($r['subject'], $r['predicate'], $r['object'], $r['l_language']);
@@ -79,7 +82,8 @@ class core_kernel_api_ModelExporter
             }
         }
 
-        $format = EasyRdf_Format::getFormat('rdfxml');
+        $format = Format::getFormat('rdfxml');
+
         return $graph->serialise($format);
     }
 

--- a/core/kernel/api/class.ModelFactory.php
+++ b/core/kernel/api/class.ModelFactory.php
@@ -24,33 +24,35 @@
  */
 
 use core_kernel_persistence_smoothsql_SmoothModel as SmoothModel;
+use EasyRdf\Format;
+use EasyRdf\Graph;
 
 class core_kernel_api_ModelFactory
 {
     /**
      * @param string $namespace
      * @param string $data xml content
+     *
+     * @throws \EasyRdf\Exception
      */
     public function createModel($namespace, $data)
     {
         $modelId = SmoothModel::DEFAULT_READ_ONLY_MODEL;
 
-        $modelDefinition = new EasyRdf_Graph($namespace);
+        $modelDefinition = new Graph($namespace);
+
         if (is_file($data)) {
             $modelDefinition->parseFile($data);
         } else {
             $modelDefinition->parse($data);
         }
-        $graph = $modelDefinition->toRdfPhp();
-        $resources = $modelDefinition->resources();
-        $format = EasyRdf_Format::getFormat('php');
         
-        $data = $modelDefinition->serialise($format);
+        $data = $modelDefinition->serialise(Format::getFormat('php'));
         
         foreach ($data as $subjectUri => $propertiesValues) {
             foreach ($propertiesValues as $prop => $values) {
                 foreach ($values as $k => $v) {
-                    $this->addStatement($modelId, $subjectUri, $prop, $v['value'], isset($v['lang']) ? $v['lang'] : null);
+                    $this->addStatement($modelId, $subjectUri, $prop, $v['value'], $v['lang'] ?? null);
                 }
             }
         }

--- a/core/kernel/persistence/file/FileIterator.php
+++ b/core/kernel/persistence/file/FileIterator.php
@@ -22,22 +22,22 @@
 
 namespace oat\generis\model\kernel\persistence\file;
 
-use EasyRdf_Graph;
+use EasyRdf\Graph;
 use core_kernel_classes_Triple;
 use IteratorAggregate;
 use ArrayIterator;
 
 class FileIterator implements IteratorAggregate
 {
-    
     private $triples = [];
-    
+
     /**
+     * @param string      $file
+     * @param string|null $forceModelId
      *
-     * @param string $file
-     * @param string $forceModelId
+     * @throws \common_exception_Error
      */
-    public function __construct($file, $forceModelId = null)
+    public function __construct(string $file, string $forceModelId = null)
     {
         $modelId = is_null($forceModelId) ? FileModel::getModelIdFromXml($file) : $forceModelId;
         $this->load($modelId, $file);
@@ -46,7 +46,7 @@ class FileIterator implements IteratorAggregate
     /**
      * @see IteratorAggregate::getIterator()
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->triples);
     }
@@ -59,19 +59,18 @@ class FileIterator implements IteratorAggregate
      */
     protected function load($modelId, $file)
     {
-        
-        $easyRdf = new EasyRdf_Graph();
+        $easyRdf = new Graph();
         $easyRdf->parseFile($file);
         
         foreach ($easyRdf->toRdfPhp() as $subject => $propertiesValues) {
             foreach ($propertiesValues as $predicate => $values) {
-                foreach ($values as $k => $v) {
+                foreach ($values as $v) {
                     $triple = new core_kernel_classes_Triple();
                     $triple->modelid = $modelId;
                     $triple->subject = $subject;
                     $triple->predicate = $predicate;
                     $triple->object = $v['value'];
-                    $triple->lg = isset($v['lang']) ? $v['lang'] : null;
+                    $triple->lg = $v['lang'] ?? null;
                     $this->triples[] = $triple;
                 }
             }

--- a/core/kernel/persistence/file/FileModel.php
+++ b/core/kernel/persistence/file/FileModel.php
@@ -21,6 +21,8 @@
 
 namespace oat\generis\model\kernel\persistence\file;
 
+use EasyRdf\Format;
+use EasyRdf\Graph;
 use oat\generis\model\data\Model;
 use \common_exception_MissingParameter;
 use \common_exception_Error;
@@ -45,10 +47,13 @@ class FileModel implements Model
     {
         return new self(['file' => $filePath]);
     }
-    
+
+    /**
+     * @throws \EasyRdf\Exception
+     */
     public static function toFile($filePath, $triples)
     {
-        $graph = new \EasyRdf_Graph();
+        $graph = new Graph();
         foreach ($triples as $triple) {
             if (!empty($triple->lg)) {
                 $graph->addLiteral($triple->subject, $triple->predicate, $triple->object, $triple->lg);
@@ -58,7 +63,7 @@ class FileModel implements Model
                 $graph->addLiteral($triple->subject, $triple->predicate, $triple->object);
             }
         }
-        $format = \EasyRdf_Format::getFormat('rdfxml');
+        $format = Format::getFormat('rdfxml');
         return file_put_contents($filePath, $graph->serialise($format));
     }
     

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -28,7 +28,6 @@ use common_ext_ExtensionsManager;
 use common_ext_ExtensionUpdater;
 use core_kernel_impl_ApiModelOO;
 use core_kernel_persistence_smoothsql_SmoothModel;
-use EasyRdf_Exception;
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\Memory\MemoryAdapter;
 use oat\generis\model\data\ModelManager;
@@ -74,7 +73,8 @@ class Updater extends common_ext_ExtensionUpdater
      *
      * @return string $versionUpdatedTo
      * @throws common_Exception
-     * @throws EasyRdf_Exception
+     * @throws \EasyRdf\Exception
+     * @throws \oat\oatbox\service\ServiceNotFoundException
      */
     public function update($initialVersion)
     {


### PR DESCRIPTION
[REL-112: TAO CG EasyRDF PHP 7.4 Support](https://oat-sa.atlassian.net/browse/REL-112)

This pull request should be merged first and after it should be released. Other extensions should update their dependencies to require a new major release.

---

Support of PHP 7.4 in the library was added in the major release [1.0.0](https://github.com/easyrdf/easyrdf/releases/tag/1.0.0) which is broke backward compatibility. It also requires updating the major release of `generis` as well. I required the release [1.1.1](https://github.com/easyrdf/easyrdf/releases/tag/1.1.1) as it brings some internal improvements but does not break anything, so it is safe for usage.