### PR TITLE
Feature EP-765 User Identity based on a Bearer access token

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -14,9 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest ]
-        php-version: [ '8.3', '8.4' ]
+        php-version: [ '8.3', '8.4', '8.5' ]
         include:
-          - php-version: '8.3'
+          - php-version: '8.5'
             coverage: true
 
     steps:

--- a/common/oatbox/user/BasicUser.php
+++ b/common/oatbox/user/BasicUser.php
@@ -1,10 +1,21 @@
 <?php
 
 /**
- * SPDX-FileCopyrightText: 2026 Open Assessment Technologies S.A.
- * Copyright (C) 2026 (original work) Open Assessment Technologies S.A.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
  *
- * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-TAO-Commercial-License
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);

--- a/common/oatbox/user/BasicUser.php
+++ b/common/oatbox/user/BasicUser.php
@@ -1,21 +1,10 @@
 <?php
 
 /**
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; under version 2
- * of the License (non-upgradable).
+ * SPDX-FileCopyrightText: 2026 Open Assessment Technologies S.A.
+ * Copyright (C) 2026 (original work) Open Assessment Technologies S.A.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *
- * Copyright (c) 2026 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-TAO-Commercial-License
  */
 
 declare(strict_types=1);

--- a/common/oatbox/user/BasicUser.php
+++ b/common/oatbox/user/BasicUser.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ */
+
+declare(strict_types=1);
+
+namespace oat\oatbox\user;
+
+use oat\generis\model\user\UserRdf;
+
+class BasicUser implements User
+{
+    private string $identifier;
+    private array $roles;
+    private string $login;
+
+    public function __construct(string $identifier, array $roles, string $login)
+    {
+        $this->identifier = $identifier;
+        $this->roles = $roles;
+        $this->login = $login;
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function getRoles(): array
+    {
+        return $this->roles;
+    }
+
+    public function getPropertyValues($property): array
+    {
+        if ($property === UserRdf::PROPERTY_LOGIN) {
+            return [$this->login];
+        }
+
+        return [];
+    }
+}

--- a/common/oatbox/user/BasicUser.php
+++ b/common/oatbox/user/BasicUser.php
@@ -26,15 +26,11 @@ use oat\generis\model\user\UserRdf;
 
 class BasicUser implements User
 {
-    private string $identifier;
-    private array $roles;
-    private string $login;
-
-    public function __construct(string $identifier, array $roles, string $login)
-    {
-        $this->identifier = $identifier;
-        $this->roles = $roles;
-        $this->login = $login;
+    public function __construct(
+        private readonly string $identifier,
+        private readonly array $roles,
+        private readonly string $login
+    ) {
     }
 
     public function getIdentifier(): string

--- a/common/session/class.SessionManager.php
+++ b/common/session/class.SessionManager.php
@@ -1,10 +1,21 @@
 <?php
 
 /**
- * SPDX-FileCopyrightText: 2013-2026 Open Assessment Technologies S.A.
- * Copyright (C) 2013-2026 (original work) Open Assessment Technologies S.A.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
  *
- * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-TAO-Commercial-License
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2013-2026 (original work) Open Assessment Technologies SA;
  */
 
 use oat\oatbox\user\BasicUser;

--- a/common/session/class.SessionManager.php
+++ b/common/session/class.SessionManager.php
@@ -15,10 +15,11 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2013 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * Copyright (c) 2013-2026 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
  *
  */
 
+use oat\oatbox\user\BasicUser;
 use Zend\ServiceManager\ServiceLocatorAwareInterface;
 use oat\oatbox\service\ServiceManager;
 
@@ -45,7 +46,10 @@ abstract class common_session_SessionManager
     public static function getSession()
     {
         if (is_null(self::$session)) {
-            if (PHPSession::singleton()->hasAttribute(self::PHPSESSION_SESSION_KEY)) {
+            $session = self::createAccessTokenSession();
+            if ($session) {
+                self::$session = $session;
+            } elseif (PHPSession::singleton()->hasAttribute(self::PHPSESSION_SESSION_KEY)) {
                 $session = PHPSession::singleton()->getAttribute(self::PHPSESSION_SESSION_KEY);
                 if (! $session instanceof common_session_Session) {
                     throw new common_exception_Error('Non session stored in php-session');
@@ -113,5 +117,49 @@ abstract class common_session_SessionManager
     public static function isAnonymous()
     {
         return is_null(self::getSession()->getUserUri());
+    }
+
+    public static function extractAccessTokenFromRequest(): string
+    {
+        $authorizationHeader = explode(' ', $_SERVER['HTTP_AUTHORIZATION'] ?? '', 2);
+        return array_pop($authorizationHeader);
+    }
+
+    public static function parseAccessToken(string $accessToken): ?array
+    {
+        /** @noinspection PhpUnusedLocalVariableInspection */
+        @[$_, $payload] = explode('.', $accessToken);
+        $rawToken = base64_decode(strtr($payload ?? '', '-_', '+/'));
+        return json_decode($rawToken, true);
+    }
+
+    public static function buildUserIdentityString(string $userId, string $role = ''): string
+    {
+        return sprintf('%s%s%s', $role, $role ? '#' : '', $userId);
+    }
+
+    private static function createAccessTokenSession(): ?common_session_Session
+    {
+        $token = self::parseAccessToken(self::extractAccessTokenFromRequest());
+        if (
+            empty($token['user']['login'])
+            || !is_string($token['user']['login'])
+            || !preg_match(
+                '/^(?:(?<role>[^#]*#[^#]*)#)?(?<userId>.*)$/',
+                $token['user']['login'],
+                $matches
+            )
+        ) {
+            return null;
+        }
+
+        $role = $matches['role'] ?? '';
+        return new common_session_BasicSession(
+            new BasicUser(
+                $role,
+                $role ? [$role] : [],
+                $matches['userId'],
+            )
+        );
     }
 }

--- a/common/session/class.SessionManager.php
+++ b/common/session/class.SessionManager.php
@@ -1,22 +1,10 @@
 <?php
 
 /**
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; under version 2
- * of the License (non-upgradable).
+ * SPDX-FileCopyrightText: 2013-2026 Open Assessment Technologies S.A.
+ * Copyright (C) 2013-2026 (original work) Open Assessment Technologies S.A.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *
- * Copyright (c) 2013-2026 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- *
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-TAO-Commercial-License
  */
 
 use oat\oatbox\user\BasicUser;
@@ -122,7 +110,7 @@ abstract class common_session_SessionManager
     public static function extractAccessTokenFromRequest(): string
     {
         $authorizationHeader = explode(' ', $_SERVER['HTTP_AUTHORIZATION'] ?? '', 2);
-        return array_pop($authorizationHeader);
+        return array_pop($authorizationHeader) ?: $_GET['jwt'] ?? '';
     }
 
     public static function parseAccessToken(string $accessToken): ?array

--- a/common/session/class.SessionManager.php
+++ b/common/session/class.SessionManager.php
@@ -115,8 +115,8 @@ abstract class common_session_SessionManager
 
     public static function parseAccessToken(string $accessToken): ?array
     {
-        /** @noinspection PhpUnusedLocalVariableInspection */
-        @[$_, $payload] = explode('.', $accessToken);
+        $parts = explode('.', $accessToken, 3);
+        $payload = $parts[1] ?? '';
         $rawToken = base64_decode(strtr($payload ?? '', '-_', '+/'));
         return json_decode($rawToken, true);
     }

--- a/composer.json
+++ b/composer.json
@@ -82,9 +82,10 @@
     "wikibase-solutions/php-cypher-dsl": "^5.0"
   },
   "require-dev": {
+    "lcobucci/jwt": "~5",
     "mikey179/vfsstream": "~1",
-    "phpunit/phpunit": "^8.5 || ^9.6",
-    "php-mock/php-mock": "^2.0"
+    "php-mock/php-mock": "^2.0",
+    "phpunit/phpunit": "^8.5 || ^9.6"
   },
   "suggest": {
     "league/flysystem-google-cloud-storage": "Supports google flystore"

--- a/test/unit/ConfigurationTest.php
+++ b/test/unit/ConfigurationTest.php
@@ -24,6 +24,17 @@
 
 namespace oat\generis\test\unit;
 
+use common_configuration_ComponentCollection;
+use common_configuration_ComponentFactory;
+use common_configuration_ComponentFactoryException;
+use common_configuration_CyclicDependencyException;
+use common_configuration_FileSystemComponent;
+use common_configuration_MalformedRightsException;
+use common_configuration_Mock;
+use common_configuration_PHPExtension;
+use common_configuration_PHPINIValue;
+use common_configuration_PHPRuntime;
+use common_configuration_Report;
 use PHPUnit\Framework\TestCase;
 
 class ConfigurationTest extends TestCase
@@ -50,7 +61,7 @@ class ConfigurationTest extends TestCase
     public function testPHPIniValues()
     {
         // core tests.
-        $ini = new \common_configuration_PHPINIValue('text/html', 'default_mimetype');
+        $ini = new common_configuration_PHPINIValue('text/html', 'default_mimetype');
         $this->assertEquals($ini->getName(), 'default_mimetype');
         $this->assertEquals($ini->isOptional(), false);
         $this->assertEquals($ini->getExpectedValue(), 'text/html');
@@ -67,17 +78,17 @@ class ConfigurationTest extends TestCase
         $oldIniValue = ini_get($ini->getName());
         ini_set($ini->getName(), 'text/html');
         $report = $ini->check();
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::VALID);
         $this->assertEquals($report->getStatusAsString(), 'valid');
 
         ini_set($ini->getName(), 'text/xml');
         $report = $ini->check();
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::INVALID);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::INVALID);
         $this->assertEquals($report->getStatusAsString(), 'invalid');
 
         $ini->setName('foobar');
         $report = $ini->check();
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::UNKNOWN);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::UNKNOWN);
         $this->assertEquals($report->getStatusAsString(), 'unknown');
 
         ini_set($ini->getName(), $oldIniValue);
@@ -86,7 +97,7 @@ class ConfigurationTest extends TestCase
     public function testPHPRuntime()
     {
         // Core tests.
-        $php = new \common_configuration_PHPRuntime('5.3', '5.4');
+        $php = new common_configuration_PHPRuntime('5.3', '5.4');
         $this->assertEquals($php->getName(), 'tao.configuration.phpruntime'); //automatically set
         $this->assertEquals($php->getMin(), '5.3');
         $this->assertEquals($php->getMax(), '5.4');
@@ -105,34 +116,34 @@ class ConfigurationTest extends TestCase
         $this->assertTrue($php->isOptional());
 
         // max & min test.
-        $php = new \common_configuration_PHPRuntime('7.4', '8.3.x');
+        $php = new common_configuration_PHPRuntime('7.4', '8.5.x');
         $report = $php->check();
 
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::VALID);
 
         $php->setMin(self::UNSUPPORTED_PHP_MAJOR_VERSION . '.5');
         $php->setMax(self::UNSUPPORTED_PHP_MAJOR_VERSION . '.5.6.3');
         $report = $php->check();
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::INVALID);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::INVALID);
 
         // min test.
-        $php = new \common_configuration_PHPRuntime('5.3', null);
+        $php = new common_configuration_PHPRuntime('5.3', null);
         $report = $php->check();
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::VALID);
 
         $php->setMin(self::UNSUPPORTED_PHP_MAJOR_VERSION . '.5.3');
         $report = $php->check();
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::INVALID);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::INVALID);
 
         // max test.
-        $php = new \common_configuration_PHPRuntime(null, self::UNSUPPORTED_PHP_MAJOR_VERSION . '.5');
+        $php = new common_configuration_PHPRuntime(null, self::UNSUPPORTED_PHP_MAJOR_VERSION . '.5');
         $report = $php->check();
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::VALID);
 
         $php->setMax('5.2');
         $this->assertEquals($php->getMax(), '5.2');
         $report = $php->check();
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::INVALID);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::INVALID);
 
         $php->setMax('5.3.x');
         $this->assertEquals($php->getMax(), '5.3.99999');
@@ -147,7 +158,7 @@ class ConfigurationTest extends TestCase
         // --disable-dom directive.
 
         // core tests.
-        $ext = new \common_configuration_PHPExtension(null, null, 'dom');
+        $ext = new common_configuration_PHPExtension(null, null, 'dom');
         $this->assertEquals($ext->getMin(), null);
         $this->assertEquals($ext->getMax(), null);
         $this->assertEquals($ext->getName(), 'dom');
@@ -167,50 +178,50 @@ class ConfigurationTest extends TestCase
         // We consider that if there is no version information but the extension
         // is loaded, the report is always valid even if min and/or max version(s)
         // are specified.
-        $ext = new \common_configuration_PHPExtension(null, null, 'json');
+        $ext = new common_configuration_PHPExtension(null, null, 'json');
         $report = $ext->check();
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::VALID);
 
         $ext->setMin('1.0');
         $report = $ext->check();
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::VALID);
 
-        $ext->setMax('8.3.x');
+        $ext->setMax('8.5.x');
         $report = $ext->check();
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::VALID);
 
         $ext->setMin(null);
         $report = $ext->check();
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::VALID);
 
         // test with the dom extension that has version information.
-        $ext = new \common_configuration_PHPExtension('19851127', '20090601', 'dom');
+        $ext = new common_configuration_PHPExtension('19851127', '20090601', 'dom');
         $report = $ext->check();
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::VALID);
 
         $ext->setMin('20050112');
         $report = $ext->check();
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::INVALID);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::INVALID);
 
         $ext->setMin(null);
         $ext->setMax('20020423');
         $report = $ext->check();
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::INVALID);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::INVALID);
 
         $ext->setMin('20010731');
         $ext->setMax(null);
         $report = $ext->check();
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::VALID);
 
         // Unexisting extension.
-        $ext = new \common_configuration_PHPExtension('1.0', '1.4', 'foobar');
+        $ext = new common_configuration_PHPExtension('1.0', '1.4', 'foobar');
         $report = $ext->check();
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::UNKNOWN);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::UNKNOWN);
     }
 
     public function testFileSystemComponent()
     {
-        $f = new \common_configuration_FileSystemComponent(__FILE__, 'r');
+        $f = new common_configuration_FileSystemComponent(__FILE__, 'r');
         $this->assertEquals($f->getLocation(), __FILE__);
         $this->assertEquals($f->getExpectedRights(), 'r');
         $this->assertEquals($f->getName(), 'tao.configuration.filesystem'); // automatically set.
@@ -223,7 +234,7 @@ class ConfigurationTest extends TestCase
         try {
             $f->setExpectedRights('rw');
             $this->pass();
-        } catch (\common_configuration_MalformedRightsException $e) {
+        } catch (common_configuration_MalformedRightsException $e) {
             $this->fail();
         }
     }
@@ -231,10 +242,10 @@ class ConfigurationTest extends TestCase
     public function testSimpleComponentCollection()
     {
         // Non acyclic simple test.
-        $collection = new \common_configuration_ComponentCollection();
-        $componentA = new \common_configuration_Mock(\common_configuration_Report::VALID, 'componentA');
-        $componentB = new \common_configuration_Mock(\common_configuration_Report::VALID, 'componentB');
-        $componentC = new \common_configuration_Mock(\common_configuration_Report::VALID, 'componentC');
+        $collection = new common_configuration_ComponentCollection();
+        $componentA = new common_configuration_Mock(common_configuration_Report::VALID, 'componentA');
+        $componentB = new common_configuration_Mock(common_configuration_Report::VALID, 'componentB');
+        $componentC = new common_configuration_Mock(common_configuration_Report::VALID, 'componentC');
 
         $collection->addComponent($componentA);
         $collection->addComponent($componentB);
@@ -262,7 +273,7 @@ class ConfigurationTest extends TestCase
             $this->assertEquals(count($reports), 3);
 
             // Now change some reports validity.
-            $componentA->setExpectedStatus(\common_configuration_Report::INVALID);
+            $componentA->setExpectedStatus(common_configuration_Report::INVALID);
 
             $reports = $collection->check();
             $this->assertTrue(true); // Acyclic graph, no CyclicDependencyException thrown.
@@ -271,7 +282,7 @@ class ConfigurationTest extends TestCase
             $this->assertEquals($collection->getUncheckedComponents(), [$componentB, $componentC]);
 
             // Add an additional independant component.
-            $componentD = new \common_configuration_Mock(\common_configuration_Report::VALID, 'componentD');
+            $componentD = new common_configuration_Mock(common_configuration_Report::VALID, 'componentD');
             $collection->addComponent($componentD);
             $reports = $collection->check();
             $this->assertTrue(true); // Acyclic graph, no CyclicDependencyException thrown.
@@ -280,7 +291,7 @@ class ConfigurationTest extends TestCase
             $this->assertEquals($collection->getUncheckedComponents(), [$componentB, $componentC]);
 
             // Make the whole components valid again.
-            $componentA->setExpectedStatus(\common_configuration_Report::VALID);
+            $componentA->setExpectedStatus(common_configuration_Report::VALID);
             $reports = $collection->check();
             $this->assertTrue(true); // Acyclic graph, no CyclicDependencyException thrown.
             $this->assertEquals(count($reports), 4);
@@ -295,7 +306,7 @@ class ConfigurationTest extends TestCase
                 $collection->addDependency($componentA, $componentB);
                 $collection->check();
                 $this->assertTrue(false, 'The graph should be cyclic.');
-            } catch (\common_configuration_CyclicDependencyException $e) {
+            } catch (common_configuration_CyclicDependencyException $e) {
                 $this->assertTrue(true);
                 $this->assertEquals($collection->getReports(), []);
                 $this->assertEquals($collection->getCheckedComponents(), []);
@@ -315,98 +326,98 @@ class ConfigurationTest extends TestCase
                 $this->assertEquals($collection->getCheckedComponents(), []);
                 $this->assertEquals($collection->getUncheckedComponents(), []);
             }
-        } catch (\common_configuration_CyclicDependencyException $e) {
+        } catch (common_configuration_CyclicDependencyException $e) {
             $this->assertTrue(false, 'The graph dependency formed by the ComponentCollection must be acyclic.');
         }
     }
 
     public function testComponentFactory()
     {
-        $component = \common_configuration_ComponentFactory::buildPHPRuntime('5.0', '8.3.x', true);
-        $this->assertInstanceOf(\common_configuration_PHPRuntime::class, $component);
+        $component = common_configuration_ComponentFactory::buildPHPRuntime('5.0', '8.5.x', true);
+        $this->assertInstanceOf(common_configuration_PHPRuntime::class, $component);
         $this->assertEquals($component->getMin(), '5.0');
         // 5.5.x will be replaced internally
         //$this->assertEquals($component->getMax(), '5.5.x');
         $this->assertTrue($component->isOptional());
         $report = $component->check();
-        $this->assertInstanceOf(\common_configuration_Report::class, $report);
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
+        $this->assertInstanceOf(common_configuration_Report::class, $report);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::VALID);
 
-        $component = \common_configuration_ComponentFactory::buildPHPExtension('spl');
-        $this->assertInstanceOf(\common_configuration_PHPExtension::class, $component);
+        $component = common_configuration_ComponentFactory::buildPHPExtension('spl');
+        $this->assertInstanceOf(common_configuration_PHPExtension::class, $component);
         $this->assertNull($component->getMin());
         $this->assertNull($component->getMax());
         $this->assertEquals($component->getName(), 'spl');
         $this->assertFalse($component->isOptional());
         $report = $component->check();
-        $this->assertInstanceOf(\common_configuration_Report::class, $report);
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
+        $this->assertInstanceOf(common_configuration_Report::class, $report);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::VALID);
 
-        $component = \common_configuration_ComponentFactory::buildPHPExtension('spl', null, null, true);
-        $this->assertInstanceOf(\common_configuration_PHPExtension::class, $component);
+        $component = common_configuration_ComponentFactory::buildPHPExtension('spl', null, null, true);
+        $this->assertInstanceOf(common_configuration_PHPExtension::class, $component);
         $this->assertEquals($component->getName(), 'spl');
         $this->assertTrue($component->isOptional());
         $report = $component->check();
-        $this->assertInstanceOf(\common_configuration_Report::class, $report);
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
+        $this->assertInstanceOf(common_configuration_Report::class, $report);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::VALID);
 
-        $component = \common_configuration_ComponentFactory::buildPHPINIValue('magic_quotes_gpc', '0');
-        $this->assertInstanceOf(\common_configuration_PHPINIValue::class, $component);
+        $component = common_configuration_ComponentFactory::buildPHPINIValue('magic_quotes_gpc', '0');
+        $this->assertInstanceOf(common_configuration_PHPINIValue::class, $component);
         $this->assertEquals($component->getName(), 'magic_quotes_gpc');
         $this->assertFalse($component->isOptional());
 
         $location = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'ConfigurationTest.php';
-        $component = \common_configuration_ComponentFactory::buildFileSystemComponent($location, 'r');
-        $this->assertInstanceOf(\common_configuration_FileSystemComponent::class, $component);
+        $component = common_configuration_ComponentFactory::buildFileSystemComponent($location, 'r');
+        $this->assertInstanceOf(common_configuration_FileSystemComponent::class, $component);
         $this->assertFalse($component->isOptional());
         $this->assertEquals($component->getLocation(), $location);
         $this->assertEquals($component->getExpectedRights(), 'r');
         $report = $component->check();
-        $this->assertInstanceOf(\common_configuration_Report::class, $report);
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
+        $this->assertInstanceOf(common_configuration_Report::class, $report);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::VALID);
 
-        $array = ['type' => 'PHPRuntime', 'value' => ['min' => '5.0', 'max' => '8.3.x', 'optional' => true]];
-        $component = \common_configuration_ComponentFactory::buildFromArray($array);
-        $this->assertInstanceOf(\common_configuration_PHPRuntime::class, $component);
+        $array = ['type' => 'PHPRuntime', 'value' => ['min' => '5.0', 'max' => '8.5.x', 'optional' => true]];
+        $component = common_configuration_ComponentFactory::buildFromArray($array);
+        $this->assertInstanceOf(common_configuration_PHPRuntime::class, $component);
         $this->assertEquals($component->getMin(), '5.0');
         // 5.5.x will be replaced internally
         // $this->assertEquals($component->getMax(), '5.5');
         $this->assertTrue($component->isOptional());
         $report = $component->check();
-        $this->assertInstanceOf(\common_configuration_Report::class, $report);
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
+        $this->assertInstanceOf(common_configuration_Report::class, $report);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::VALID);
 
         $array = ['type' => 'PHPExtension', 'value' => ['name' => 'spl']];
-        $component = \common_configuration_ComponentFactory::buildFromArray($array);
-        $this->assertInstanceOf(\common_configuration_PHPExtension::class, $component);
+        $component = common_configuration_ComponentFactory::buildFromArray($array);
+        $this->assertInstanceOf(common_configuration_PHPExtension::class, $component);
         $this->assertEquals($component->getName(), 'spl');
         $this->assertFalse($component->isOptional());
         $report = $component->check();
-        $this->assertInstanceOf(\common_configuration_Report::class, $report);
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
+        $this->assertInstanceOf(common_configuration_Report::class, $report);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::VALID);
 
         // 'Check' before the Component type is accepted.
         $array = ['type' => 'CheckPHPINIValue', 'value' => ['name' => 'magic_quotes_gpc', 'value' => '0']];
-        $component = \common_configuration_ComponentFactory::buildFromArray($array);
-        $this->assertInstanceOf(\common_configuration_PHPINIValue::class, $component);
+        $component = common_configuration_ComponentFactory::buildFromArray($array);
+        $this->assertInstanceOf(common_configuration_PHPINIValue::class, $component);
         $this->assertEquals($component->getName(), 'magic_quotes_gpc');
         $this->assertFalse($component->isOptional());
 
         $array = ['type' => 'FileSystemComponent', 'value' => ['location' => $location, 'rights' => 'r']];
-        $component = \common_configuration_ComponentFactory::buildFromArray($array);
-        $this->assertInstanceOf(\common_configuration_FileSystemComponent::class, $component);
+        $component = common_configuration_ComponentFactory::buildFromArray($array);
+        $this->assertInstanceOf(common_configuration_FileSystemComponent::class, $component);
         $this->assertFalse($component->isOptional());
         $this->assertEquals($component->getLocation(), $location);
         $this->assertEquals($component->getExpectedRights(), 'r');
         $report = $component->check();
-        $this->assertInstanceOf(\common_configuration_Report::class, $report);
-        $this->assertEquals($report->getStatus(), \common_configuration_Report::VALID);
+        $this->assertInstanceOf(common_configuration_Report::class, $report);
+        $this->assertEquals($report->getStatus(), common_configuration_Report::VALID);
 
         try {
             $array = ['type' => 'PHPINIValue', 'value' => []];
-            $component = \common_configuration_ComponentFactory::buildFromArray($array);
+            $component = common_configuration_ComponentFactory::buildFromArray($array);
             $this->assertTrue(false, 'An exception should be raised because of missing attributes.');
-        } catch (\common_configuration_ComponentFactoryException $e) {
+        } catch (common_configuration_ComponentFactoryException $e) {
             $this->assertTrue(true);
         }
     }

--- a/test/unit/common/session/SessionManagerTest.php
+++ b/test/unit/common/session/SessionManagerTest.php
@@ -1,21 +1,10 @@
 <?php
 
 /**
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; under version 2
- * of the License (non-upgradable).
+ * SPDX-FileCopyrightText: 2026 Open Assessment Technologies S.A.
+ * Copyright (C) 2026 (original work) Open Assessment Technologies S.A.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
- *
- * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-TAO-Commercial-License
  */
 
 declare(strict_types=1);
@@ -71,12 +60,37 @@ class SessionManagerTest extends TestCase
 
     /**
      * @runInSeparateProcess
+     */
+    public function testExtractAccessTokenFromRequestQueryParameters(): void
+    {
+        $token = $this->generateAccessToken('test_user_id');
+        $this->setAccessTokenToQueryParameters($token);
+        $this->assertSame($token, SessionManager::extractAccessTokenFromRequest());
+    }
+
+    /**
+     * @runInSeparateProcess
      * @dataProvider dataProvider
      */
     public function testGetAccessTokenBasedSession(string $userId, string $role): void
     {
         $token = $this->generateAccessToken($userId, $role);
         $this->setAccessToken($token);
+        $user = SessionManager::getSession()->getUser();
+        $this->assertInstanceOf(BasicUser::class, $user);
+        $this->assertSame([$userId], $user->getPropertyValues(UserRdf::PROPERTY_LOGIN));
+        $this->assertSame($role, $user->getIdentifier());
+        $this->assertSame($role ? [$role] : [], $user->getRoles());
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @dataProvider dataProvider
+     */
+    public function testGetAccessTokenBasedSessionFromQueryParameters(string $userId, string $role): void
+    {
+        $token = $this->generateAccessToken($userId, $role);
+        $this->setAccessTokenToQueryParameters($token);
         $user = SessionManager::getSession()->getUser();
         $this->assertInstanceOf(BasicUser::class, $user);
         $this->assertSame([$userId], $user->getPropertyValues(UserRdf::PROPERTY_LOGIN));
@@ -95,6 +109,11 @@ class SessionManagerTest extends TestCase
     private function setAccessToken(string $token): void
     {
         $_SERVER['HTTP_AUTHORIZATION'] = "Bearer $token";
+    }
+
+    private function setAccessTokenToQueryParameters(string $token): void
+    {
+        $_GET['jwt'] = $token;
     }
 
     private function generateAccessToken(string $userId = '', string $role = ''): string

--- a/test/unit/common/session/SessionManagerTest.php
+++ b/test/unit/common/session/SessionManagerTest.php
@@ -1,10 +1,21 @@
 <?php
 
 /**
- * SPDX-FileCopyrightText: 2026 Open Assessment Technologies S.A.
- * Copyright (C) 2026 (original work) Open Assessment Technologies S.A.
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
  *
- * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-TAO-Commercial-License
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * 31 Milk St # 960789 Boston, MA 02196 USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
  */
 
 declare(strict_types=1);

--- a/test/unit/common/session/SessionManagerTest.php
+++ b/test/unit/common/session/SessionManagerTest.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2026 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\generis\test\unit\common\session;
+
+use common_session_AnonymousSession as AnonumousSession;
+use common_session_SessionManager as SessionManager;
+use DateTimeImmutable;
+use Lcobucci\JWT\Builder;
+use Lcobucci\JWT\JwtFacade;
+use Lcobucci\JWT\Signer\Hmac\Sha256;
+use Lcobucci\JWT\Signer\Key\InMemory;
+use oat\generis\model\GenerisRdf;
+use oat\generis\model\user\UserRdf;
+use oat\oatbox\user\BasicUser;
+use PHPUnit\Framework\TestCase;
+
+class SessionManagerTest extends TestCase
+{
+    public static function dataProvider(): array
+    {
+        return [
+            'No role' => ['user_id_1', '', ['login' => 'user_id_1']],
+            'TAO 3.x role' => [
+                'user_id_2',
+                GenerisRdf::INSTANCE_ROLE_GENERIS,
+                ['login' => GenerisRdf::INSTANCE_ROLE_GENERIS . '#user_id_2'],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProvider
+     */
+    public function testParseAccessToken(string $userId, string $role, array $expected): void
+    {
+        $this->assertSame(
+            $expected,
+            SessionManager::parseAccessToken($this->generateAccessToken($userId, $role))['user'] ?? []
+        );
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testExtractAccessTokenFromRequest(): void
+    {
+        $token = $this->generateAccessToken('test_user_id');
+        $this->setAccessToken($token);
+        $this->assertSame($token, SessionManager::extractAccessTokenFromRequest());
+    }
+
+    /**
+     * @runInSeparateProcess
+     * @dataProvider dataProvider
+     */
+    public function testGetAccessTokenBasedSession(string $userId, string $role): void
+    {
+        $token = $this->generateAccessToken($userId, $role);
+        $this->setAccessToken($token);
+        $user = SessionManager::getSession()->getUser();
+        $this->assertInstanceOf(BasicUser::class, $user);
+        $this->assertSame([$userId], $user->getPropertyValues(UserRdf::PROPERTY_LOGIN));
+        $this->assertSame($role, $user->getIdentifier());
+        $this->assertSame($role ? [$role] : [], $user->getRoles());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testGetCookieBasedSession(): void
+    {
+        $this->assertInstanceOf(AnonumousSession::class, SessionManager::getSession());
+    }
+
+    private function setAccessToken(string $token): void
+    {
+        $_SERVER['HTTP_AUTHORIZATION'] = "Bearer $token";
+    }
+
+    private function generateAccessToken(string $userId = '', string $role = ''): string
+    {
+        $userIdentity = $userId ? SessionManager::buildUserIdentityString($userId, $role) : null;
+        $key = InMemory::base64Encoded(bin2hex(random_bytes(32)));
+        return (new JwtFacade())->issue(
+            new Sha256(),
+            $key,
+            static function (
+                Builder $builder,
+                DateTimeImmutable $issuedAt,
+            ) use ($userIdentity): Builder {
+                $builder = $builder
+                    ->issuedBy('https://backoffice.ngs.test')
+                    ->expiresAt($issuedAt->modify('+1 minute'));
+                return $userIdentity ? $builder->withClaim('user', ['login' => $userIdentity]) : $builder;
+            }
+        )->toString();
+    }
+}


### PR DESCRIPTION
## Ticket: [EP-765](https://oat-sa.atlassian.net/browse/EP-765)

## What's Changed
This adds support for User Identity based on a bearer access token

> Please tick the appropriate points
- [x] Ticket attached or not required
- [ ] Breaking change
- [ ] Configuration change
- [x] Release version change
- [x] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [x] New code is respecting code style rules
- [x] New code is respecting best practices
- [x] New code is not subject to concurrency issues (if applicable)
- [x] Feature is working correctly on my local machine (if applicable)
- [x] Acceptance criteria are respected
- [x] Pull request title and description are meaningful


[EP-693]: https://oat-sa.atlassian.net/browse/EP-693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions can now be established using access tokens, including user identity, login, and role information.
  * Added support for authenticated users represented by identifiers, roles, and login details.
  * Access-token sessions fall back to existing session handling when no valid token is provided.

* **Compatibility**
  * Added PHP 8.5 to supported continuous-integration test coverage.

* **Tests**
  * Added coverage for access-token parsing, request extraction, and authenticated session creation.
  * Added validation for authenticated sessions with and without assigned roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[EP-765]: https://oat-sa.atlassian.net/browse/EP-765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ