### PR TITLE
fix: creating a directory for a service container

### DIFF
--- a/core/DependencyInjection/ContainerBuilder.php
+++ b/core/DependencyInjection/ContainerBuilder.php
@@ -101,6 +101,10 @@ class ContainerBuilder extends SymfonyContainerBuilder
             return $this->legacyContainer;
         }
 
+        if (!file_exists($this->cachePath)) {
+            mkdir($this->cachePath, 0700, true);
+        }
+
         if (!is_writable($this->cachePath)) {
             throw new InvalidArgumentException(
                 sprintf(


### PR DESCRIPTION
## Goal
Make sure cache directory exists before creating a service container file. This way we can ensure no error happen during later steps.

## Changelog
- fix: creating a directory as a service container requires it.

## How to test / use
1. Install application
2. Remove `data` directory
3. Run the command `php index.php oat\generis\scripts\tools\ContainerCacheWarmup`
