### PR TITLE
chore: add switch to follow redirects on request sent

### DIFF
--- a/common/http/class.Request.php
+++ b/common/http/class.Request.php
@@ -242,6 +242,10 @@ class common_http_Request
         //curl_setopt($curlHandler, CURLINFO_HEADER_OUT, 1);
         //curl_setopt($curlHandler, CURLOPT_HEADER, true);
 
+        //directly setting `FOLLOWLOCATION` to false to make sure next lines would be working as expected
+        //and we can get the redirect url from curl
+        curl_setopt($curlHandler, CURLOPT_FOLLOWLOCATION, 0);
+
         $responseData = curl_exec($curlHandler);
         $httpResponse = new common_http_Response();
 

--- a/common/http/class.Request.php
+++ b/common/http/class.Request.php
@@ -255,13 +255,20 @@ class common_http_Request
         $httpResponse->responseData = $responseData;
 
         $redirectUrl = curl_getinfo($curlHandler, CURLINFO_REDIRECT_URL);
+        $sameDomain = null;
+        if ($redirectUrl) {
+            $initialDomain = parse_url($this->getUrl(), PHP_URL_HOST);
+            $redirectDomain = parse_url($redirectUrl, PHP_URL_HOST);
+
+            $sameDomain = ($initialDomain === $redirectDomain);
+        }
 
         //curl_setopt($curlHandler, );
         curl_close($curlHandler);
 
         if (
             $followRedirects
-            && $redirectUrl
+            && $sameDomain
             && in_array($httpResponse->httpCode, self::REDIRECT_CODES, true)
         ) {
             $this->url = $redirectUrl;

--- a/common/http/class.Request.php
+++ b/common/http/class.Request.php
@@ -254,17 +254,18 @@ class common_http_Request
         $httpResponse->effectiveUrl = curl_getinfo($curlHandler, CURLINFO_EFFECTIVE_URL);
         $httpResponse->responseData = $responseData;
 
-        $fullInfo = curl_getinfo($curlHandler);
+        $redirectUrl = curl_getinfo($curlHandler, CURLINFO_REDIRECT_URL);
 
         //curl_setopt($curlHandler, );
         curl_close($curlHandler);
 
-        if ($followRedirects && in_array($httpResponse->httpCode, self::REDIRECT_CODES, true)) {
-            $redirectUrl = $fullInfo['redirectUrl'] ?? '';
-            if ($redirectUrl) {
-                $this->url = $redirectUrl;
-                $httpResponse = $this->send();
-            }
+        if (
+            $followRedirects
+            && $redirectUrl
+            && in_array($httpResponse->httpCode, self::REDIRECT_CODES, true)
+        ) {
+            $this->url = $redirectUrl;
+            $httpResponse = $this->send();
         }
 
         return $httpResponse;


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/LSI-2325

Adds a possibility to follow redirects when sending requests with legacy `Request` class via curl.
This is needed as a part of ISO-27001 changes. As an example: in the setup with SimpleRoster - we have problems after changing CloudFront origin settings to `Redirect HTTP to HTTPS`, as the `LtiOutcomeCallback` doesn't follow redirects and simply stops on getting 307 response code. This comes also from next:
all routes generated by SimpleRoster app are generated as HTTP routes (and the LtiOutcome is generated by SR). Ofc, we can force HTTPS scheme for SR routes, but this won't help because of point the way how we are working with SSL certs. We are using certs provided by AWS ACM. Those certificates cannot be exported, and due to this, the only way we can setup secure connections is apply the certificate on the load balancer side, not on the application side (via apache or other WS). And due  to this even if we are forcing the route to be HTTPS one, the HTTPS request would come only to load balancer. After - it is getting decrypted, and sent as a plain HTTP to the application instance. Which will return 404, since route is forced to be https.

So, this one, is atm the minimal changes need to make things working after applying ISO-27001-related security changes.

Small addition: this changes may look awkward, because not using `curl_setopt($handler, CURLOPT_FOLLOWLOCATION, 1);`, but this is not a solution, because in this case we are missing `Authorization` header, which also breaks the loop, since requests would be un-authorized on the SR side.