### PR TITLE
Bugfix TR 3532 - async s3 result transmission

### DIFF
--- a/common/oatbox/filesystem/FileSystemHandler.php
+++ b/common/oatbox/filesystem/FileSystemHandler.php
@@ -22,12 +22,17 @@
 
 namespace oat\oatbox\filesystem;
 
+use oat\oatbox\service\ServiceManager;
+use ReflectionClass;
+use ReflectionProperty;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Zend\ServiceManager\ServiceLocatorAwareTrait;
 
 abstract class FileSystemHandler implements ServiceLocatorAwareInterface
 {
     use ServiceLocatorAwareTrait;
+
+    protected const UNSERIALIZABLE_PROPERTIES = ['fileSystem', 'serviceLocator'];
 
     /**
      * @var mixed
@@ -125,5 +130,25 @@ abstract class FileSystemHandler implements ServiceLocatorAwareInterface
         $path = trim($path, '/');
 
         return $path;
+    }
+
+    public function __sleep()
+    {
+        return array_diff($this->getAllProperties(), self::UNSERIALIZABLE_PROPERTIES);
+    }
+
+    public function __wakeup()
+    {
+        $this->setServiceLocator(ServiceManager::getServiceManager());
+    }
+
+    private function getAllProperties(): array
+    {
+        return array_map(
+            static function (ReflectionProperty $property): string {
+                return $property->getName();
+            },
+            (new ReflectionClass($this))->getProperties()
+        );
     }
 }

--- a/common/oatbox/filesystem/FileSystemHandler.php
+++ b/common/oatbox/filesystem/FileSystemHandler.php
@@ -32,7 +32,7 @@ abstract class FileSystemHandler implements ServiceLocatorAwareInterface
 {
     use ServiceLocatorAwareTrait;
 
-    protected const UNSERIALIZABLE_PROPERTIES = ['fileSystem', 'serviceLocator'];
+    private const UNSERIALIZABLE_PROPERTIES = ['fileSystem', 'serviceLocator'];
 
     /**
      * @var mixed

--- a/common/oatbox/filesystem/FileSystemHandler.php
+++ b/common/oatbox/filesystem/FileSystemHandler.php
@@ -32,7 +32,7 @@ abstract class FileSystemHandler implements ServiceLocatorAwareInterface
 {
     use ServiceLocatorAwareTrait;
 
-    private const UNSERIALIZABLE_PROPERTIES = ['fileSystem', 'serviceLocator'];
+    private const NOT_SERIALIZABLE_PROPERTIES = ['fileSystem', 'serviceLocator'];
 
     /**
      * @var mixed
@@ -134,7 +134,7 @@ abstract class FileSystemHandler implements ServiceLocatorAwareInterface
 
     public function __sleep()
     {
-        return array_diff($this->getAllProperties(), self::UNSERIALIZABLE_PROPERTIES);
+        return array_diff($this->getAllProperties(), self::NOT_SERIALIZABLE_PROPERTIES);
     }
 
     public function __wakeup()


### PR DESCRIPTION
# [TR-3532](https://oat-sa.atlassian.net/browse/TR-3532)

## Summary 
define properties for serialization of `common/oatbox/filesystem/FileSystemHandler.php`

## Required for 
https://github.com/oat-sa/extension-tao-testqti/pull/2202

## How to test
- install `oat-sa/lib-generis-aws`
- configure `config/generis/awsClient.conf.php` and `config/generis/filesystem.conf.php` corresponding [this article](https://oat-sa.atlassian.net/wiki/spaces/INFOSIGN/pages/1651376266/Setup+S3+Filesystem+persistence)
- configure asynchronous result variables transmission but next command
```bash
sudo -u www-data php index.php 'oat\taoQtiTest\scripts\tools\ResultVariableTransmissionEvenHandlerSwitcher' -c 'oat\taoQtiTest\models\classes\eventHandler\ResultTransmissionEventHandler\AsynchronousResultTransmissionEventHandler'
```
- create delivery for test with audio record item
- execute this delivery 
- no error will be provided and results with record will be available on result page