### PR TITLE
chore: automate generis extension release

### DIFF
--- a/.github/workflows/conventional_commits_check.yml
+++ b/.github/workflows/conventional_commits_check.yml
@@ -1,0 +1,19 @@
+# Action to check conventional commits on OAT pull requests
+
+name: Conventional commits check
+
+on:
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  pr-check:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - run: git fetch --unshallow --tags
+    - name: Check commit
+      if: always()
+      uses: oat-sa/conventional-commit-action@v0
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_tao_extension.yml
+++ b/.github/workflows/release_tao_extension.yml
@@ -1,0 +1,23 @@
+# Make an extension release after merging to develop branch
+
+name: Release Tao extension
+
+on:
+  pull_request:
+    branches:
+      - develop
+    types: [closed]
+jobs:
+  auto-release:
+    if: github.event.pull_request.merged == true
+    name: Automated Tao extension release
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Release
+        uses: oat-sa/extension-release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
# Goal 

Allow generis extension to be released automatically

# Why?

- We are spending to much time on releasing it manually
- There is no much benefit on it as many other core extensions also have automatic release