### PR TITLE
fix: use sweetrdf/easyrdf fork with php 8.4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
   "require": {
     "php": "^8.1",
     "clearfw/clearfw": "~1.2.0",
-    "easyrdf/easyrdf": "^1.1",
+    "sweetrdf/easyrdf": "^1.19",
     "doctrine/dbal": "^3.10",
     "doctrine/annotations": "^1.13",
     "laminas/laminas-servicemanager": "~2.5.0",


### PR DESCRIPTION
Use sweetrdf/easyrdf wtih supporting PHP 8.4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal library dependency to improve stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->