### PR TITLE
fix: only close stream in case the resource is valid

### DIFF
--- a/common/oatbox/task/AbstractTaskAction.php
+++ b/common/oatbox/task/AbstractTaskAction.php
@@ -56,9 +56,9 @@ abstract class AbstractTaskAction extends AbstractAction
 
         $stream = fopen($path, 'r+');
         $filesystem->writeStream($filename, $stream);
-        
+
         if (is_resource($stream)) {
-            fclose($stream);   
+            fclose($stream);
         } else {
             $this->logWarning(
                 sprintf(

--- a/common/oatbox/task/AbstractTaskAction.php
+++ b/common/oatbox/task/AbstractTaskAction.php
@@ -56,7 +56,17 @@ abstract class AbstractTaskAction extends AbstractAction
 
         $stream = fopen($path, 'r+');
         $filesystem->writeStream($filename, $stream);
-        fclose($stream);
+        
+        if (is_resource($stream)) {
+            fclose($stream);   
+        } else {
+            $this->logWarning(
+                sprintf(
+                    'Stream for file "%s" is not valid. It may be already closed',
+                    $name
+                )
+            );
+        }
 
         $file = $dir->getFile($filename);
         return $this->getFileReferenceSerializer()->serialize($file);


### PR DESCRIPTION
# Goal 

For some cases using GCP storage we were having the following error: 

```
2024-06-26 15:09:22 [ERROR] [tao] 'php error(1) in /var/www/html/generis/common/oatbox/task/AbstractTaskAction.php@82: Uncaught TypeError: fclose(): supplied resource is not a valid stream resource in /var/www/html/generis/common/oatbox/task/AbstractTaskAction.php:82
Stack trace:
#0 /var/www/html/generis/common/oatbox/task/AbstractTaskAction.php(82): fclose()
#1 /var/www/html/taoQtiTest/models/classes/tasks/ImportQtiTest.php(132): oat\oatbox\task\AbstractTaskAction->saveFile()
#2 /var/www/html/taoQtiTest/actions/class.RestQtiTests.php(171): oat\taoQtiTest\models\tasks\ImportQtiTest::createTask()
#3 [internal function]: taoQtiTest_actions_RestQtiTests->importDeferred()
#4 /var/www/html/tao/models/classes/routing/ActionEnforcer.php(257): call_user_func_array()
#5 /var/www/html/tao/models/classes/routing/ActionEnforcer.php(207): oat\tao\model\routing\ActionEnforcer->resolve()
#6 /var/www/html/tao/models/classes/routing/ActionEnforcer.php(183): oat\tao\model\routing\ActionEnforcer->execute()
#7 /var/www/html/tao/models/classes/routing/TaoFrontController.php(106): oat\tao\model\routing\ActionEnforcer->__invoke()
#8 /var/www/html/tao/models/classes/mvc/Bootstrap.php(342): oat\tao\model\routing\TaoFrontController->__invoke()
#9 /var/www/html/tao/models/classes/mvc/Bootstrap.php(189): oat\tao\model\mvc\Bootstrap->mvc()
#10 /var/www/html/tao/models/classes/mvc/Bootstrap.php(249): oat\tao\model\mvc\Bootstrap->dispatchHttp()
#11 /var/www/html/index.php(27): oat\tao\model\mvc\Bootstrap->dispatch()
#12 {main}
  thrown' undefined 0
2024-06-26 15:09:22 [ERROR] [tao] '==================== oat\oatbox\task\AbstractTaskAction::saveFile $path = '/tmp/phpgEAkEL', $name = 'gabrielTest.zip'' /var/www/html/generis/common/oatbox/task/AbstractTaskAction.php 62
2024-06-26 15:09:22 [ERROR] [tao] '========= EXISTS =========== oat\oatbox\task\AbstractTaskAction::saveFile path exists? = true' /var/www/html/generis/common/oatbox/task/AbstractTaskAction.php 63
2024-06-26 15:09:22 [ERROR] [tao] '========= Stream =========== oat\oatbox\task\AbstractTaskAction::saveFile = resource(23) of type (stream)
' /var/www/html/generis/common/oatbox/task/AbstractTaskAction.php 67
2024-06-26 15:09:22 [ERROR] [tao] '========= Filesystem =========== oat\oatbox\task\AbstractTaskAction::saveFile = 'oat\\oatbox\\filesystem\\FileSystem'' /var/www/html/generis/common/oatbox/task/AbstractTaskAction.php 68
2024-06-26 15:09:22 [ERROR] [tao] '========= Stream After =========== oat\oatbox\task\AbstractTaskAction::saveFile = resource(23) of type (Unknown)
' /var/www/html/generis/common/oatbox/task/AbstractTaskAction.php 79
```

It may be related to the fact that the stream was already closed, but the file is there.