### PR TITLE
feat: Cache warmup after instance refresh

### DIFF
--- a/common/persistence/PersistenceManager.php
+++ b/common/persistence/PersistenceManager.php
@@ -131,11 +131,15 @@ class PersistenceManager extends ConfigurableService
         $config = $configs[$persistenceId];
         $driverString = $config['driver'];
 
-        $driverClassName = isset(self::DRIVER_MAP[$driverString]) ? self::DRIVER_MAP[$driverString] : $driverString;
+        $driverClassName = self::DRIVER_MAP[$driverString] ?? (string)$driverString;
 
         if (!class_exists($driverClassName)) {
             throw new \common_exception_Error(
-                'Driver ' . $driverString . ' not found, check your database configuration'
+                sprintf(
+                    'Driver "%s" not found, check your database configuration for %s.',
+                    $driverString,
+                    $persistenceId
+                )
             );
         }
 

--- a/core/data/event/CacheWarmupEvent.php
+++ b/core/data/event/CacheWarmupEvent.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023(original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\generis\model\data\event;
+
+use oat\oatbox\event\Event;
+use oat\oatbox\reporting\Report;
+
+class CacheWarmupEvent implements Event
+{
+    /**
+     * @return Report[]
+     */
+    private array $reports = [];
+
+    public function getName(): string
+    {
+        return self::class;
+    }
+
+    public function addReport(Report $report): self
+    {
+        $this->reports[] = $report;
+
+        return $this;
+    }
+
+    /**
+     * @return Report[]
+     */
+    public function getReports(): array
+    {
+        return $this->reports;
+    }
+}

--- a/helpers/class.PhpTools.php
+++ b/helpers/class.PhpTools.php
@@ -36,13 +36,15 @@ class helpers_PhpTools
      */
     public static function getClassInfo($file)
     {
+        $namespaceToken = PHP_VERSION_ID < 80000 ? T_STRING : T_NAME_QUALIFIED;
+
         $buffer = file_get_contents($file);
         $tokens = @token_get_all($buffer);
         $class = $namespace = $buffer = '';
         for ($i = 0; $i < count($tokens); $i++) {
             if ($tokens[$i][0] === T_NAMESPACE) {
                 for ($j = $i + 1; $j < count($tokens); $j++) {
-                    if ($tokens[$j][0] === T_STRING) {
+                    if ($tokens[$j][0] === $namespaceToken) {
                         $namespace .= '\\' . $tokens[$j][1];
                     } elseif ($tokens[$j] === '{' || $tokens[$j] === ';') {
                         break;

--- a/scripts/tools/ApplicationCacheWarmup.php
+++ b/scripts/tools/ApplicationCacheWarmup.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\generis\scripts\tools;
+
+use oat\generis\model\data\event\CacheWarmupEvent;
+use oat\oatbox\cache\SimpleCache;
+use oat\oatbox\event\EventManager;
+use oat\oatbox\extension\script\ScriptAction;
+use oat\oatbox\reporting\Report;
+
+/**
+ * php index.php 'oat\generis\scripts\tools\ApplicationCacheWarmup' --clear
+ */
+class ApplicationCacheWarmup extends ScriptAction
+{
+    protected function showTime()
+    {
+        return true;
+    }
+
+    protected function provideUsage(): array
+    {
+        return [
+            'prefix' => 'h',
+            'longPrefix' => 'help',
+            'description' => 'Warmup TAO Cache',
+        ];
+    }
+
+    protected function provideOptions(): array
+    {
+        return [
+            'clear' => [
+                'prefix' => 'c',
+                'longPrefix' => 'clear',
+                'flag' => true,
+                'description' => 'Clear cache before warm it up.',
+                'defaultValue' => false,
+            ],
+        ];
+    }
+
+    protected function provideDescription(): string
+    {
+        return 'Warmup TAO Cache';
+    }
+
+    protected function run(): Report
+    {
+        $reports = [];
+
+        $clearCache = (bool)$this->getOption('clear');
+        if ($clearCache) {
+            $this->getServiceLocator()->get(SimpleCache::SERVICE_ID)->clear();
+            $reports[] = Report::createInfo('Cache was cleared.');
+        }
+
+        try {
+            $cacheWarmupEvent = new CacheWarmupEvent();
+            /** @var EventManager $eventManager */
+            $eventManager = $this->getServiceLocator()->get(EventManager::SERVICE_ID);
+            $eventManager->trigger($cacheWarmupEvent);
+
+            $reports = array_merge($reports, $cacheWarmupEvent->getReports());
+        } catch (\Throwable $e) {
+            return Report::createError(sprintf('Cache warmup failed: %s', $e->getMessage()));
+        }
+
+        return Report::createSuccess('TAO cache warmed up!', null, $reports);
+    }
+}

--- a/test/unit/helpers/PhpToolsTest.php
+++ b/test/unit/helpers/PhpToolsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\generis\tests\unit\helpers;
+
+use PHPUnit\Framework\TestCase;
+
+class PhpToolsTest extends TestCase
+{
+    public function testNamespaceAndClass(): void
+    {
+        $info = \helpers_PhpTools::getClassInfo(__FILE__);
+
+        $this->assertEquals('\oat\generis\tests\unit\helpers', $info['ns'], 'Namespace is wrong.');
+        $this->assertEquals('PhpToolsTest', $info['class'], 'Class is wrong.');
+    }
+
+    public function testNamespaceAndClassLegacy(): void
+    {
+        $reflectionHelper = new \ReflectionClass(\helpers_PhpTools::class);
+        $info = \helpers_PhpTools::getClassInfo($reflectionHelper->getFileName());
+
+        $this->assertEquals('', $info['ns'], 'Namespace is wrong.');
+        $this->assertEquals('helpers_PhpTools', $info['class'], 'Class is wrong.');
+    }
+}


### PR DESCRIPTION
## Goal
Premium EC2 instances are recycled every night. This clears the application cache and results in slow first requests until the cache is refilled. The purpose of this PR is to implement a solution for warming up the cache after the instance refresh to improve the performance of the first requests.

## Changelog
- fix: updated parsing to PHP 8.0+ standard
- fix: When driver is nor defined class_exists throw an error about type mismatch.
- feat: add new command which allow to warmup of the application cache.

## How to test / use
You can run following command to execute  command. `--clear` flag clens up cache before warming it up and can be useful in case of issues or interrupted execution of previous command
```bash
php index.php 'oat\generis\scripts\tools\ApplicationCacheWarmup' --clear
```