### PR TITLE
Fix REL-1101 guest user locale

### DIFF
--- a/core/kernel/users/class.GenerisUser.php
+++ b/core/kernel/users/class.GenerisUser.php
@@ -30,7 +30,8 @@ use oat\generis\model\OntologyRdf;
  * @access public
  * @author Joel Bout, <joel@taotesting.com>
  * @package generis
-
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
  */
 class core_kernel_users_GenerisUser extends common_user_User implements UserInternalInterface
 {

--- a/core/kernel/users/class.GenerisUser.php
+++ b/core/kernel/users/class.GenerisUser.php
@@ -85,7 +85,7 @@ class core_kernel_users_GenerisUser extends common_user_User implements UserInte
             case GenerisRdf::PROPERTY_USER_DEFLG:
                 $lang = $this->findLanguage($property);
 
-                return $lang ?: [DEFAULT_LANG];
+                return $lang ?: [DEFAULT_ANONYMOUS_INTERFACE_LANG];
 
             case GenerisRdf::PROPERTY_USER_UILG:
                 return $this->findLanguage($property);


### PR DESCRIPTION
# [REL-1101](https://oat-sa.atlassian.net/browse/REL-1101)

This PR uses `DEFAULT_ANONYMOUS_INTERFACE_LANG` as a default locale value for all guest users.
One way to spot the difference is to launch the TAO Advance tool via TAO 3.x as a guest user.

This is an alternative to https://github.com/oat-sa/extension-tao-lti/pull/365.

https://user-images.githubusercontent.com/2943256/233679803-87c7b059-022e-4abe-b054-5e6069bcb563.mov

## How to test

1. Set `DEFAULT_ANONYMOUS_INTERFACE_LANG` to any locale other than `en-US` by modifying `./config/generis.conf`
2. Have a guest-accessible delivery published to remote TAO Advance tool
3. Sign in as a guest to TAO 3.x
4. Launch the delivery
5. Make sure the locale is propagated to the TAO Advance session

## Change log
a418fd53 fix: guest user locale by defining it via `DEFAULT_ANONYMOUS_INTERFACE_LANG` instead of `DEFAULT_LANG`

[REL-1101]: https://oat-sa.atlassian.net/browse/REL-1101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ