### PR TITLE
fix: move updating updated_at to the generis during global onUpdate

### DIFF
--- a/core/kernel/classes/class.Resource.php
+++ b/core/kernel/classes/class.Resource.php
@@ -29,7 +29,6 @@ use oat\generis\model\OntologyRdfs;
 use oat\oatbox\event\EventAggregator;
 use oat\oatbox\service\ServiceManager;
 use oat\generis\model\OntologyAwareTrait;
-use oat\tao\model\TaoOntology;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use oat\generis\model\data\event\ResourceUpdated;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;

--- a/core/kernel/classes/class.Resource.php
+++ b/core/kernel/classes/class.Resource.php
@@ -870,6 +870,10 @@ class core_kernel_classes_Resource extends core_kernel_classes_Container
 
     private function onUpdate(): void
     {
+        $updatedAt = microtime(true);
+        $property = $this->getProperty('http://www.tao.lu/Ontologies/TAO.rdf#UpdatedAt');
+        $this->getImplementation()->setPropertyValue($this, $property, $updatedAt);
+
         /** @var EventAggregator $eventAggregator */
         $eventAggregator = $this->getServiceManager()->get(EventAggregator::SERVICE_ID);
         $eventAggregator->put($this->getUri(), new ResourceUpdated($this));

--- a/core/kernel/classes/class.Resource.php
+++ b/core/kernel/classes/class.Resource.php
@@ -29,6 +29,7 @@ use oat\generis\model\OntologyRdfs;
 use oat\oatbox\event\EventAggregator;
 use oat\oatbox\service\ServiceManager;
 use oat\generis\model\OntologyAwareTrait;
+use oat\tao\model\TaoOntology;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use oat\generis\model\data\event\ResourceUpdated;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;
@@ -870,9 +871,17 @@ class core_kernel_classes_Resource extends core_kernel_classes_Container
 
     private function onUpdate(): void
     {
-        $updatedAt = microtime(true);
+        ## Update the 'UpdatedAt' property of the resource
+        $now = microtime(true);
+
         $property = $this->getProperty('http://www.tao.lu/Ontologies/TAO.rdf#UpdatedAt');
-        $this->getImplementation()->setPropertyValue($this, $property, $updatedAt);
+        $updatedAt = $this->getOnePropertyValue($property);
+        if ($updatedAt && $updatedAt instanceof core_kernel_classes_Literal) {
+            $updatedAt = (float)$updatedAt->literal;
+        }
+        if ((int)$now - (int)$updatedAt > 1) {
+            $this->getImplementation()->setPropertyValue($this, $property, $now);
+        }
 
         /** @var EventAggregator $eventAggregator */
         $eventAggregator = $this->getServiceManager()->get(EventAggregator::SERVICE_ID);


### PR DESCRIPTION
Depends on https://github.com/oat-sa/tao-core/pull/4260

We found that during updating we also try to update the updatedAt which will also trigger onUpdate event which will be collected by the Event Aggregator
https://github.com/oat-sa/tao-core/blob/v54.39.2/models/classes/resources/ResourceWatcher.php#L95

For fixing, we will move updating the updatedAt inside onUpdate to prevent creating multi update events 