### PR TITLE
fix: ensure cache directory exists

### DIFF
--- a/common/oatbox/cache/SetupFileCache.php
+++ b/common/oatbox/cache/SetupFileCache.php
@@ -29,10 +29,13 @@ class SetupFileCache extends ConfigurableService
 {
     public const PERSISTENCE = 'cache';
 
+    /**
+     * @throws Exception
+     */
     public function createDirectory($cachePath): void
     {
         if (is_dir($cachePath) && is_writable($cachePath)) {
-            return true;
+            return;
         }
 
         if (!@mkdir($cachePath, 0700, true)) {

--- a/common/oatbox/cache/SetupFileCache.php
+++ b/common/oatbox/cache/SetupFileCache.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA ;
+ */
+
+declare(strict_types=1);
+
+namespace oat\oatbox\cache;
+
+use oat\generis\persistence\PersistenceManager;
+use oat\oatbox\service\ConfigurableService;
+
+class SetupFileCache extends ConfigurableService
+{
+    public const PERSISTENCE = 'cache';
+
+    public function createDirectory($cachePath): bool
+    {
+        return mkdir($cachePath, 0700, true) || is_dir($cachePath);
+    }
+
+    public function createPersistence(): void
+    {
+        $persistenceManager = $this->getPersistenceManager();
+        $persistenceManager->registerPersistence(self::PERSISTENCE, [
+            'driver' => 'phpfile'
+        ]);
+        $persistenceManager->getPersistenceById(self::PERSISTENCE)->purge();
+        $this->getServiceManager()->register(PersistenceManager::SERVICE_ID, $persistenceManager);
+    }
+
+    private function getPersistenceManager(): PersistenceManager
+    {
+        return $this->getServiceManager()->get(PersistenceManager::SERVICE_ID);
+    }
+}

--- a/common/oatbox/cache/SetupFileCache.php
+++ b/common/oatbox/cache/SetupFileCache.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 
 namespace oat\oatbox\cache;
 
+use Exception;
 use oat\generis\persistence\PersistenceManager;
 use oat\oatbox\service\ConfigurableService;
 
@@ -28,13 +29,15 @@ class SetupFileCache extends ConfigurableService
 {
     public const PERSISTENCE = 'cache';
 
-    public function createDirectory($cachePath): bool
+    public function createDirectory($cachePath): void
     {
         if (is_dir($cachePath) && is_writable($cachePath)) {
             return true;
         }
 
-        return @mkdir($cachePath, 0700, true);
+        if (!@mkdir($cachePath, 0700, true)) {
+            throw new Exception(sprintf( 'Could not create application cache at "%s"', $cachePath) );
+        }
     }
 
     public function createPersistence(): void

--- a/common/oatbox/cache/SetupFileCache.php
+++ b/common/oatbox/cache/SetupFileCache.php
@@ -30,7 +30,11 @@ class SetupFileCache extends ConfigurableService
 
     public function createDirectory($cachePath): bool
     {
-        return mkdir($cachePath, 0700, true) || is_dir($cachePath);
+        if (is_dir($cachePath) && is_writable($cachePath)) {
+            return true;
+        }
+
+        return @mkdir($cachePath, 0700, true);
     }
 
     public function createPersistence(): void

--- a/core/DependencyInjection/ContainerBuilder.php
+++ b/core/DependencyInjection/ContainerBuilder.php
@@ -101,6 +101,8 @@ class ContainerBuilder extends SymfonyContainerBuilder
             return $this->legacyContainer;
         }
 
+        $this->ensureCacheDirectoryIsCreated();
+
         if (!is_writable($this->cachePath)) {
             throw new InvalidArgumentException(
                 sprintf(
@@ -226,5 +228,10 @@ class ContainerBuilder extends SymfonyContainerBuilder
     private function isApplicationInstalled(): bool
     {
         return file_exists(rtrim((string)$this->configPath, '/') . '/generis/installation.conf.php');
+    }
+
+    private function ensureCacheDirectoryIsCreated(): void
+    {
+        @mkdir($this->cachePath, 0700, true);
     }
 }

--- a/core/DependencyInjection/ContainerBuilder.php
+++ b/core/DependencyInjection/ContainerBuilder.php
@@ -101,7 +101,16 @@ class ContainerBuilder extends SymfonyContainerBuilder
             return $this->legacyContainer;
         }
 
-        $this->ensureCacheDirectoryIsCreatedAndWritable();
+        $this->ensureCacheDirectoryIsCreated();
+
+        if (!is_writable($this->cachePath)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'DI container build requires directory "%s" to be writable',
+                    $this->cachePath
+                )
+            );
+        }
 
         try {
             file_put_contents($this->cachePath . '/services.php', $this->getTemporaryServiceFileContent());
@@ -221,24 +230,8 @@ class ContainerBuilder extends SymfonyContainerBuilder
         return file_exists(rtrim((string)$this->configPath, '/') . '/generis/installation.conf.php');
     }
 
-    private function ensureCacheDirectoryIsCreatedAndWritable(): void
+    private function ensureCacheDirectoryIsCreated(): void
     {
-        if (!mkdir($this->cachePath, 0700, true) && !is_dir($this->cachePath)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'DI container build could not create "%s" directory',
-                    $this->cachePath
-                )
-            );
-        }
-
-        if (!is_writable($this->cachePath)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'DI container build requires directory "%s" to be writable',
-                    $this->cachePath
-                )
-            );
-        }
+        @mkdir($this->cachePath, 0700, true);
     }
 }

--- a/core/DependencyInjection/ContainerBuilder.php
+++ b/core/DependencyInjection/ContainerBuilder.php
@@ -101,8 +101,6 @@ class ContainerBuilder extends SymfonyContainerBuilder
             return $this->legacyContainer;
         }
 
-        $this->ensureCacheDirectoryIsCreated();
-
         if (!is_writable($this->cachePath)) {
             throw new InvalidArgumentException(
                 sprintf(
@@ -228,10 +226,5 @@ class ContainerBuilder extends SymfonyContainerBuilder
     private function isApplicationInstalled(): bool
     {
         return file_exists(rtrim((string)$this->configPath, '/') . '/generis/installation.conf.php');
-    }
-
-    private function ensureCacheDirectoryIsCreated(): void
-    {
-        @mkdir($this->cachePath, 0700, true);
     }
 }

--- a/core/DependencyInjection/ContainerBuilder.php
+++ b/core/DependencyInjection/ContainerBuilder.php
@@ -101,16 +101,7 @@ class ContainerBuilder extends SymfonyContainerBuilder
             return $this->legacyContainer;
         }
 
-        $this->ensureCacheDirectoryIsCreated();
-
-        if (!is_writable($this->cachePath)) {
-            throw new InvalidArgumentException(
-                sprintf(
-                    'DI container build requires directory "%s" to be writable',
-                    $this->cachePath
-                )
-            );
-        }
+        $this->ensureCacheDirectoryIsCreatedAndWritable();
 
         try {
             file_put_contents($this->cachePath . '/services.php', $this->getTemporaryServiceFileContent());
@@ -230,8 +221,24 @@ class ContainerBuilder extends SymfonyContainerBuilder
         return file_exists(rtrim((string)$this->configPath, '/') . '/generis/installation.conf.php');
     }
 
-    private function ensureCacheDirectoryIsCreated(): void
+    private function ensureCacheDirectoryIsCreatedAndWritable(): void
     {
-        @mkdir($this->cachePath, 0700, true);
+        if (!mkdir($this->cachePath, 0700, true) && !is_dir($this->cachePath)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'DI container build could not create "%s" directory',
+                    $this->cachePath
+                )
+            );
+        }
+
+        if (!is_writable($this->cachePath)) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'DI container build requires directory "%s" to be writable',
+                    $this->cachePath
+                )
+            );
+        }
     }
 }

--- a/test/unit/core/DependencyInjection/ContainerBuilderTest.php
+++ b/test/unit/core/DependencyInjection/ContainerBuilderTest.php
@@ -84,7 +84,7 @@ class ContainerBuilderTest extends TestCase
 
         $this->cache = $this->createMock(ContainerCache::class);
         $this->subject = new ContainerBuilder(
-            $this->tempDir . '/cache',
+            $this->tempDir,
             $this->legacyContainer,
             true,
             $this->cache,

--- a/test/unit/core/DependencyInjection/ContainerBuilderTest.php
+++ b/test/unit/core/DependencyInjection/ContainerBuilderTest.php
@@ -31,6 +31,7 @@ use oat\generis\model\DependencyInjection\ContainerCache;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 use oat\generis\model\Middleware\MiddlewareExtensionsMapper;
 use oat\oatbox\extension\Manifest;
+use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -70,7 +71,8 @@ class ContainerBuilderTest extends TestCase
         $this->legacyContainer->method('get')
             ->willReturn($this->extensionManager);
 
-        $this->tempDir = sys_get_temp_dir();
+        vfsStream::setup('testRoot', 0777);
+        $this->tempDir = vfsStream::url('testRoot');
         $this->installationDir = $this->tempDir . '/generis';
         $this->installationFile = $this->installationDir . '/installation.conf.php';
 
@@ -82,7 +84,7 @@ class ContainerBuilderTest extends TestCase
 
         $this->cache = $this->createMock(ContainerCache::class);
         $this->subject = new ContainerBuilder(
-            $this->tempDir,
+            $this->tempDir . '/cache',
             $this->legacyContainer,
             true,
             $this->cache,


### PR DESCRIPTION
When TAO instance is reacreated and `taoUpdate.php` gets called, any migration trying to access DI container will fail with an error of missing cache directory. This change ensures the directory is present  

Related to : https://oat-sa.atlassian.net/browse/REL-783
   
Companion PR :
 - [ ] https://github.com/oat-sa/tao-core/pull/3561