### PR TITLE
fix: missing return types

### DIFF
--- a/common/class.Collection.php
+++ b/common/class.Collection.php
@@ -88,7 +88,7 @@ class common_Collection extends common_Object implements IteratorAggregate, Coun
      * @author Lionel Lecaque <lionel.lecaque@tudor.lu>
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         $returnValue = (int) 0;
 
@@ -238,9 +238,8 @@ class common_Collection extends common_Object implements IteratorAggregate, Coun
      * @author Lionel Lecaque <lionel.lecaque@tudor.lu>
      * @return mixed
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
-
         return new ArrayIterator($this->sequence);
     }
 

--- a/common/oatbox/filesystem/Directory.php
+++ b/common/oatbox/filesystem/Directory.php
@@ -21,6 +21,7 @@
 
 namespace oat\oatbox\filesystem;
 
+use ArrayIterator;
 use League\Flysystem\FileExistsException;
 
 class Directory extends FileSystemHandler implements \IteratorAggregate
@@ -57,10 +58,8 @@ class Directory extends FileSystemHandler implements \IteratorAggregate
 
     /**
      * Method constraints by IteratorAggregator, wrapper to getFlyIterator
-     *
-     * @return \ArrayIterator
      */
-    public function getIterator()
+    public function getIterator(): ArrayIterator
     {
         return $this->getFlyIterator();
     }


### PR DESCRIPTION
Missing return types in: 
 - `common/class.Collection.php`
 - `common/oatbox/filesystem/Directory.php`