### PR TITLE
fix: rebuilding DI container when it was already built during same request

### DIFF
--- a/common/oatbox/service/ServiceManager.php
+++ b/common/oatbox/service/ServiceManager.php
@@ -267,7 +267,11 @@ class ServiceManager implements ServiceLocatorInterface, ContainerInterface
 
     public function rebuildContainer(): void
     {
+        // if container was already built on same request, it has to be restarted before rebuild
+        // to avoid fatal error of compiled container modification
+        $this->containerStarter = null;
         $this->getContainerStarter()->getContainerBuilder()->forceBuild();
+        // after container rebuild this cached starter needs a reset, to avoid using container already cached in memory
         $this->containerStarter = null;
     }
 


### PR DESCRIPTION
Adds an additional cache clear of DI container starter 
 
Related to : https://oat-sa.atlassian.net/browse/REL-1625
 
Fixes an issue with `tao/scripts/taoUpdate.php`, and DI container when update installs several extensions.  
 
#### Steps to reproduce
 - Application needs to have more than 1 additional required extension, that would be installed during update
 - Clear application cache from `tao/data/generis/cache/*`
 - Run `php tao/scripts/taoUpdate.php`
 - Witness how script stops without any output, check exit code `echo $?` and see it is not `0`
  
With this change there should be no errors when running `taoUpdate.php`