### PR TITLE
fix: add a fix to cover infinity recursive call

### DIFF
--- a/core/kernel/classes/class.Resource.php
+++ b/core/kernel/classes/class.Resource.php
@@ -763,13 +763,7 @@ class core_kernel_classes_Resource extends core_kernel_classes_Container
      */
     public function isInstanceOf(core_kernel_classes_Class $class): bool
     {
-        foreach ($this->getTypes() as $type) {
-            if ($class->equals($type) || $type->isSubClassOf($class)) {
-                return true;
-            }
-        }
-
-        return false;
+        return in_array($class->getUri(), $this->getParentClassesIds(), true);
     }
 
     public function getRootId(): string

--- a/core/kernel/persistence/smoothsql/class.Resource.php
+++ b/core/kernel/persistence/smoothsql/class.Resource.php
@@ -24,6 +24,7 @@
  *               2017 (update and modification) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  */
 
+use oat\generis\model\GenerisRdf;
 use oat\generis\model\OntologyRdf;
 use oat\generis\model\OntologyRdfs;
 use oat\oatbox\session\SessionService;
@@ -120,7 +121,7 @@ WITH RECURSIVE statements_tree AS (
         JOIN statements_tree st
             ON s.subject = st.object
                    AND s.predicate IN (?, ?)
-                   AND s.object NOT IN (?, ?, ?, ?)
+                   AND s.object NOT IN (?, ?, ?, ?, ?)
 )
 SELECT object FROM statements_tree;
 SQL;
@@ -136,8 +137,9 @@ SQL;
                 OntologyRdf::RDF_TYPE,
                 'http://www.tao.lu/Ontologies/TAO.rdf#AssessmentContentObject',
                 'http://www.tao.lu/Ontologies/TAO.rdf#TAOObject',
-                'http://www.tao.lu/Ontologies/generis.rdf#generis_Ressource',
-                'http://www.w3.org/2000/01/rdf-schema#Resource',
+                GenerisRdf::CLASS_GENERIS_RESOURCE,
+                OntologyRdfs::RDFS_RESOURCE,
+                OntologyRdfs::RDFS_CLASS,
             ]
         );
 


### PR DESCRIPTION
## Goal
Use `getParentClassesIds` recursive call in `isInstanceOf` method to improve performance.

## Issue
When using `isInstanceOf` with `getParentClassesIds` recursive call on properties, it stuck due to infinity recursive call, because `http://www.w3.org/2000/01/rdf-schema#Class` type points to itself.

## TODO
- [ ] Check other types of resources to be compatible with new solution