### PR TITLE
feat: upgrade psr/cache dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
     "symfony/dependency-injection": "5.3.*",
     "symfony/config":"5.3.*",
     "psr/log": "~1.0",
-    "psr/cache": "~1.0",
+    "psr/cache": "^1.0 || ^2.0",
     "psr/container": "^1.1.1",
     "psr/simple-cache" : "^1.0.1",
     "ramsey/uuid": "^3.8",
@@ -82,7 +82,7 @@
   },
   "require-dev": {
     "mikey179/vfsstream": "~1",
-    "phpunit/phpunit": "^8.5",
+    "phpunit/phpunit": "^8.5 || ^9.6",
     "php-mock/php-mock": "^2.0"
   },
   "suggest": {


### PR DESCRIPTION
This PR allows to use psr/cache of version 2.0 as the interface is backwards compatible with the version 1.0