### PR TITLE
fix: Add distinct to neo4j count query

### DIFF
--- a/core/kernel/persistence/starsql/search/CountSerializer.php
+++ b/core/kernel/persistence/starsql/search/CountSerializer.php
@@ -36,7 +36,10 @@ class CountSerializer extends QuerySerializer
 
         $query = Query::new()->match($this->matchPatterns);
         $query->where($this->whereConditions);
-        $query->returning(Procedure::raw('count', $subject));
+        $query->returning(Procedure::raw(
+            'count',
+            Query::rawExpression(sprintf('DISTINCT %s', $subject->getVariable()->getName()))
+        ));
 
         return Statement::create($query->build(), $this->parameters);
     }


### PR DESCRIPTION
In some cases `count` query can return the bigger number of nodes than expected. It happens because `grandParent` node and `parent` node can be taking into account twice.
Example of a such query (it returns 3 instead of 2):
```
MATCH (subject:Resource)-[:`http://www.w3.org/1999/02/22-rdf-syntax-ns#type`]->(parent:Resource)
        -[:`http://www.w3.org/2000/01/rdf-schema#subClassOf`*0..]->(grandParent:Resource)
  WHERE ((parent.uri IN ['https://studio-neo4j.docker.localhost/ontologies/tao.rdf#i65310f09f0462218c0d13cf11864cc5']) OR (grandParent.uri = 'https://studio-neo4j.docker.localhost/ontologies/tao.rdf#i65310f09f0462218c0d13cf11864cc5'))
RETURN count(subject)
```
If we exchange `*0..` by `*1..` or by `*` the issue is gone.

This bug was caused by setting `withMinHopes(0)` instead of `withArbitraryHopes()` here - https://github.com/oat-sa/generis/blob/feat/REL-1198/list-neo4j/core/kernel/persistence/starsql/search/QuerySerializer.php#L179
It was decided to add `DISTINCT` to a `count` query in order to get the valid number of nodes.

How to test:
1. Integration test has to pass
https://github.com/oat-sa/generis/blob/feat/REL-1198/list-neo4j/test/integration/model/persistence/starsql/ClassTest.php#L436
(`php vendor/bin/phpunit -c phpunit.xml generis/test/integration/model/persistence/starsql/`)