### PR TITLE
fix: avoid build the container before the application is installed

### DIFF
--- a/core/DependencyInjection/ContainerBuilder.php
+++ b/core/DependencyInjection/ContainerBuilder.php
@@ -28,7 +28,6 @@ use common_ext_Extension;
 use common_ext_ExtensionsManager;
 use InvalidArgumentException;
 use oat\generis\model\Middleware\MiddlewareExtensionsMapper;
-use oat\tao\model\Middleware\Contract\MiddlewareMapInterface;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder as SymfonyContainerBuilder;
@@ -76,7 +75,7 @@ class ContainerBuilder extends SymfonyContainerBuilder
 
         parent::__construct();
         $this->middlewareExtensionsMapper = $middlewareExtensionsMapper ?? new MiddlewareExtensionsMapper();
-        $this->configPath = $configPath  === null ? (defined('CONFIG_PATH') ? CONFIG_PATH : null) : $configPath;
+        $this->configPath = $configPath ?? (defined('CONFIG_PATH') ? CONFIG_PATH : null);
     }
 
     public function build(): ContainerInterface
@@ -210,6 +209,6 @@ class ContainerBuilder extends SymfonyContainerBuilder
 
     private function isApplicationInstalled(): bool
     {
-        return file_exists($this->configPath . 'generis/installation.conf.php');
+        return file_exists(rtrim((string)$this->configPath, '/') . '/generis/installation.conf.php');
     }
 }

--- a/test/unit/core/DependencyInjection/ContainerBuilderTest.php
+++ b/test/unit/core/DependencyInjection/ContainerBuilderTest.php
@@ -30,9 +30,9 @@ use oat\generis\model\DependencyInjection\ContainerBuilder;
 use oat\generis\model\DependencyInjection\ContainerCache;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\generis\model\Middleware\MiddlewareExtensionsMapper;
-use oat\generis\test\TestCase;
 use oat\oatbox\extension\Manifest;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
 class ContainerBuilderTest extends TestCase
@@ -75,7 +75,7 @@ class ContainerBuilderTest extends TestCase
             true,
             $this->cache,
             $this->middlewareExtensionsMapper,
-            $this->tempDir . '/'
+            $this->tempDir
         );
     }
 


### PR DESCRIPTION
Allow installation to run without building the container twice, so it can only be built after all extensions are installed