### PR TITLE
chore: add hability to read the tenant id by session

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,2 @@
+remote_config:
+    url: 'https://raw.githubusercontent.com/oat-sa/tao-code-quality/refs/heads/main/coderabbit/php/authoring/v1/.coderabbit.yaml'

--- a/README.md
+++ b/README.md
@@ -22,3 +22,9 @@ Read here [how to use the Middlewares](./core/Middleware/README.md).
 ### Log
 
 Learn more here about [how to log](./common/oatbox/log/README.md).
+
+### Environment Variables
+
+| Environment Variable | Description                | Default Value                          |
+|----------------------|----------------------------|----------------------------------------|
+| `TENANT_ID`          | Identifier for the tenant. | `ROOT_URL` or empty string if not set. |

--- a/common/oatbox/session/SessionService.php
+++ b/common/oatbox/session/SessionService.php
@@ -54,6 +54,11 @@ class SessionService extends ConfigurableService
         return $this->getCurrentSession()->getUser();
     }
 
+    public function getTenantId(): string
+    {
+        return (string)(getenv('TENANT_ID') ?: rtrim(ROOT_URL, '/'));
+    }
+
     /**
      * Is the current session anonymous or associated to a user?
      * @return boolean


### PR DESCRIPTION
## Ticket: 

https://oat-sa.atlassian.net/browse/ADF-1977

## What's Changed

- Get tenantId By session

> Please tick the appropriate points
- [ ] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [ ] Release version change
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful

## TODO 
- [x] Unit tests
- [x] E2E tests
- [ ] Update with packages

## Dependencies PRs
- https://github.com/oat-sa/tao-core/pull/4255

## How to test
- Explain here how to test or make a small demo to our team how this works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving the tenant identifier, which uses the `TENANT_ID` environment variable or defaults to the root URL.
- **Documentation**
  - Updated the README with a new section detailing environment variables, including information about `TENANT_ID`.
- **Chores**
  - Introduced a new configuration file to enable referencing remote configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->