### PR TITLE
feat: decrease query count by cacheing some RDF property fields

### DIFF
--- a/config/default/RedisCache.conf.php
+++ b/config/default/RedisCache.conf.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * The default cache implementation
+ */
+
+use oat\oatbox\cache\KeyValueCache;
+
+return new KeyValueCache([
+    KeyValueCache::OPTION_PERSISTENCE => 'redis'
+]);

--- a/core/kernel/classes/class.Resource.php
+++ b/core/kernel/classes/class.Resource.php
@@ -302,9 +302,8 @@ class core_kernel_classes_Resource extends core_kernel_classes_Container
      */
     public function getPropertyValues(core_kernel_classes_Property $property, $options = [])
     {
-        $returnValue = [];
         $returnValue = $this->getImplementation()->getPropertyValues($this, $property, $options);
-        return (array) $returnValue;
+        return $returnValue;
     }
 
     /**

--- a/core/kernel/persistence/Cache.php
+++ b/core/kernel/persistence/Cache.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; under version 2
+ *  of the License (non-upgradable).
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  Copyright (c) 2023 (original work) Open Assessment Technologies SA ;
+ */
+
+namespace oat\generis\model\kernel\persistence;
+
+use oat\oatbox\cache\SimpleCache;
+
+interface Cache
+{
+    public function getCache(): SimpleCache;
+}

--- a/core/kernel/persistence/smoothsql/class.Property.php
+++ b/core/kernel/persistence/smoothsql/class.Property.php
@@ -65,15 +65,12 @@ class core_kernel_persistence_smoothsql_Property extends core_kernel_persistence
      */
     public function isLgDependent(core_kernel_classes_Resource $resource)
     {
-        $lgDependent = $this->getModel()->getCache()->get($resource->getUri());
-        if (is_null($lgDependent)) {
-            $lgDependentProperty = $this->getModel()->getProperty(GenerisRdf::PROPERTY_IS_LG_DEPENDENT);
-            $lgDependentResource = $resource->getOnePropertyValue($lgDependentProperty);
-            $lgDependent = !is_null($lgDependentResource)
-                && $lgDependentResource instanceof \core_kernel_classes_Resource
-                && $lgDependentResource->getUri() == GenerisRdf::GENERIS_TRUE;
-            $this->getModel()->getCache()->set($resource->getUri(), $lgDependent);
-        }
+        $lgDependentProperty = $this->getModel()->getProperty(GenerisRdf::PROPERTY_IS_LG_DEPENDENT);
+        $lgDependentResource = $resource->getOnePropertyValue($lgDependentProperty);
+        $lgDependent = !is_null($lgDependentResource)
+            && $lgDependentResource instanceof \core_kernel_classes_Resource
+            && $lgDependentResource->getUri() == GenerisRdf::GENERIS_TRUE;
+
         return (bool) $lgDependent;
     }
 
@@ -174,7 +171,6 @@ class core_kernel_persistence_smoothsql_Property extends core_kernel_persistence
      */
     public function setMultiple(core_kernel_classes_Resource $resource, $isMultiple)
     {
-
         $multipleProperty = new core_kernel_classes_Property(GenerisRdf::PROPERTY_MULTIPLE);
         $value = ((bool)$isMultiple) ? GenerisRdf::GENERIS_TRUE : GenerisRdf::GENERIS_FALSE ;
         $this->removePropertyValues($resource, $multipleProperty);
@@ -192,7 +188,6 @@ class core_kernel_persistence_smoothsql_Property extends core_kernel_persistence
      */
     public function setLgDependent(core_kernel_classes_Resource $resource, $isLgDependent)
     {
-
         $lgDependentProperty = new core_kernel_classes_Property(GenerisRdf::PROPERTY_IS_LG_DEPENDENT, __METHOD__);
         $value = ((bool)$isLgDependent) ? GenerisRdf::GENERIS_TRUE : GenerisRdf::GENERIS_FALSE ;
         $this->removePropertyValues($resource, $lgDependentProperty);
@@ -208,7 +203,6 @@ class core_kernel_persistence_smoothsql_Property extends core_kernel_persistence
      */
     public static function singleton()
     {
-        $returnValue = null;
         if (core_kernel_persistence_smoothsql_Property::$instance == null) {
             core_kernel_persistence_smoothsql_Property::$instance = new core_kernel_persistence_smoothsql_Property();
         }

--- a/core/kernel/persistence/smoothsql/class.SmoothModel.php
+++ b/core/kernel/persistence/smoothsql/class.SmoothModel.php
@@ -20,13 +20,14 @@
  */
 
 use oat\generis\model\data\ModelManager;
-use oat\oatbox\service\ConfigurableService;
-use oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService;
 use oat\generis\model\data\Ontology;
-use oat\generis\persistence\sql\SchemaProviderInterface;
-use oat\generis\persistence\sql\SchemaCollection;
+use oat\generis\model\kernel\persistence\Cache;
 use oat\generis\model\kernel\persistence\smoothsql\install\SmoothRdsModel;
+use oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService;
+use oat\generis\persistence\sql\SchemaCollection;
+use oat\generis\persistence\sql\SchemaProviderInterface;
 use oat\oatbox\cache\SimpleCache;
+use oat\oatbox\service\ConfigurableService;
 
 /**
  * transitory model for the smooth sql implementation
@@ -36,7 +37,8 @@ use oat\oatbox\cache\SimpleCache;
  */
 class core_kernel_persistence_smoothsql_SmoothModel extends ConfigurableService implements
     Ontology,
-    SchemaProviderInterface
+    SchemaProviderInterface,
+    Cache
 {
     public const OPTION_PERSISTENCE = 'persistence';
     public const OPTION_READABLE_MODELS = 'readable';
@@ -104,7 +106,7 @@ class core_kernel_persistence_smoothsql_SmoothModel extends ConfigurableService 
 
     public function getCache(): SimpleCache
     {
-        return $this->getServiceLocator()->get(SimpleCache::SERVICE_ID);
+        return $this->getServiceLocator()->get('generis/RedisCache');
     }
 
     /**

--- a/core/kernel/persistence/starsql/class.Property.php
+++ b/core/kernel/persistence/starsql/class.Property.php
@@ -33,15 +33,12 @@ class core_kernel_persistence_starsql_Property extends core_kernel_persistence_s
 
     public function isLgDependent(core_kernel_classes_Resource $resource): bool
     {
-        $lgDependent = $this->getModel()->getCache()->get($resource->getUri());
-        if (is_null($lgDependent)) {
-            $lgDependentProperty = $this->getModel()->getProperty(GenerisRdf::PROPERTY_IS_LG_DEPENDENT);
-            $lgDependentResource = $resource->getOnePropertyValue($lgDependentProperty);
-            $lgDependent = !is_null($lgDependentResource)
-                && $lgDependentResource instanceof \core_kernel_classes_Resource
-                && $lgDependentResource->getUri() == GenerisRdf::GENERIS_TRUE;
-            $this->getModel()->getCache()->set($resource->getUri(), $lgDependent);
-        }
+        $lgDependentProperty = $this->getModel()->getProperty(GenerisRdf::PROPERTY_IS_LG_DEPENDENT);
+        $lgDependentResource = $resource->getOnePropertyValue($lgDependentProperty);
+        $lgDependent = !is_null($lgDependentResource)
+            && $lgDependentResource instanceof \core_kernel_classes_Resource
+            && $lgDependentResource->getUri() == GenerisRdf::GENERIS_TRUE;
+
         return (bool) $lgDependent;
     }
 
@@ -105,7 +102,6 @@ class core_kernel_persistence_starsql_Property extends core_kernel_persistence_s
 
     public function setLgDependent(core_kernel_classes_Resource $resource, $isLgDependent)
     {
-
         $lgDependentProperty = new core_kernel_classes_Property(GenerisRdf::PROPERTY_IS_LG_DEPENDENT, __METHOD__);
         $value = ((bool)$isLgDependent) ?  GenerisRdf::GENERIS_TRUE : GenerisRdf::GENERIS_FALSE ;
         $this->setPropertyValue($resource, $lgDependentProperty, $value);

--- a/core/kernel/persistence/starsql/class.StarModel.php
+++ b/core/kernel/persistence/starsql/class.StarModel.php
@@ -20,11 +20,12 @@
 
 use oat\generis\model\data\ModelManager;
 use oat\generis\model\data\Ontology;
+use oat\generis\model\kernel\persistence\Cache;
 use oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService;
 use oat\oatbox\cache\SimpleCache;
 use oat\oatbox\service\ConfigurableService;
 
-class core_kernel_persistence_starsql_StarModel extends ConfigurableService implements Ontology
+class core_kernel_persistence_starsql_StarModel extends ConfigurableService implements Ontology, Cache
 {
     public const OPTION_PERSISTENCE = 'persistence';
     public const OPTION_READABLE_MODELS = 'readable';
@@ -89,7 +90,7 @@ class core_kernel_persistence_starsql_StarModel extends ConfigurableService impl
 
     public function getCache(): SimpleCache
     {
-        return $this->getServiceLocator()->get(SimpleCache::SERVICE_ID);
+        return $this->getServiceLocator()->get('generis/RedisCache');
     }
 
     /**

--- a/helpers/class.PropertyCache.php
+++ b/helpers/class.PropertyCache.php
@@ -5,22 +5,22 @@ class helpers_PropertyCache
     /**
      * Clear property cached data
      */
-    public static function clearCachedValues(Iterator $triples): void
+    public static function clearCachedValuesByTriples(Iterator $triples): void
     {
         foreach ($triples as $triple) {
-            $property = new \core_kernel_classes_Property($triple->predicate);
-            $property->clearCachedValues();
+            $classProperty = new \core_kernel_classes_Property($triple->predicate);
+            $classProperty->clearCachedValues();
         }
     }
 
     /**
      * Warmup property cached data
      */
-    public static function warmupCachedValues(Iterator $triples): void
+    public static function warmupCachedValuesByProperties(array $properties): void
     {
-        foreach ($triples as $triple) {
-            $property = new \core_kernel_classes_Property($triple->predicate);
-            $property->warmupCachedValues();
+        foreach ($properties as $property) {
+            $classProperty = new \core_kernel_classes_Property($property);
+            $classProperty->warmupCachedValues();
         }
     }
 }

--- a/helpers/class.PropertyCache.php
+++ b/helpers/class.PropertyCache.php
@@ -1,0 +1,26 @@
+<?php
+
+class helpers_PropertyCache
+{
+    /**
+     * Clear property cached data
+     */
+    public static function clearCachedValues(Iterator $triples): void
+    {
+        foreach ($triples as $triple) {
+            $property = new \core_kernel_classes_Property($triple->predicate);
+            $property->clearCachedValues();
+        }
+    }
+
+    /**
+     * Warmup property cached data
+     */
+    public static function warmupCachedValues(Iterator $triples): void
+    {
+        foreach ($triples as $triple) {
+            $property = new \core_kernel_classes_Property($triple->predicate);
+            $property->warmupCachedValues();
+        }
+    }
+}

--- a/test/unit/core/kernel/classes/PropertyTest.php
+++ b/test/unit/core/kernel/classes/PropertyTest.php
@@ -1,0 +1,305 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\generis\test\unit\core\kernel\classes;
+
+use core_kernel_classes_Property;
+use core_kernel_persistence_PropertyInterface;
+use core_kernel_persistence_starsql_StarModel;
+use oat\generis\model\data\RdfsInterface;
+use oat\generis\model\GenerisRdf;
+use oat\generis\model\OntologyRdfs;
+use oat\generis\test\GenerisTestCase;
+use oat\oatbox\cache\SimpleCache;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class PropertyTest extends GenerisTestCase
+{
+    /** @var core_kernel_classes_Property */
+    private $property;
+
+    /** @var core_kernel_persistence_starsql_StarModel|MockObject */
+    private $model;
+
+    /** @var core_kernel_persistence_PropertyInterface|MockObject */
+    private $persistenceProperty;
+
+    /** @var SimpleCache|MockObject */
+    private $cache;
+
+    public function setUp(): void
+    {
+        $this->model = $this->createMock(core_kernel_persistence_starsql_StarModel::class);
+        $this->rdfs = $this->createMock(RdfsInterface::class);
+        $this->persistenceProperty = $this->createMock(core_kernel_persistence_PropertyInterface::class);
+        $this->cache = $this->createMock(SimpleCache::class);
+
+        $this->model
+            ->method('getRdfsInterface')
+            ->willReturn($this->rdfs);
+        $this->rdfs
+            ->method('getPropertyImplementation')
+            ->willReturn($this->persistenceProperty);
+
+        $this->model
+            ->method('getCache')
+            ->willReturn($this->cache);
+
+        $this->property = $this->createPartialMock(
+            core_kernel_classes_Property::class,
+            ['getRange', 'getProperty', 'getOnePropertyValue']
+        );
+        $this->property->__construct('uri');
+        $this->property->setModel($this->model);
+    }
+
+    public function testIsRelationshipFalseWithoutCache(): void
+    {
+        $this->property
+            ->expects(self::once())
+            ->method('getRange')
+            ->willReturn(new core_kernel_classes_Property(OntologyRdfs::RDFS_LITERAL));
+
+        $this->cache
+            ->expects(self::once())
+            ->method('has')
+            ->with('PropIsRelationship_uri')
+            ->willReturn(false);
+        $this->cache
+            ->expects(self::never())
+            ->method('get');
+        $this->cache
+            ->expects(self::once())
+            ->method('set')
+            ->with('PropIsRelationship_uri', false);
+
+        $result = $this->property->isRelationship();
+
+        $this->assertFalse($result);
+    }
+
+    public function testIsRelationshipTrueWithoutCache(): void
+    {
+        $this->property
+            ->expects(self::once())
+            ->method('getRange')
+            ->willReturn(new core_kernel_classes_Property(OntologyRdfs::RDFS_LABEL));
+
+        $this->cache
+            ->expects(self::once())
+            ->method('has')
+            ->with('PropIsRelationship_uri')
+            ->willReturn(false);
+        $this->cache
+            ->expects(self::never())
+            ->method('get');
+        $this->cache
+            ->expects(self::once())
+            ->method('set')
+            ->with('PropIsRelationship_uri', true);
+
+        $result = $this->property->isRelationship();
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsRelationshipTrueWithCache(): void
+    {
+        $this->property
+            ->expects(self::never())
+            ->method('getRange');
+
+        $this->cache
+            ->expects(self::once())
+            ->method('has')
+            ->with('PropIsRelationship_uri')
+            ->willReturn(true);
+        $this->cache
+            ->expects(self::once())
+            ->method('get')
+            ->with('PropIsRelationship_uri')
+            ->willReturn(true);
+        $this->cache
+            ->expects(self::never())
+            ->method('set');
+
+        $result = $this->property->isRelationship();
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsLgDependentFalseWithoutCache(): void
+    {
+        $this->persistenceProperty
+            ->expects(self::once())
+            ->method('isLgDependent')
+            ->willReturn(false);
+
+        $this->cache
+            ->expects(self::once())
+            ->method('has')
+            ->with('PropIsLgDependent_uri')
+            ->willReturn(false);
+        $this->cache
+            ->expects(self::never())
+            ->method('get');
+        $this->cache
+            ->expects(self::once())
+            ->method('set')
+            ->with('PropIsLgDependent_uri', false);
+
+        $result = $this->property->isLgDependent();
+
+        $this->assertFalse($result);
+    }
+
+    public function testIsLgDependentTrueWithCache(): void
+    {
+        $this->persistenceProperty
+            ->expects(self::never())
+            ->method('isLgDependent');
+
+        $this->cache
+            ->expects(self::once())
+            ->method('has')
+            ->with('PropIsLgDependent_uri')
+            ->willReturn(true);
+        $this->cache
+            ->expects(self::once())
+            ->method('get')
+            ->with('PropIsLgDependent_uri')
+            ->willReturn(true);
+        $this->cache
+            ->expects(self::never())
+            ->method('set');
+
+        $result = $this->property->isLgDependent();
+
+        $this->assertTrue($result);
+    }
+
+    public function testSetLgDependent(): void
+    {
+        $this->cache
+            ->expects(self::once())
+            ->method('set')
+            ->with('PropIsLgDependent_uri', true);
+
+        $this->property->setLgDependent(true);
+    }
+
+    public function testIsMultipleTrueWithoutCache(): void
+    {
+        $this->property
+            ->expects(self::once())
+            ->method('getProperty')
+            ->willReturn(new core_kernel_classes_Property('test'));
+        $this->property
+            ->expects(self::once())
+            ->method('getOnePropertyValue')
+            ->willReturn(new core_kernel_classes_Property(GenerisRdf::GENERIS_TRUE));
+
+        $this->cache
+            ->expects(self::once())
+            ->method('has')
+            ->with('PropIsMultiple_uri')
+            ->willReturn(false);
+        $this->cache
+            ->expects(self::never())
+            ->method('get');
+        $this->cache
+            ->expects(self::once())
+            ->method('set')
+            ->with('PropIsMultiple_uri', true);
+
+        $result = $this->property->isMultiple();
+
+        $this->assertTrue($result);
+    }
+
+    public function testIsMultipleFalseWithCache(): void
+    {
+        $this->property
+            ->expects(self::never())
+            ->method('getProperty');
+        $this->property
+            ->expects(self::never())
+            ->method('getOnePropertyValue');
+
+        $this->cache
+            ->expects(self::once())
+            ->method('has')
+            ->with('PropIsMultiple_uri')
+            ->willReturn(true);
+        $this->cache
+            ->expects(self::once())
+            ->method('get')
+            ->with('PropIsMultiple_uri')
+            ->willReturn(false);
+        $this->cache
+            ->expects(self::never())
+            ->method('set');
+
+        $result = $this->property->isMultiple();
+
+        $this->assertFalse($result);
+    }
+
+    public function testSetMultiple(): void
+    {
+        $this->cache
+            ->expects(self::once())
+            ->method('set')
+            ->with('PropIsMultiple_uri', true);
+
+        $this->property->setMultiple(true);
+    }
+
+    public function testOnDeleteWithCacheClear(): void
+    {
+        $this->cache
+            ->expects(self::exactly(3))
+            ->method('has')
+            ->withConsecutive(['PropIsRelationship_uri'], ['PropIsMultiple_uri'], ['PropIsLgDependent_uri'])
+            ->willReturnOnConsecutiveCalls(true, true, true);
+        $this->cache
+            ->expects(self::exactly(3))
+            ->method('delete')
+            ->withConsecutive(['PropIsRelationship_uri'], ['PropIsMultiple_uri'], ['PropIsLgDependent_uri']);
+
+        $this->property->delete();
+    }
+
+    public function testOnDeleteWithoutCacheClear(): void
+    {
+        $this->cache
+            ->expects(self::exactly(3))
+            ->method('has')
+            ->withConsecutive(['PropIsRelationship_uri'], ['PropIsMultiple_uri'], ['PropIsLgDependent_uri'])
+            ->willReturnOnConsecutiveCalls(false, false, false);
+        $this->cache
+            ->expects(self::never())
+            ->method('delete');
+
+        $this->property->delete();
+    }
+}


### PR DESCRIPTION
Ticket - https://oat-sa.atlassian.net/browse/REL-1279

## Goal
Decrease query count by cacheing some RDF property fields

## Changelog
- feat: added cache for fields isLgDependent, isMultiple, isRelationship and control changes on set and delete data in database

## How to test
1. Debug `\core_kernel_classes_Property` on open items
2. Run `tao/scripts/taoInit.php` to check warmup
3. To check how to works method `OntologyUpdater::modelSync` you can add it to `tao/scripts/taoInit.php` because running it in an update depends on the version and does not run every time 
4. Unit tests for check cache for property fields `\oat\generis\test\unit\core\kernel\classes\PropertyTest`