### PR TITLE
fix: typo fix in PropertyCache class name

### DIFF
--- a/helpers/PropertyCache.php
+++ b/helpers/PropertyCache.php
@@ -4,7 +4,7 @@ namespace oat\generis\Helper;
 
 use Iterator;
 
-class PropertyCaches
+class PropertyCache
 {
     /**
      * Clear property cached data


### PR DESCRIPTION
Fix typo in class name of PropertyCache.