### PR TITLE
tests: use PHPUnit instead of Prophecy

### DIFF
--- a/test/PersistenceManagerMockTrait.php
+++ b/test/PersistenceManagerMockTrait.php
@@ -15,32 +15,26 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018-2022 (original work) Open Assessment Technologies SA.
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA.
  */
 
 declare(strict_types=1);
 
 namespace oat\generis\test;
 
-use Prophecy\Argument;
 use common_persistence_sql_dbal_Driver;
 use oat\generis\persistence\PersistenceManager;
 
-/**
- * @deprecated Use \oat\generis\test\PersistenceManagerMockTrait
- */
-trait SqlMockTrait
+trait PersistenceManagerMockTrait
 {
-    /**
-     * @deprecated Use \oat\generis\test\PersistenceManagerMockTrait::getPersistenceManagerMock() instead
-     */
-    public function getSqlMock(string $key): PersistenceManager
+    public function getPersistenceManagerMock(string $key): PersistenceManager
     {
         if (!extension_loaded('pdo_sqlite')) {
-            $this->markTestSkipped('sqlite not found, tests skipped.');
+            $this->markTestSkipped('Extension "pdo_sqlite" not loaded, test skipped');
         }
 
-        $persistence = (new common_persistence_sql_dbal_Driver())->connect(
+        $driver = new common_persistence_sql_dbal_Driver();
+        $persistence = $driver->connect(
             $key,
             [
                 'connection' => [
@@ -49,14 +43,15 @@ trait SqlMockTrait
             ]
         );
 
-        $pmProphecy = $this->prophesize(PersistenceManager::class);
-        $pmProphecy
-            ->setServiceLocator(Argument::any())
+        $persistenceManager = $this->createMock(PersistenceManager::class);
+        $persistenceManager
+            ->method('setServiceLocator')
             ->willReturn(null);
-        $pmProphecy
-            ->getPersistenceById($key)
+        $persistenceManager
+            ->method('getPersistenceById')
+            ->with($key)
             ->willReturn($persistence);
 
-        return $pmProphecy->reveal();
+        return $persistenceManager;
     }
 }

--- a/test/ServiceLocatorMockTrait.php
+++ b/test/ServiceLocatorMockTrait.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\generis\test;
+
+use Psr\Container\ContainerInterface;
+use oat\oatbox\service\ServiceManager;
+
+trait ServiceLocatorMockTrait
+{
+    public function getServiceLocatorMock(array $services = []): ServiceManager
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->method('has')
+            ->willReturnCallback(
+                static function (string $key) use ($services): bool {
+                    return array_key_exists($key, $services);
+                }
+            );
+        $container
+            ->method('get')
+            ->willReturnCallback(
+                static function (string $key) use ($services) {
+                    return $services[$key] ?? null;
+                }
+            );
+
+        $serviceManager  = $this->createMock(ServiceManager::class);
+        $serviceManager
+            ->method('getContainer')
+            ->willReturn($container);
+        $serviceManager
+            ->method('has')
+            ->willReturnCallback(
+                static function (string $key) use ($services): bool {
+                    return array_key_exists($key, $services);
+                }
+            );
+        $serviceManager
+            ->method('get')
+            ->willReturnCallback(
+                static function (string $key) use ($services) {
+                    return $services[$key] ?? null;
+                }
+            );
+
+        return $serviceManager;
+    }
+}

--- a/test/ServiceManagerMockTrait.php
+++ b/test/ServiceManagerMockTrait.php
@@ -25,9 +25,9 @@ namespace oat\generis\test;
 use Psr\Container\ContainerInterface;
 use oat\oatbox\service\ServiceManager;
 
-trait ServiceLocatorMockTrait
+trait ServiceManagerMockTrait
 {
-    public function getServiceLocatorMock(array $services = []): ServiceManager
+    public function getServiceManagerMock(array $services = []): ServiceManager
     {
         $container = $this->createMock(ContainerInterface::class);
         $container
@@ -45,7 +45,7 @@ trait ServiceLocatorMockTrait
                 }
             );
 
-        $serviceManager  = $this->createMock(ServiceManager::class);
+        $serviceManager = $this->createMock(ServiceManager::class);
         $serviceManager
             ->method('getContainer')
             ->willReturn($container);

--- a/test/SqlMockTrait.php
+++ b/test/SqlMockTrait.php
@@ -27,12 +27,14 @@ use common_persistence_sql_dbal_Driver;
 use oat\generis\persistence\PersistenceManager;
 
 /**
- * @deprecated Use \oat\generis\test\PersistenceManagerMockTrait
+ * @deprecated Use \oat\generis\test\PersistenceManagerMockTrait.
+ *             Since PHPUnit does all the work, we no longer have to use Prophecy to reduce dependencies.
  */
 trait SqlMockTrait
 {
     /**
-     * @deprecated Use \oat\generis\test\PersistenceManagerMockTrait::getPersistenceManagerMock() instead
+     * @deprecated Use \oat\generis\test\PersistenceManagerMockTrait::getPersistenceManagerMock() instead.
+     *             Since PHPUnit does all the work, we no longer have to use Prophecy to reduce dependencies.
      */
     public function getSqlMock(string $key): PersistenceManager
     {

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -15,17 +15,75 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018-2022 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2018-2022 (original work) Open Assessment Technologies SA.
  */
 
 declare(strict_types=1);
 
 namespace oat\generis\test;
 
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Container\ContainerInterface;
+use oat\oatbox\service\ServiceManager;
 use PHPUnit\Framework\TestCase as UnitTestCase;
 
+/**
+ * @deprecated Use \PHPUnit\Framework\TestCase instead
+ */
 abstract class TestCase extends UnitTestCase
 {
     use SqlMockTrait;
-    use ServiceLocatorMockTrait;
+
+    /**
+     * @deprecated Use \oat\generis\test\ServiceManagerMockTrait::getServiceManagerMock() instead
+     *
+     * @param array<string, object> $services
+     *
+     * @return ServiceManager
+     */
+    public function getServiceLocatorMock(array $services = [])
+    {
+        /** @var ContainerInterface|ObjectProphecy $containerProphecy */
+        $containerProphecy = $this->prophesize(ContainerInterface::class);
+
+        /** @var ServiceManager|ObjectProphecy $serviceLocatorProphecy */
+        $serviceLocatorProphecy = $this->prophesize(ServiceManager::class);
+        $serviceLocatorProphecy
+            ->getContainer()
+            ->willReturn($containerProphecy);
+
+        foreach ($services as $key => $service) {
+            $serviceLocatorProphecy
+                ->get($key)
+                ->willReturn($service);
+            $serviceLocatorProphecy
+                ->has($key)
+                ->willReturn(true);
+
+            $containerProphecy
+                ->get($key)
+                ->willReturn($service);
+            $containerProphecy
+                ->has($key)
+                ->willReturn(true);
+        }
+
+        $serviceLocatorProphecy
+            ->has(Argument::any())
+            ->willReturn(false);
+        $containerProphecy
+            ->has(Argument::any())
+            ->willReturn(false);
+
+        return $serviceLocatorProphecy->reveal();
+    }
+
+    /**
+     * @deprecated Use PHPUnit mocks instead
+     */
+    protected function prophesize($classOrInterface = null): ObjectProphecy
+    {
+        return parent::prophesize($classOrInterface);
+    }
 }

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -15,45 +15,17 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2018-2021 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2018-2022 (original work) Open Assessment Technologies SA;
  */
+
+declare(strict_types=1);
 
 namespace oat\generis\test;
 
-use oat\oatbox\service\ServiceManager;
-use Prophecy\Argument;
-use Psr\Container\ContainerInterface;
-use Zend\ServiceManager\ServiceLocatorInterface;
 use PHPUnit\Framework\TestCase as UnitTestCase;
 
 abstract class TestCase extends UnitTestCase
 {
     use SqlMockTrait;
-
-    /**
-     * @param array $services
-     * @return ServiceLocatorInterface|ServiceManager
-     */
-    public function getServiceLocatorMock(array $services = [])
-    {
-        /** @var ContainerInterface $containerProphecy */
-        $containerProphecy = $this->prophesize(ContainerInterface::class);
-
-        /** @var ServiceManager $serviceLocatorProphecy */
-        $serviceLocatorProphecy = $this->prophesize(ServiceManager::class);
-        $serviceLocatorProphecy->getContainer()->willReturn($containerProphecy);
-
-        foreach ($services as $key => $service) {
-            $serviceLocatorProphecy->get($key)->willReturn($service);
-            $serviceLocatorProphecy->has($key)->willReturn(true);
-
-            $containerProphecy->get($key)->willReturn($service);
-            $containerProphecy->has($key)->willReturn(true);
-        }
-
-        $serviceLocatorProphecy->has(Argument::any())->willReturn(false);
-        $containerProphecy->has(Argument::any())->willReturn(false);
-
-        return $serviceLocatorProphecy->reveal();
-    }
+    use ServiceLocatorMockTrait;
 }

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -29,14 +29,17 @@ use oat\oatbox\service\ServiceManager;
 use PHPUnit\Framework\TestCase as UnitTestCase;
 
 /**
- * @deprecated Use \PHPUnit\Framework\TestCase instead
+ * @deprecated Use \PHPUnit\Framework\TestCase instead.
+ *             To reduce number of dependencies, we must not use generis TestCase anymore, since SQL and ServiceLocator
+ *             mocks can be used separately via specific traits.
  */
 abstract class TestCase extends UnitTestCase
 {
     use SqlMockTrait;
 
     /**
-     * @deprecated Use \oat\generis\test\ServiceManagerMockTrait::getServiceManagerMock() instead
+     * @deprecated Use \oat\generis\test\ServiceManagerMockTrait::getServiceManagerMock() instead.
+     *             Since PHPUnit does all the work, we no longer have to use Prophecy to reduce dependencies.
      *
      * @param array<string, object> $services
      *
@@ -80,7 +83,8 @@ abstract class TestCase extends UnitTestCase
     }
 
     /**
-     * @deprecated Use PHPUnit mocks instead
+     * @deprecated Use PHPUnit mocks instead.
+     *             Since PHPUnit does all the work, we no longer have to use Prophecy to reduce dependencies.
      */
     protected function prophesize($classOrInterface = null): ObjectProphecy
     {


### PR DESCRIPTION
## Changes
* Now service locator (service manager) mock created via `PHPUnit` instead of `Prophecy`.
* Logic moved from `\oat\generis\test\TestCase` to separate trait.