### PR TITLE
fix: fixing array to string conversion error in logs

### DIFF
--- a/common/log/class.SingleFileAppender.php
+++ b/common/log/class.SingleFileAppender.php
@@ -169,7 +169,7 @@ class common_log_SingleFileAppender extends common_log_BaseAppender
                 '%t' => $item->getDateTime(),
                 '%r' => $item->getRequest(),
                 '%f' => $item->getCallerFile(),
-                '%g' => implode(',', $item->getTags()),
+                '%g' => json_encode($item->getTags()),
                 '%l' => $item->getCallerLine()
             ];
             if (strpos($this->format, '%b')) {


### PR DESCRIPTION
This PR fixes the 'array to string conversion error' in logs. 
The error was caused by an attempt to convert a multidimensional array into a string using the 'implode' function.
The data will now be converted to a json string.