### PR TITLE
chore: remove php requirement

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -14,9 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-version: [ '7.2', '7.3', '7.4', '8.0', '8.1' ]
+        php-version: [ '7.4', '8.0', '8.1' ]
         include:
-          - php-version: '7.2'
+          - php-version: '8.1'
             coverage: true
 
     steps:

--- a/common/cache/class.SingletonCache.php
+++ b/common/cache/class.SingletonCache.php
@@ -55,14 +55,14 @@ abstract class common_cache_SingletonCache
     {
         $returnValue = null;
 
-        
+
         $cacheName = get_called_class();
         if (!isset(self::$instances[$cacheName])) {
             self::$instances[$cacheName] = new $cacheName();
         }
-        
+
         $returnValue = self::$instances[$cacheName];
-        
+
 
         return $returnValue;
     }
@@ -78,7 +78,7 @@ abstract class common_cache_SingletonCache
     {
         $returnValue = null;
 
-        
+
         $args = func_get_args();
         array_shift($args);
         if (!is_string($function)) {
@@ -94,10 +94,10 @@ abstract class common_cache_SingletonCache
         if (static::singleton()->has($serial)) {
             $returnValue = static::singleton()->has($serial);
         } else {
-            $returnValue = call_user_func_array($fn, $args);
+            $returnValue = call_user_func_array($function, $args);
             static::singleton()->put($serial, $returnValue);
         }
-        
+
 
         return $returnValue;
     }

--- a/common/oatbox/log/VerboseLogger.php
+++ b/common/oatbox/log/VerboseLogger.php
@@ -53,7 +53,7 @@ class VerboseLogger extends AbstractLogger
      */
     public function __construct($minimumLevel)
     {
-        if (! in_array($minimumLevel, array_keys($this->levels))) {
+        if (!in_array($minimumLevel, $this->levels, true)) {
             throw new \common_Exception('Level "' . $minimumLevel . '" is not managed by verbose logger');
         }
         $this->levelPosition = array_search($minimumLevel, $this->levels);

--- a/common/persistence/class.PhpFileDriver.php
+++ b/common/persistence/class.PhpFileDriver.php
@@ -52,7 +52,7 @@ class common_persistence_PhpFileDriver implements common_persistence_KvDriver, c
      * @var string
      */
     private $directory;
-    
+
     /**
      * Nr of subfolder levels in order to prevent filesystem bottlenecks
      * Only used in non human readable mode
@@ -60,7 +60,7 @@ class common_persistence_PhpFileDriver implements common_persistence_KvDriver, c
      * @var int
      */
     private $levels;
-    
+
     /**
      * Whenever or not the filenames should be human readable
      * FALSE by default for performance issues with many keys
@@ -81,7 +81,7 @@ class common_persistence_PhpFileDriver implements common_persistence_KvDriver, c
      * @var int
      */
     const DEFAULT_LEVELS = 3;
-    
+
     const DEFAULT_MASK = 0700;
 
     /**
@@ -103,7 +103,7 @@ class common_persistence_PhpFileDriver implements common_persistence_KvDriver, c
 
         return new common_persistence_KeyValuePersistence($params, $this);
     }
-    
+
     /**
      * (non-PHPdoc)
      * @see common_persistence_KvDriver::set()
@@ -239,7 +239,13 @@ class common_persistence_PhpFileDriver implements common_persistence_KvDriver, c
      */
     private function readFile($id)
     {
-        return @include $this->getPath($id);
+        $path = $this->getPath($id);
+
+        if (is_readable($path)) {
+            return @include $path;
+        }
+
+        return false;
     }
 
     /**
@@ -264,7 +270,7 @@ class common_persistence_PhpFileDriver implements common_persistence_KvDriver, c
             return $this->get($id) !== false;
         }
     }
-    
+
     /**
      * (non-PHPdoc)
      * @see common_persistence_KvDriver::del()
@@ -386,7 +392,7 @@ class common_persistence_PhpFileDriver implements common_persistence_KvDriver, c
         }
         return  $this->directory . $path . '.php';
     }
-    
+
     /**
      * Cannot use helpers_File::sanitizeInjectively() because
      * of backwards compatibility
@@ -402,7 +408,7 @@ class common_persistence_PhpFileDriver implements common_persistence_KvDriver, c
         }
         return $path;
     }
-    
+
     /**
      * Generate the php code that returns the provided value
      *

--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
     "ext-pdo": "*"
   },
   "require-dev": {
-    "mikey179/vfsstream": "1.4.0",
+    "mikey179/vfsstream": "~1",
     "phpunit/phpunit": "^8.5",
     "php-mock/php-mock": "^2.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -56,8 +56,8 @@
   "require": {
     "clearfw/clearfw": "~1.2.0",
     "easyrdf/easyrdf": "^1.1",
-    "doctrine/dbal": "^2.10.1",
-    "doctrine/annotations": "^1.6.0",
+    "doctrine/dbal": "2.12.*",
+    "doctrine/annotations": "~1.6.0",
     "laminas/laminas-servicemanager": "~2.5.0",
     "league/flysystem": "~1.0",
     "league/flysystem-memory": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
     "clearfw/clearfw": "~1.2.0",
     "easyrdf/easyrdf": "^1.1",
     "doctrine/dbal": "2.12.*",
-    "doctrine/annotations": "~1.6.0",
+    "doctrine/annotations": "1.13.*",
     "laminas/laminas-servicemanager": "~2.5.0",
     "league/flysystem": "~1.0",
     "league/flysystem-memory": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,6 @@
     "tao-extension-name": "generis"
   },
   "require": {
-    "php": "^7.1",
     "clearfw/clearfw": "~1.2.0",
     "easyrdf/easyrdf": "^1.1",
     "doctrine/dbal": "^2.10.1",

--- a/test/integration/mutex/test_action.php
+++ b/test/integration/mutex/test_action.php
@@ -10,17 +10,14 @@ $actionId = $argv[0];
 $sleep = (int) $argv[1];
 $timeout = (int) $argv[2];
 
-$service = getInstance();
+$service = getLockServiceInstance();
 $factory = $service->getLockFactory();
 $lock = $factory->createLock($actionId, $timeout);
 $lock->acquire(true);
 sleep($sleep);
 $lock->release();
 
-/**
- * @return LockService
- */
-function getInstance()
+function getLockServiceInstance(): LockService
 {
     return ServiceManager::getServiceManager()->get(LockService::class);
 }

--- a/test/unit/ConfigurationTest.php
+++ b/test/unit/ConfigurationTest.php
@@ -99,7 +99,7 @@ class ConfigurationTest extends TestCase
         $this->assertTrue($php->isOptional());
 
         // max & min test.
-        $php = new \common_configuration_PHPRuntime('5.3', '7.4.x');
+        $php = new \common_configuration_PHPRuntime('7.4', '8.1.x');
         $report = $php->check();
 
         $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
@@ -169,7 +169,7 @@ class ConfigurationTest extends TestCase
         $report = $ext->check();
         $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
 
-        $ext->setMax('7.5');
+        $ext->setMax('8.2');
         $report = $ext->check();
         $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
 
@@ -310,7 +310,7 @@ class ConfigurationTest extends TestCase
 
     public function testComponentFactory()
     {
-        $component = \common_configuration_ComponentFactory::buildPHPRuntime('5.0', '7.4.x', true);
+        $component = \common_configuration_ComponentFactory::buildPHPRuntime('5.0', '8.1.x', true);
         $this->assertInstanceOf(\common_configuration_PHPRuntime::class, $component);
         $this->assertEquals($component->getMin(), '5.0');
         // 5.5.x will be replaced internally
@@ -353,7 +353,7 @@ class ConfigurationTest extends TestCase
         $this->assertInstanceOf(\common_configuration_Report::class, $report);
         $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
 
-        $array = ['type' => 'PHPRuntime', 'value' => ['min' => '5.0', 'max' => '7.4.x', 'optional' => true]];
+        $array = ['type' => 'PHPRuntime', 'value' => ['min' => '5.0', 'max' => '8.1.x', 'optional' => true]];
         $component = \common_configuration_ComponentFactory::buildFromArray($array);
         $this->assertInstanceOf(\common_configuration_PHPRuntime::class, $component);
         $this->assertEquals($component->getMin(), '5.0');

--- a/test/unit/common/configuration/ComponentFactoryTest.php
+++ b/test/unit/common/configuration/ComponentFactoryTest.php
@@ -98,11 +98,11 @@ class ComponentFactoryTest extends TestCase
         $this->assertTrue($output->isOptional());
         $this->assertTrue($output->getRecursive());
         $this->assertTrue($output->getMustCheckIfEmpty());
-        $this->assertEquals('FileSystemComponentCheck_3', $output->getName());
+        $this->assertStringStartsWith('FileSystemComponentCheck_', $output->getName());
 
         $output2 = $this->subject->buildFileSystemComponent('/path2', 'rw');
 
-        $this->assertEquals('FileSystemComponentCheck_4', $output2->getName());
+        $this->assertStringStartsWith('FileSystemComponentCheck_', $output2->getName());
     }
 
     public function testBuildCustomFailureOnNonExistingExtension()

--- a/test/unit/core/Middleware/MiddlewareRequestHandlerTest.php
+++ b/test/unit/core/Middleware/MiddlewareRequestHandlerTest.php
@@ -94,7 +94,7 @@ class MiddlewareRequestHandlerTest extends TestCase
         $queue = array_merge(
             array_values($middlewaresMocks),
             [
-                static function ($request, $next): ResponseInterface {
+                function ($request, $next): ResponseInterface {
                     return $this->originalResponse;
                 }
             ]
@@ -175,7 +175,7 @@ class MiddlewareRequestHandlerTest extends TestCase
     {
         $queue = array_merge(
             [
-                static function ($request, $next): ResponseInterface {
+                function ($request, $next): ResponseInterface {
                     return $this->originalResponse;
                 }
             ]

--- a/test/unit/oatbox/mutex/test_action.php
+++ b/test/unit/oatbox/mutex/test_action.php
@@ -1,11 +1,6 @@
 <?php
 
-$extRoot = __DIR__ . '/../../../../';
-if (is_dir($extRoot.'vendor')) {
-    require($extRoot.'vendor/autoload.php');
-} elseif (is_dir($extRoot.'../vendor')) {
-    require($extRoot.'../vendor/autoload.php');
-}
+require __DIR__ . '/../../../bootstrap.php';
 
 use oat\oatbox\mutex\LockService;
 use oat\oatbox\service\ServiceManager;


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-1097
https://oat-sa.atlassian.net/browse/ADF-1087
https://oat-sa.atlassian.net/browse/ADF-1105

## Goal 

Make the extension not dictating PHP version to easier our PHP maintenance, since the extension does not work in isolation and PHP version should be equally respected to all TAO extensions.