### PR TITLE
fix: return type of Directory::getIterator() should be Traversable.

### DIFF
--- a/common/class.Collection.php
+++ b/common/class.Collection.php
@@ -236,9 +236,8 @@ class common_Collection extends common_Object implements IteratorAggregate, Coun
      *
      * @access public
      * @author Lionel Lecaque <lionel.lecaque@tudor.lu>
-     * @return mixed
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
 
         return new ArrayIterator($this->sequence);

--- a/common/class.Collection.php
+++ b/common/class.Collection.php
@@ -86,15 +86,10 @@ class common_Collection extends common_Object implements IteratorAggregate, Coun
      *
      * @access public
      * @author Lionel Lecaque <lionel.lecaque@tudor.lu>
-     * @return int
      */
-    public function count()
+    public function count(): int
     {
-        $returnValue = (int) 0;
-
-
         $returnValue = count($this->sequence);
-
 
         return (int) $returnValue;
     }

--- a/common/oatbox/filesystem/Directory.php
+++ b/common/oatbox/filesystem/Directory.php
@@ -21,6 +21,7 @@
 
 namespace oat\oatbox\filesystem;
 
+use ArrayIterator;
 use League\Flysystem\FileExistsException;
 
 class Directory extends FileSystemHandler implements \IteratorAggregate
@@ -57,10 +58,8 @@ class Directory extends FileSystemHandler implements \IteratorAggregate
 
     /**
      * Method constraints by IteratorAggregator, wrapper to getFlyIterator
-     *
-     * @return \ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return $this->getFlyIterator();
     }
@@ -71,9 +70,8 @@ class Directory extends FileSystemHandler implements \IteratorAggregate
      * By default iterator is not recursive and includes directories & files
      *
      * @param null $flags
-     * @return \ArrayIterator
      */
-    public function getFlyIterator($flags = null)
+    public function getFlyIterator($flags = null): ArrayIterator
     {
         if (is_null($flags)) {
             $flags = self::ITERATOR_DIRECTORY | self::ITERATOR_FILE;
@@ -99,7 +97,7 @@ class Directory extends FileSystemHandler implements \IteratorAggregate
             }
         }
 
-        return new \ArrayIterator($iterator);
+        return new ArrayIterator($iterator);
     }
 
     /**

--- a/common/persistence/sql/class.QueryIterator.php
+++ b/common/persistence/sql/class.QueryIterator.php
@@ -107,7 +107,7 @@ class common_persistence_sql_QueryIterator implements Iterator
         }
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return !empty($this->cache);
     }

--- a/common/persistence/sql/class.QueryIterator.php
+++ b/common/persistence/sql/class.QueryIterator.php
@@ -96,7 +96,7 @@ class common_persistence_sql_QueryIterator implements Iterator
         return $this->currentResult;
     }
 
-    public function next()
+    public function next(): void
     {
         if ($this->valid()) {
             $last = $this->key();

--- a/core/kernel/persistence/smoothsql/class.SmoothRdf.php
+++ b/core/kernel/persistence/smoothsql/class.SmoothRdf.php
@@ -164,7 +164,7 @@ class core_kernel_persistence_smoothsql_SmoothRdf implements RdfInterface
         throw new \common_Exception('Not implemented');
     }
 
-    public function getIterator()
+    public function getIterator(): core_kernel_persistence_smoothsql_SmoothIterator
     {
         return new core_kernel_persistence_smoothsql_SmoothIterator($this->getPersistence());
     }


### PR DESCRIPTION
## What's Changed
- Fixed return type of Directory::getIterator().
- Fixed return type of common_Collection::getIterator().
- Fixed return type of common_Collection::count().
- Fixed return type of core_kernel_persistence_smoothsql_SmoothRdf::getIterator().
- Fixed return type of common_persistence_sql_QueryIterator::next().
- Fixed return type of common_persistence_sql_QueryIterator::valid().

## TODO 

- [x] Unit tests
- [x] E2E tests

## How to test
- Import Tests from zip file
- Run worker process
- Watch logs:
`tail -f /var/www/html/tao.log`
- No errors should be visible in logs:
`Return type of oat\oatbox\filesystem\Directory::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable`
`Return type of common_Collection::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`
`Return type of common_Collection::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`
`Return type of core_kernel_persistence_smoothsql_SmoothRdf::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`
`Return type of common_persistence_sql_QueryIterator::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`
''Return type of common_persistence_sql_QueryIterator::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice`