### PR TITLE
fix: avoid looping through each service when the service ID is missing from the PSR container and has to be loaded via ServiceManager

### DIFF
--- a/core/DependencyInjection/BaseContainer.php
+++ b/core/DependencyInjection/BaseContainer.php
@@ -15,9 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2021 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- *
- * @author Gabriel Felipe Soares <gabriel.felipe.soares@taotesting.com>
+ * Copyright (c) 2021-2025 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);
@@ -25,8 +23,8 @@ declare(strict_types=1);
 namespace oat\generis\model\DependencyInjection;
 
 use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 
 /**
@@ -50,12 +48,16 @@ class BaseContainer extends Container
     /**
      * @inheritDoc
      */
-    public function get($id, int $invalidBehavior = 1)
+    public function get($id, int $invalidBehavior = self::EXCEPTION_ON_INVALID_REFERENCE)
     {
         try {
-            return parent::get($id, $invalidBehavior);
-        } catch (ServiceNotFoundException $exception) {
-            return $this->legacyContainer->get($id);
+            return parent::get($id, self::NULL_ON_INVALID_REFERENCE) ?? $this->legacyContainer->get($id);
+        } catch (NotFoundExceptionInterface $exception) {
+            if ($invalidBehavior >= self::NULL_ON_INVALID_REFERENCE) {
+                return null;
+            }
+
+            throw $exception;
         }
     }
 


### PR DESCRIPTION
# [LSI-5144](https://oat-sa.atlassian.net/browse/LSI-5144)


This PR is inspired by the problem described in https://github.com/oat-sa/extension-tao-testqti/pull/2565.

The PR avoids multiple long loops through each service when the service ID provided is missing from the PSR container and has to be loaded via the ServiceManager.
See https://github.com/symfony/dependency-injection/blob/5.4/Container.php#L262-L270.

I expect this PR to give TAO 3.x a measurable performance boost.

[LSI-5144]: https://oat-sa.atlassian.net/browse/LSI-5144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ