### PR TITLE
AUT-3384: TAO Studio - Neo4j: pagination is limited by 7 users and page navigation is disabled in 'Manage users'

### DIFF
--- a/core/kernel/persistence/starsql/search/GateWay.php
+++ b/core/kernel/persistence/starsql/search/GateWay.php
@@ -137,7 +137,7 @@ class GateWay extends TaoSearchGateWay
             if (!$object) {
                 continue;
             }
-            $returnValue[] = \common_Utils::toResource($object);
+            $returnValue[] = \common_Utils::toResource($object->getProperty('uri'));
         }
         return $returnValue;
     }


### PR DESCRIPTION
# Goal
In the “Manage users” section, the user is not able to see all created users due to broken pagination. We should fix it so that pagination will work properly as it works for SQL implementation.

## Changelog
- fix: used only distinct results, so it will match count of items and not pagination issues.

## How to test / use
1. Login as global manager
2. Go to Manage Users Page
3. Try to use pagination
