### PR TITLE
[Fix] Set the maximum allowable value for URI - 36 characters

### DIFF
--- a/core/kernel/uri/Bin2HexUriProvider.php
+++ b/core/kernel/uri/Bin2HexUriProvider.php
@@ -49,10 +49,7 @@ class Bin2HexUriProvider extends ConfigurableService implements UriProvider
      */
     public function provide()
     {
-        $uniqIdAndPid = uniqid('i') . getmypid();
-        $bytesLength = floor((36 - strlen($uniqIdAndPid)) / 2);
-
-        return $this->getOption(self::OPTION_NAMESPACE) . $uniqIdAndPid
-            . bin2hex(openssl_random_pseudo_bytes($bytesLength));
+        return $this->getOption(self::OPTION_NAMESPACE) . uniqid('i') . date('YmdHis')
+            . bin2hex(openssl_random_pseudo_bytes(4));
     }
 }

--- a/core/kernel/uri/Bin2HexUriProvider.php
+++ b/core/kernel/uri/Bin2HexUriProvider.php
@@ -49,7 +49,10 @@ class Bin2HexUriProvider extends ConfigurableService implements UriProvider
      */
     public function provide()
     {
-        return $this->getOption(self::OPTION_NAMESPACE) . uniqid('i') . getmypid()
-            . bin2hex(openssl_random_pseudo_bytes(8));
+        $uniqIdAndPid = uniqid('i') . getmypid();
+        $bytesLength = floor((36 - strlen($uniqIdAndPid)) / 2);
+
+        return $this->getOption(self::OPTION_NAMESPACE) . $uniqIdAndPid
+            . bin2hex(openssl_random_pseudo_bytes($bytesLength));
     }
 }

--- a/test/unit/core/kernel/uri/Bin2HexUriProviderTest.php
+++ b/test/unit/core/kernel/uri/Bin2HexUriProviderTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA.
+ */
+
+declare(strict_types=1);
+
+namespace oat\generis\test\unit\core\kernel\uri;
+
+use oat\generis\model\kernel\uri\Bin2HexUriProvider;
+use PHPUnit\Framework\TestCase;
+
+class Bin2HexUriProviderTest extends TestCase
+{
+    private const NAMESPACE = 'test#';
+
+    private Bin2HexUriProvider $sut;
+
+    protected function setUp(): void
+    {
+        $this->sut = new Bin2HexUriProvider(['namespace' => self::NAMESPACE]);
+    }
+
+    public function testProvide(): void
+    {
+        $uri = $this->sut->provide();
+
+        $this->assertStringContainsString(self::NAMESPACE, $uri);
+        $this->assertEquals(36, strlen(substr($uri, strlen(self::NAMESPACE))));
+    }
+}


### PR DESCRIPTION
# [TR-5940](https://oat-sa.atlassian.net/browse/TR-5940)

## Changes
* Use `date('YmdHis')` instead of `getmypid()`
* Reduce bytes length from 8 to 4

## Reason
The fix was made to comply with the Proctorio API requirements, where the unique part of the generated delivery execution URI is used as the user ID. Since generation of the unique part depends on the current PID, sometimes its length exceeded 36 characters.

## Companion PRs
* https://github.com/oat-sa/extension-tao-delivery/pull/584
* https://github.com/oat-sa/extension-remote-proctoring/pull/89

[TR-5940]: https://oat-sa.atlassian.net/browse/TR-5940?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ