### PR TITLE
Add missing information into event ResourceDeleted

### DIFF
--- a/core/data/event/ResourceDeleted.php
+++ b/core/data/event/ResourceDeleted.php
@@ -37,6 +37,7 @@ class ResourceDeleted implements Event, JsonSerializable
 
     /** @var core_kernel_classes_Resource|null */
     private $parentClass;
+    private string $resourceType;
 
     /**
      * @param string $uri
@@ -71,6 +72,18 @@ class ResourceDeleted implements Event, JsonSerializable
         $this->parentClass = $class;
 
         return $this;
+    }
+
+    public function setResourceType(string $resourceType): self
+    {
+        $this->resourceType = $resourceType;
+
+        return $this;
+    }
+
+    public function getResourceType(): string
+    {
+        return $this->resourceType;
     }
 
     public function jsonSerialize(): array

--- a/core/resource/Repository/ResourceRepository.php
+++ b/core/resource/Repository/ResourceRepository.php
@@ -71,6 +71,8 @@ class ResourceRepository implements ResourceRepositoryInterface
 
         $beforeResourceDeletedEvent = new BeforeResourceDeleted($resource->getUri());
         $this->eventManager->trigger($beforeResourceDeletedEvent);
+        $resourceType = $resource->getTypes();
+        $resourceType = reset($resourceType);
 
         if (!$this->getImplementation()->delete($resource, $deleteReference)) {
             throw new RuntimeException(
@@ -86,13 +88,6 @@ class ResourceRepository implements ResourceRepositoryInterface
         $selectedClass = $context->getParameter(ResourceRepositoryContext::PARAM_SELECTED_CLASS);
         /** @var core_kernel_classes_Class|null $selectedClass */
         $parentClass = $context->getParameter(ResourceRepositoryContext::PARAM_PARENT_CLASS);
-
-        $resourceType = $resource->getTypes();
-        $resourceType = reset($resourceType);
-
-        if (!$resourceType instanceof core_kernel_classes_Class) {
-            throw new InvalidArgumentException('Resource type is not a class.');
-        }
         $resourceDeletedEvent = (new ResourceDeleted($resource->getUri()))
             ->setSelectedClass($selectedClass)
             ->setParentClass($parentClass)

--- a/core/resource/Repository/ResourceRepository.php
+++ b/core/resource/Repository/ResourceRepository.php
@@ -87,12 +87,15 @@ class ResourceRepository implements ResourceRepositoryInterface
         $selectedClass = $context->getParameter(ResourceRepositoryContext::PARAM_SELECTED_CLASS);
         /** @var core_kernel_classes_Class|null $selectedClass */
         $parentClass = $context->getParameter(ResourceRepositoryContext::PARAM_PARENT_CLASS);
+        $resourceType = reset($resourceType);
 
+        if (!$resourceType instanceof core_kernel_classes_Class) {
+            throw new InvalidArgumentException('Resource type is not a class.');
+        }
         $resourceDeletedEvent = (new ResourceDeleted($resource->getUri()))
             ->setSelectedClass($selectedClass)
             ->setParentClass($parentClass)
-            ->setResourceType(reset($resourceType)->getUri());
-        $this->eventManager->trigger($resourceDeletedEvent);
+            ->setResourceType($resourceType->getUri());
     }
 
     private function getImplementation(): core_kernel_persistence_ResourceInterface

--- a/core/resource/Repository/ResourceRepository.php
+++ b/core/resource/Repository/ResourceRepository.php
@@ -59,6 +59,7 @@ class ResourceRepository implements ResourceRepositoryInterface
     {
         /** @var core_kernel_classes_Resource|null $resource */
         $resource = $context->getParameter(ResourceRepositoryContext::PARAM_RESOURCE);
+        $resourceType = $resource->getTypes();
 
         if ($resource === null) {
             throw new InvalidArgumentException('Resource was not provided for deletion.');
@@ -89,7 +90,8 @@ class ResourceRepository implements ResourceRepositoryInterface
 
         $resourceDeletedEvent = (new ResourceDeleted($resource->getUri()))
             ->setSelectedClass($selectedClass)
-            ->setParentClass($parentClass);
+            ->setParentClass($parentClass)
+            ->setResourceType(reset($resourceType)->getUri());
         $this->eventManager->trigger($resourceDeletedEvent);
     }
 

--- a/core/resource/Repository/ResourceRepository.php
+++ b/core/resource/Repository/ResourceRepository.php
@@ -59,7 +59,6 @@ class ResourceRepository implements ResourceRepositoryInterface
     {
         /** @var core_kernel_classes_Resource|null $resource */
         $resource = $context->getParameter(ResourceRepositoryContext::PARAM_RESOURCE);
-        $resourceType = $resource->getTypes();
 
         if ($resource === null) {
             throw new InvalidArgumentException('Resource was not provided for deletion.');
@@ -87,6 +86,8 @@ class ResourceRepository implements ResourceRepositoryInterface
         $selectedClass = $context->getParameter(ResourceRepositoryContext::PARAM_SELECTED_CLASS);
         /** @var core_kernel_classes_Class|null $selectedClass */
         $parentClass = $context->getParameter(ResourceRepositoryContext::PARAM_PARENT_CLASS);
+
+        $resourceType = $resource->getTypes();
         $resourceType = reset($resourceType);
 
         if (!$resourceType instanceof core_kernel_classes_Class) {
@@ -96,6 +97,8 @@ class ResourceRepository implements ResourceRepositoryInterface
             ->setSelectedClass($selectedClass)
             ->setParentClass($parentClass)
             ->setResourceType($resourceType->getUri());
+
+        $this->eventManager->trigger($resourceDeletedEvent);
     }
 
     private function getImplementation(): core_kernel_persistence_ResourceInterface

--- a/core/resource/Repository/ResourceRepository.php
+++ b/core/resource/Repository/ResourceRepository.php
@@ -71,7 +71,7 @@ class ResourceRepository implements ResourceRepositoryInterface
 
         $beforeResourceDeletedEvent = new BeforeResourceDeleted($resource->getUri());
         $this->eventManager->trigger($beforeResourceDeletedEvent);
-        $resourceType = $resource->getTypes();
+        $resourceType = $resource->getTypes() ?? [];
         $resourceType = reset($resourceType);
 
         if (!$this->getImplementation()->delete($resource, $deleteReference)) {

--- a/test/unit/core/resource/Repository/ResourceRepositoryTest.php
+++ b/test/unit/core/resource/Repository/ResourceRepositoryTest.php
@@ -93,8 +93,11 @@ class ResourceRepositoryTest extends TestCase
         $this->eventManager
             ->expects($this->exactly(2))
             ->method('trigger');
-
-        $context = $this->createContext(4, $this->createResource('resourceUri'));
+        $classMock = $this->createMock(core_kernel_classes_Class::class);
+        $resource = $this->createResource('resourceUri');
+        $resource->method('getTypes')
+            ->willReturn([$classMock]);
+        $context = $this->createContext(4, $resource);
         $this->sut->delete($context);
     }
 
@@ -146,6 +149,9 @@ class ResourceRepositoryTest extends TestCase
         $this->sut->delete($context);
     }
 
+    /**
+     * @return core_kernel_classes_Resource|MockObject
+     */
     private function createResource(string $uri, string $label = null): core_kernel_classes_Resource
     {
         $class = $this->createMock(core_kernel_classes_Resource::class);
@@ -161,6 +167,9 @@ class ResourceRepositoryTest extends TestCase
         return $class;
     }
 
+    /**
+     * @return ContextInterface|MockObject
+     */
     private function createContext(int $expects, ?core_kernel_classes_Resource $resource): ContextInterface
     {
         $context = $this->createMock(ContextInterface::class);


### PR DESCRIPTION
## PR Description: Add Resource Type to ResourceDeleted Event

### Summary
This pull request introduces a new feature to the `ResourceDeleted` event by adding a `resourceType` property. This enhancement allows for more detailed event handling by specifying the type of resource that has been deleted.

### Key Changes
- **ResourceDeleted Class**:
  - Added a private property `resourceType` to store the type of the resource.
  - Implemented `setResourceType` and `getResourceType` methods to manage the `resourceType` property.
  - Updated the `jsonSerialize` method to include the `resourceType` in the serialized data.

- **ResourceRepository Class**:
  - Extracted the resource type using `$resource->getTypes()` and set it in the `ResourceDeleted` event using the new `setResourceType` method.

### Benefits
- **Enhanced Event Data**: By including the resource type in the `ResourceDeleted` event, consumers of the event can make more informed decisions based on the type of resource that was deleted.
- **Improved Code Clarity**: The changes make the event handling more explicit and easier to understand by clearly defining the type of resource involved in the deletion.

### Notes
- This change assumes that the resource type is always available and that the first type in the list is the primary type to be used. Further validation or error handling may be required if this assumption does not hold in all cases.