### PR TITLE
[Feature] Register ServiceManager in DI container

### DIFF
--- a/core/DependencyInjection/ContainerServiceProvider.php
+++ b/core/DependencyInjection/ContainerServiceProvider.php
@@ -24,14 +24,14 @@ declare(strict_types=1);
 
 namespace oat\generis\model\DependencyInjection;
 
-use Relay\RelayBuilder;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\ServerRequest;
+use oat\generis\model\Middleware\MiddlewareExtensionsMapper;
+use oat\generis\model\Middleware\MiddlewareRequestHandler;
 use oat\oatbox\service\ServiceManager;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use oat\generis\model\Middleware\MiddlewareRequestHandler;
-use oat\generis\model\Middleware\MiddlewareExtensionsMapper;
+use Relay\RelayBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
@@ -46,8 +46,7 @@ class ContainerServiceProvider implements ContainerServiceProviderInterface
     {
         $services = $configurator->services();
 
-        $services
-            ->set(ServerRequestInterface::class, ServerRequestInterface::class)
+        $services->set(ServerRequestInterface::class, ServerRequestInterface::class)
             ->public()
             ->factory(ServerRequest::class . '::fromGlobals');
 
@@ -56,16 +55,14 @@ class ContainerServiceProvider implements ContainerServiceProviderInterface
             ->public()
             ->factory(ServiceManager::class . '::getServiceManager');
 
-        $services
-            ->set(ResponseInterface::class, Response::class)
+        $services->set(ResponseInterface::class, Response::class)
             ->public();
 
         $services->set(RelayBuilder::class, RelayBuilder::class);
 
         $services->set(LegacyServiceGateway::class, LegacyServiceGateway::class);
 
-        $services
-            ->set(MiddlewareRequestHandler::class, MiddlewareRequestHandler::class)
+        $services->set(MiddlewareRequestHandler::class, MiddlewareRequestHandler::class)
             ->public()
             ->args(
                 [

--- a/core/DependencyInjection/ContainerServiceProvider.php
+++ b/core/DependencyInjection/ContainerServiceProvider.php
@@ -24,13 +24,14 @@ declare(strict_types=1);
 
 namespace oat\generis\model\DependencyInjection;
 
+use Relay\RelayBuilder;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\ServerRequest;
-use oat\generis\model\Middleware\MiddlewareExtensionsMapper;
-use oat\generis\model\Middleware\MiddlewareRequestHandler;
+use oat\oatbox\service\ServiceManager;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Relay\RelayBuilder;
+use oat\generis\model\Middleware\MiddlewareRequestHandler;
+use oat\generis\model\Middleware\MiddlewareExtensionsMapper;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
 use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
@@ -45,18 +46,26 @@ class ContainerServiceProvider implements ContainerServiceProviderInterface
     {
         $services = $configurator->services();
 
-        $services->set(ServerRequestInterface::class, ServerRequestInterface::class)
+        $services
+            ->set(ServerRequestInterface::class, ServerRequestInterface::class)
             ->public()
             ->factory(ServerRequest::class . '::fromGlobals');
 
-        $services->set(ResponseInterface::class, Response::class)
+        $services
+            ->set(ServiceManager::class, ServiceManager::class)
+            ->public()
+            ->factory(ServiceManager::class . '::getServiceManager');
+
+        $services
+            ->set(ResponseInterface::class, Response::class)
             ->public();
 
         $services->set(RelayBuilder::class, RelayBuilder::class);
 
         $services->set(LegacyServiceGateway::class, LegacyServiceGateway::class);
 
-        $services->set(MiddlewareRequestHandler::class, MiddlewareRequestHandler::class)
+        $services
+            ->set(MiddlewareRequestHandler::class, MiddlewareRequestHandler::class)
             ->public()
             ->args(
                 [


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/RFE-530
https://oat-sa.atlassian.net/browse/ADF-1424
https://oat-sa.atlassian.net/browse/ADF-1425
https://oat-sa.atlassian.net/browse/ADF-1426
https://oat-sa.atlassian.net/browse/ADF-1427

# Goal

Add dynamic ACL strategy to `Move to` and `Copy to` features

# How to test

- Login to backoffice
- Play with the new ACL options for Items/Assets/Tests

# Related PRs

- https://github.com/oat-sa/tao-core/pull/3776
- https://github.com/oat-sa/extension-tao-item/pull/607
- https://github.com/oat-sa/extension-tao-mediamanager/pull/462
- https://github.com/oat-sa/extension-tao-test/pull/438
- https://github.com/oat-sa/extension-tao-dac-simple/pull/216
