### PR TITLE
ADF-1611: TAO Studio - Neo4j: 500 'Something unexpected happened' error when using 'QA ACL' login

### DIFF
--- a/core/kernel/persistence/starsql/class.Resource.php
+++ b/core/kernel/persistence/starsql/class.Resource.php
@@ -623,37 +623,23 @@ CYPHER;
     {
         $fallbackLanguage = '';
 
-        $sortedResults = [
-            $dataLanguage => [],
-            $defaultLanguage => [],
-            $fallbackLanguage => []
-        ];
-
         foreach ($entries as $entry) {
-            $matchSuccess = preg_match(self::LANGUAGE_TAGGED_VALUE_PATTERN, $entry, $matches);
-            $entryLang = $matches[2] ?? '';
-            $sortedResults[$entryLang][] = [
-                'value' => $matches[1] ?? $entry,
-                'language' => $entryLang
-            ];
+            preg_match(self::LANGUAGE_TAGGED_VALUE_PATTERN, $entry, $matches);
+            $entryLang = $matches[2] ?? $fallbackLanguage;
+            $sortedResults[$entryLang][] = $matches[1] ?? $entry;
         }
 
-        $languageOrderedEntries = array_merge(
-            $sortedResults[$dataLanguage],
-            (count($sortedResults) > 2) ? $sortedResults[$defaultLanguage] : [],
-            $sortedResults[$fallbackLanguage]
-        );
+        $languageOrderedEntries = [
+            $dataLanguage,
+            $defaultLanguage,
+            $fallbackLanguage,
+        ];
 
         $returnValue = [];
-        if (count($languageOrderedEntries) > 0) {
-            $previousLanguage = $languageOrderedEntries[0]['language'];
-
-            foreach ($languageOrderedEntries as $value) {
-                if ($value['language'] == $previousLanguage) {
-                    $returnValue[] = $value['value'];
-                } else {
-                    break;
-                }
+        foreach ($languageOrderedEntries as $language) {
+            if (isset($sortedResults[$language])) {
+                $returnValue = $sortedResults[$language];
+                break;
             }
         }
 

--- a/test/integration/model/persistence/starsql/ClassTest.php
+++ b/test/integration/model/persistence/starsql/ClassTest.php
@@ -433,6 +433,19 @@ class ClassTest extends GenerisPhpUnitTestRunner
         $this->assertEquals($sub1ClassInstance->getUri(), array_shift($instances)->getUri());
     }
 
+    public function testGetUniquePropertyValueLanguageSpecific()
+    {
+        $class = new core_kernel_classes_Class(WidgetRdf::CLASS_URI_WIDGET);
+        $labelProperty = new \core_kernel_classes_Property(OntologyRdfs::RDFS_LABEL);
+        $subClass = $class->createSubClass();
+
+        $subClassInstance = $subClass->createInstance('test case instance'); //en-US
+        $subClassInstance->setPropertyValueByLg($labelProperty, 'instance de cas de test', 'fr-FR');
+        $subClassInstance->setPropertyValueByLg($labelProperty, 'Testfallinstanz', 'de-DE');
+
+        $this->assertEquals('test case instance', $subClassInstance->getUniquePropertyValue($labelProperty));
+    }
+
     public function testGetCountInstances()
     {
         $class = new core_kernel_classes_Class(WidgetRdf::CLASS_URI_WIDGET);

--- a/test/integration/model/persistence/starsql/ClassTest.php
+++ b/test/integration/model/persistence/starsql/ClassTest.php
@@ -64,7 +64,6 @@ class ClassTest extends GenerisPhpUnitTestRunner
 
     protected function tearDown(): void
     {
-        $ontologyModel = ModelManager::getModel();
         /** @var ClassRepository $classRepo */
         foreach ($this->cleanupList as $classUri) {
             $class = new \core_kernel_classes_Class($classUri);
@@ -92,59 +91,47 @@ class ClassTest extends GenerisPhpUnitTestRunner
 
         $this->assertGreaterThan(0, count($instances));
 
-        foreach ($instances as $instance) {
-            $this->assertTrue($instance instanceof core_kernel_classes_Resource);
+        $expectedItems = [
+            'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#ComboBox' => [
+                'label' => 'Drop down menu',
+                'comment' => 'In drop down menu, one may select 1 to N options',
+            ],
+            'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#RadioBox' => [
+                'label' => 'Radio button',
+                'comment' => 'In radio boxes, one may select exactly one option',
+            ],
+            'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#CheckBox' => [
+                'label' => 'Check box',
+                'comment' => 'In check boxes, one may select 0 to N options',
+            ],
+            'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextBox' => [
+                'label' => 'A Text Box',
+                'comment' => 'A particular text box',
+            ],
+            $plop->getUri() => [
+                'label' => 'test',
+                'comment' => 'comment',
+            ],
+        ];
 
-            if ($instance->getUri() === 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#ComboBox') {
-                $this->assertEquals($instance->getLabel(), 'Drop down menu');
-                $this->assertEquals($instance->getComment(), 'In drop down menu, one may select 1 to N options');
-            }
-            if ($instance->getUri() === 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#RadioBox') {
-                $this->assertEquals($instance->getLabel(), 'Radio button');
-                $this->assertEquals($instance->getComment(), 'In radio boxes, one may select exactly one option');
-            }
-            if ($instance->getUri() === 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#CheckBox') {
-                $this->assertEquals($instance->getLabel(), 'Check box');
-                $this->assertEquals($instance->getComment(), 'In check boxes, one may select 0 to N options');
-            }
-            if ($instance->getUri() === 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextBox') {
-                $this->assertEquals($instance->getLabel(), 'A Text Box');
-                $this->assertEquals($instance->getComment(), 'A particular text box');
-            }
-            if ($instance->getUri() === $plop->getUri()) {
-                $this->assertEquals($instance->getLabel(), 'test');
-                $this->assertEquals($instance->getComment(), 'comment');
-            }
+        foreach (array_intersect_key($instances, $expectedItems) as $instance) {
+            $this->assertTrue($instance instanceof core_kernel_classes_Resource);
+            $this->assertEquals($instance->getLabel(), $expectedItems[$instance->getUri()]['label']);
+            $this->assertEquals($instance->getComment(), $expectedItems[$instance->getUri()]['comment']);
         }
 
         $instances2 = $class->getInstances(true);
         $this->assertTrue(count($instances2) > 0);
-        foreach ($instances2 as $k => $instance) {
+
+        $expectedItems[$subclassInstance->getUri()] = [
+            'label' => 'test3',
+            'comment' => 'comment3',
+        ];
+
+        foreach (array_intersect_key($instances2, $expectedItems) as $instance) {
             $this->assertTrue($instance instanceof core_kernel_classes_Resource);
-            if ($instance->getUri() === 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#ComboBox') {
-                $this->assertEquals($instance->getLabel(), 'Drop down menu');
-                $this->assertEquals($instance->getComment(), 'In drop down menu, one may select 1 to N options');
-            }
-            if ($instance->getUri() === 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#RadioBox') {
-                $this->assertEquals($instance->getLabel(), 'Radio button');
-                $this->assertEquals($instance->getComment(), 'In radio boxes, one may select exactly one option');
-            }
-            if ($instance->getUri() === 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#CheckBox') {
-                $this->assertEquals($instance->getLabel(), 'Check box');
-                $this->assertEquals($instance->getComment(), 'In check boxes, one may select 0 to N options');
-            }
-            if ($instance->getUri() === 'http://www.tao.lu/datatypes/WidgetDefinitions.rdf#TextBox') {
-                $this->assertEquals($instance->getLabel(), 'A Text Box');
-                $this->assertEquals($instance->getComment(), 'A particular text box');
-            }
-            if ($instance->getUri() === $plop->getUri()) {
-                $this->assertEquals($instance->getLabel(), 'test');
-                $this->assertEquals($instance->getComment(), 'comment');
-            }
-            if ($instance->getUri() === $subclassInstance->getUri()) {
-                $this->assertEquals($instance->getLabel(), 'test3');
-                $this->assertEquals($instance->getComment(), 'comment3');
-            }
+            $this->assertEquals($instance->getLabel(), $expectedItems[$instance->getUri()]['label']);
+            $this->assertEquals($instance->getComment(), $expectedItems[$instance->getUri()]['comment']);
         }
     }
 
@@ -175,9 +162,9 @@ class ClassTest extends GenerisPhpUnitTestRunner
             ->searchInstances($instance, $propertyFilter, $options)
             ->willReturn($mockResult);
 
-        $ImplementationMock = $prophetImplementation->reveal();
+        $implementationMock = $prophetImplementation->reveal();
 
-        $instance->expects($this->once())->method('getImplementation')->willReturn($ImplementationMock);
+        $instance->expects($this->once())->method('getImplementation')->willReturn($implementationMock);
         $this->assertSame([1,2,3,4,5,6], $instance->searchInstances($propertyFilter, $options));
     }
 


### PR DESCRIPTION
## Goal
Fix problem described in https://oat-sa.atlassian.net/browse/ADF-1611

## Changelog
- fix: updated function to avoid dupliucates of translations in case data nad default language are the same.
- refactor: rewrite test to decrease complexity.

## How to test / use
1. Open log in page
2. Use Login “QA ACL“ and any password (may work with “1234q“ only)
3. Click Log in

Before:
![image-20231109-115814](https://github.com/oat-sa/generis/assets/2741267/5093af6c-dff0-4e48-aa6e-160adc4483ff)

After:
![Screenshot_2023-11-15_15-37-09](https://github.com/oat-sa/generis/assets/2741267/0aa41dbe-99e6-4e25-96d8-90efecae5012)

