### PR TITLE
feat: DI container services availability during install

### DIFF
--- a/common/ext/class.ExtensionHandler.php
+++ b/common/ext/class.ExtensionHandler.php
@@ -97,6 +97,36 @@ abstract class common_ext_ExtensionHandler
         }
     }
 
+    /**
+     * Run Extension Service
+     *
+     * @param string $service
+     * @param string $method
+     * @param array $arguments
+     *
+     * @return void
+     *
+     * @throws \Psr\Container\ContainerExceptionInterface
+     * @throws \Psr\Container\NotFoundExceptionInterface
+     * @throws common_ext_InstallationException
+     */
+    protected function runExtensionService(string $service, string $method, array $arguments = []): void
+    {
+        $this->log(
+            'd',
+            sprintf('Running custom extension service "%s" for extension ', $this->getExtension()->getId())
+        );
+
+        if ($this->getServiceManager()->getContainer()->has($service)) {
+            $this->getServiceManager()->getContainer()->get($service)->$method(...$arguments);
+        } else {
+            $error = new common_ext_InstallationException(sprintf('Unable to run install service "%s"', $service));
+            $error->setExtensionId($this->getExtension()->getId());
+
+            throw $error;
+        }
+    }
+
     protected function getServiceManager()
     {
         return ServiceManager::getServiceManager();

--- a/common/ext/class.ExtensionInstaller.php
+++ b/common/ext/class.ExtensionInstaller.php
@@ -192,6 +192,13 @@ class common_ext_ExtensionInstaller extends common_ext_ExtensionHandler
                 $this->runExtensionScript($script);
             } elseif (
                 is_array($script)
+                && array_key_exists('service', $script)
+                && array_key_exists('method', $script)
+            ) {
+                $parameters = $script['arguments'] && is_array($script['arguments']) ? $script['arguments'] : [];
+                $this->runExtensionService($script['service'], $script['method'], $parameters);
+            } elseif (
+                is_array($script)
                 && isset($script[0])
                 && is_string($script[0])
                 && !empty($script[0])

--- a/common/ext/class.ExtensionInstaller.php
+++ b/common/ext/class.ExtensionInstaller.php
@@ -22,7 +22,6 @@
  *
  */
 
-use oat\generis\model\data\ModelManager;
 use oat\oatbox\service\ServiceFactoryInterface;
 use oat\oatbox\service\ServiceManager;
 use oat\oatbox\event\EventManager;
@@ -182,10 +181,6 @@ class common_ext_ExtensionInstaller extends common_ext_ExtensionHandler
      */
     protected function installCustomScript()
     {
-        if ($this->getExtension()->getManifest()->getInstallContainerRebuild()) {
-            $this->getServiceManager()->rebuildContainer();
-        }
-
         //install script
         foreach ($this->extension->getManifest()->getInstallPHPFiles() as $script) {
             if (is_string($script)) {

--- a/common/oatbox/extension/Manifest.php
+++ b/common/oatbox/extension/Manifest.php
@@ -86,7 +86,7 @@ class Manifest implements ServiceLocatorAwareInterface
                 "The Extension Manifest file located at '${filePath}' could not be read."
             );
         }
-        $this->manifest = require($filePath);
+        $this->manifest = require $filePath;
         // mandatory
         if (empty($this->manifest['name'])) {
             throw new exception\MalformedManifestException(
@@ -191,6 +191,21 @@ class Manifest implements ServiceLocatorAwareInterface
             [$this->manifest['install']['rdf']];
         $files = array_filter($files);
         return (array) $files;
+    }
+
+    /**
+     * Get service container reload flag
+     * @return bool
+     */
+    public function getInstallContainerRebuild(): bool
+    {
+        $result = false;
+
+        if (isset($this->manifest['install']['containerRebuild'])) {
+            $result = $this->manifest['install']['containerRebuild'];
+        }
+
+        return $result;
     }
 
     /**
@@ -317,7 +332,7 @@ class Manifest implements ServiceLocatorAwareInterface
             );
         }
 
-        $manifest = require($file);
+        $manifest = require $file;
         $returnValue = $manifest['install']['checks'] ?? [];
         foreach ($returnValue as &$component) {
             if (strpos($component['type'], 'FileSystemComponent') !== false) {

--- a/common/oatbox/service/ServiceManager.php
+++ b/common/oatbox/service/ServiceManager.php
@@ -24,9 +24,9 @@ namespace oat\oatbox\service;
 use oat\generis\model\DependencyInjection\ContainerBuilder;
 use oat\generis\model\DependencyInjection\ContainerStarter;
 use oat\oatbox\Configurable;
-use Zend\ServiceManager\ServiceLocatorInterface;
-use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use Psr\Container\ContainerInterface;
+use Zend\ServiceManager\ServiceLocatorAwareInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
  * The simple placeholder ServiceManager
@@ -267,8 +267,17 @@ class ServiceManager implements ServiceLocatorInterface, ContainerInterface
 
     public function rebuildContainer(): void
     {
-        $this->getContainerStarter()->getContainerBuilder()->resetContainerIsAlreadyBuilt();
-        $this->getContainerStarter()->getContainerBuilder()->forceBuild();
+        $containerBuilder = $this->getContainerStarter()->getContainerBuilder();
+        $containerBuilder->resetContainerIsAlreadyBuilt();
+        $containerBuilder->forceBuild();
+        $this->resetContainerStarter();
+    }
+
+    public function buildDIContainer($extensions = []): void
+    {
+        $containerBuilder = $this->getContainerStarter()->getContainerBuilder();
+        $containerBuilder->resetContainerIsAlreadyBuilt();
+        $containerBuilder->buildDIContainer($extensions);
         $this->resetContainerStarter();
     }
 

--- a/common/oatbox/service/ServiceManager.php
+++ b/common/oatbox/service/ServiceManager.php
@@ -267,8 +267,9 @@ class ServiceManager implements ServiceLocatorInterface, ContainerInterface
 
     public function rebuildContainer(): void
     {
+        $this->getContainerStarter()->getContainerBuilder()->resetContainerIsAlreadyBuilt();
         $this->getContainerStarter()->getContainerBuilder()->forceBuild();
-        $this->containerStarter = null;
+        $this->resetContainerStarter();
     }
 
     /**
@@ -277,6 +278,14 @@ class ServiceManager implements ServiceLocatorInterface, ContainerInterface
     public function getContainerBuilder(): ContainerBuilder
     {
         return $this->getContainerStarter()->getContainerBuilder();
+    }
+
+    /**
+     * @return void
+     */
+    public function resetContainerStarter(): void
+    {
+        $this->containerStarter = null;
     }
 
     /**

--- a/config/sample/generis.conf.php
+++ b/config/sample/generis.conf.php
@@ -76,6 +76,10 @@ define('VENDOR_PATH', ROOT_PATH . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEP
 define('EXTENSION_PATH', ROOT_PATH);
 define('FILES_PATH', '');
 define('GENERIS_CACHE_PATH', FILES_PATH . 'generis' . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR);
+define(
+    'GENERIS_CACHE_INSTALL_DI_PATH',
+    FILES_PATH . 'generis' . DIRECTORY_SEPARATOR . 'cache_container' . DIRECTORY_SEPARATOR
+);
 
 #path to read configs from
 define('CONFIG_PATH', ROOT_PATH . 'config/');

--- a/core/DependencyInjection/ContainerBuilder.php
+++ b/core/DependencyInjection/ContainerBuilder.php
@@ -28,6 +28,7 @@ use common_ext_Extension;
 use common_ext_ExtensionsManager;
 use InvalidArgumentException;
 use oat\generis\model\Middleware\MiddlewareExtensionsMapper;
+use oat\taoLti\models\classes\Platform\Service\UpdatePlatformRegistrationSnapshotListener;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder as SymfonyContainerBuilder;
@@ -133,6 +134,11 @@ class ContainerBuilder extends SymfonyContainerBuilder
         }
     }
 
+    public function resetContainerIsAlreadyBuilt()
+    {
+        self::$containerIsAlreadyBuilt = false;
+    }
+
     /**
      * @inheritDoc
      */
@@ -141,6 +147,7 @@ class ContainerBuilder extends SymfonyContainerBuilder
         try {
             return parent::get($id, $invalidBehavior);
         } catch (SymfonyServiceNotFoundException $exception) {
+            // do nothing
         }
 
         try {

--- a/core/DependencyInjection/ContainerBuilder.php
+++ b/core/DependencyInjection/ContainerBuilder.php
@@ -101,6 +101,14 @@ class ContainerBuilder extends SymfonyContainerBuilder
             return $this->legacyContainer;
         }
 
+        /** @var common_ext_Extension[] $extensions */
+        $extensions = $this->getExtensionsManager()->getInstalledExtensions();
+
+        return $this->buildDIContainer($extensions);
+    }
+
+    public function buildDIContainer($extensions = []): ContainerInterface
+    {
         if (!is_writable($this->cachePath)) {
             throw new InvalidArgumentException(
                 sprintf(
@@ -111,7 +119,10 @@ class ContainerBuilder extends SymfonyContainerBuilder
         }
 
         try {
-            file_put_contents($this->cachePath . '/services.php', $this->getTemporaryServiceFileContent());
+            file_put_contents(
+                $this->cachePath . '/services.php',
+                $this->getTemporaryServiceFileContent($extensions)
+            );
 
             $phpLoader = new PhpFileLoader(
                 $this,
@@ -190,12 +201,9 @@ class ContainerBuilder extends SymfonyContainerBuilder
         }
     }
 
-    private function getTemporaryServiceFileContent(): string
+    private function getTemporaryServiceFileContent($extensions = []): string
     {
         $contents = [];
-
-        /** @var common_ext_Extension[] $extensions */
-        $extensions = $this->getExtensionsManager()->getInstalledExtensions();
 
         foreach ($extensions as $extension) {
             foreach ($extension->getManifest()->getContainerServiceProvider() as $serviceProvider) {

--- a/core/DependencyInjection/ContainerBuilder.php
+++ b/core/DependencyInjection/ContainerBuilder.php
@@ -28,7 +28,6 @@ use common_ext_Extension;
 use common_ext_ExtensionsManager;
 use InvalidArgumentException;
 use oat\generis\model\Middleware\MiddlewareExtensionsMapper;
-use oat\taoLti\models\classes\Platform\Service\UpdatePlatformRegistrationSnapshotListener;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder as SymfonyContainerBuilder;

--- a/core/DependencyInjection/ContainerStarter.php
+++ b/core/DependencyInjection/ContainerStarter.php
@@ -46,7 +46,7 @@ final class ContainerStarter
         string $cachePath = null
     ) {
         if (!$cachePath) {
-            $cachePath = defined('GENERIS_CACHE_PATH') ? GENERIS_CACHE_PATH : null;
+            $cachePath = defined('GENERIS_CACHE_INSTALL_DI_PATH') ? GENERIS_CACHE_INSTALL_DI_PATH : null;
         }
 
         if (!$cachePath) {

--- a/core/DependencyInjection/ServiceLink.php
+++ b/core/DependencyInjection/ServiceLink.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace oat\generis\model\DependencyInjection;
+
+use oat\oatbox\service\ServiceManager;
+
+class ServiceLink
+{
+    protected string $serviceId;
+
+    /**
+     * @var mixed
+     */
+    protected $service;
+
+    public function __construct(string $serviceId)
+    {
+        $this->serviceId = $serviceId;
+    }
+
+    /**
+     * Gets a service this link refers to
+     *
+     * @return object
+     */
+    public function getService()
+    {
+        if (!$this->service) {
+            $this->service = ServiceManager::getServiceManager()->get($this->serviceId);
+        }
+
+        return $this->service;
+    }
+}

--- a/core/DependencyInjection/ServiceLink.php
+++ b/core/DependencyInjection/ServiceLink.php
@@ -31,4 +31,8 @@ class ServiceLink
 
         return $this->service;
     }
+
+    public function __call($name, $arguments) {
+        return $this->getService()->$name(...$arguments);
+    }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -40,6 +40,7 @@ return [
     'license' => 'GPL-2.0',
     'author' => 'Open Assessment Technologies, CRP Henri Tudor',
     'install' => [
+        'containerRebuild' => true,
         'rdf' => [
             __DIR__ . '/core/ontology/22-rdf-syntax-ns.rdf',
             __DIR__ . '/core/ontology/rdf-schema.rdf',

--- a/test/config/generis.conf.php
+++ b/test/config/generis.conf.php
@@ -75,6 +75,10 @@ define('VENDOR_PATH', ROOT_PATH . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEP
 define('EXTENSION_PATH', ROOT_PATH);
 define('FILES_PATH', '');
 define('GENERIS_CACHE_PATH', FILES_PATH . 'generis' . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR);
+define(
+    'GENERIS_CACHE_INSTALL_DI_PATH',
+    FILES_PATH . 'generis' . DIRECTORY_SEPARATOR . 'cache_container' . DIRECTORY_SEPARATOR
+);
 
 #path to read configs from
 define('CONFIG_PATH', ROOT_PATH . 'config/');


### PR DESCRIPTION
Ticket - https://oat-sa.atlassian.net/browse/REL-1326

## Goal
DI container services availability during install

## Changelog
- feat: DI container services availability during install
- feat: added the ability to configure the run DI container registered service->method as part extension install process. 

## How to test
Configure extension manifest install section with parameter  ```'containerRebuild' => true,```
Debug one of install->php classes to check the availability of some DI services registered in the provider from ```containerServiceProviders```
Run setup to debug
```docker exec -it studio-phpfpm php tao/scripts/taoSetup.php /var/docker-stack-cli/setup.json -vvv```

To check the ability to run DI container registered service->method configured in the manifest.php file you should add some service to section  [install][php] in this format:
```
            [
                'service' => SomeServiceClass::class,
                'method' => 'methodName',
                'arguments' => ['argument1', ...]
            ]       
```
```containerRebuild``` must be set to true for this extension