### PR TITLE
fix: allow performing only class search in complex search

### DIFF
--- a/core/kernel/persistence/smoothsql/class.Class.php
+++ b/core/kernel/persistence/smoothsql/class.Class.php
@@ -563,6 +563,7 @@ class core_kernel_persistence_smoothsql_Class extends core_kernel_persistence_sm
         $limit = (isset($options['limit']) === false) ? 0 : $options['limit'];
         $order = (isset($options['order']) === false) ? '' : $options['order'];
         $orderdir = (isset($options['orderdir']) === false) ? 'ASC' : $options['orderdir'];
+        $onlyClass = (isset($options['onlyClass']) === false) ? false : $options['onlyClass'];
 
         if ($this->getServiceLocator()->has(ComplexSearchService::SERVICE_ID)) {
             $search = $this->getModel()->getSearchInterface();
@@ -576,7 +577,8 @@ class core_kernel_persistence_smoothsql_Class extends core_kernel_persistence_sm
                 $offset,
                 $limit,
                 $order,
-                $orderdir
+                $orderdir,
+                $onlyClass
             );
         } else {
             $query = core_kernel_persistence_smoothsql_Utils::buildFilterQuery(

--- a/core/kernel/persistence/smoothsql/search/ComplexSearchService.php
+++ b/core/kernel/persistence/smoothsql/search/ComplexSearchService.php
@@ -238,7 +238,8 @@ class ComplexSearchService extends ConfigurableService
         $offset = 0,
         $limit = 0,
         $order = '',
-        $orderDir = 'ASC'
+        $orderDir = 'ASC',
+        $onlyClass = false
     ) {
         $query = $this->getGateway()->query()->setLimit($limit)->setOffset($offset);
 
@@ -248,9 +249,15 @@ class ComplexSearchService extends ConfigurableService
 
         $this->setLanguage($query, $lang);
 
-        $criteria = $query->newQuery()
+        if ($onlyClass === true) {
+            $criteria = $query->newQuery()
+                ->add('http://www.w3.org/2000/01/rdf-schema#subClassOf')
+                ->in($classUri);
+        } else {
+            $criteria = $query->newQuery()
                 ->add('http://www.w3.org/1999/02/22-rdf-syntax-ns#type')
                 ->in($classUri);
+        }
 
         $query->setCriteria($criteria);
         $count     = 0;


### PR DESCRIPTION
Backward compatible method modification that will allow change of search method so programaticaly we can decide if search should list resource OR items. 

This can be observed in item class destination placement when importing a Test

![Screenshot 2024-05-22 at 10 32 31](https://github.com/oat-sa/generis/assets/16231681/cc397152-401b-42ae-a88b-99bb9e9ae70a)

